### PR TITLE
feat: 1.1 domain dataclasses — instance state (capital, risk, positions, operational mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## v0.3.0 on 17th of March, 2026
 
-- Add [`enums.py`](nexus/core/domain/enums.py) with `OperationalMode`, `OrderSide`, `BreachLevel`
-- Add [`position.py`](nexus/core/domain/position.py) with mutable `Position` dataclass (trade_id, strategy_id, size, entry_price, pending_exit)
 - Add [`capital_state.py`](nexus/core/domain/capital_state.py) with mutable `CapitalState` dataclass and derived `available` property
-- Add [`risk_state.py`](nexus/core/domain/risk_state.py) with `RiskState` and `StrategyRiskState` (instance-level losses derived from per-strategy state)
-- Add [`operational_mode.py`](nexus/core/domain/operational_mode.py) with `ModeState` and `StrategyModeState` (composes `ModeState`)
+- Add [`enums.py`](nexus/core/domain/enums.py) with `OperationalMode`, `OrderSide`, `BreachLevel`
 - Add [`instance_state.py`](nexus/core/domain/instance_state.py) composing all state with `from_config` factory
-- Wire [`nexus/core/domain/__init__.py`](nexus/core/domain/__init__.py) re-exports
+- Add [`operational_mode.py`](nexus/core/domain/operational_mode.py) with `ModeState` and `StrategyModeState` (composes `ModeState`)
+- Add [`position.py`](nexus/core/domain/position.py) with mutable `Position` dataclass (trade_id, strategy_id, size, entry_price, pending_exit)
+- Add [`risk_state.py`](nexus/core/domain/risk_state.py) with `RiskState` and `StrategyRiskState` (instance-level losses derived from per-strategy state)
+- Add [`nexus/core/domain/__init__.py`](nexus/core/domain/__init__.py) re-exports
 - Add 34 tests covering enums, position, capital state, risk state, operational mode, and instance state composition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,14 @@
 - Add [`test_instance_config.py`](tests/test_instance_config.py) with 7 tests covering creation, immutability, and validation
 - Add `nexus-journals/` to `.gitignore`
 - Wire `nexus/__init__.py` public API exports
+
+## v0.3.0 on 17th of March, 2026
+
+- Add [`enums.py`](nexus/core/domain/enums.py) with `OperationalMode`, `OrderSide`, `BreachLevel`
+- Add [`position.py`](nexus/core/domain/position.py) with mutable `Position` dataclass (trade_id, strategy_id, size, entry_price, pending_exit)
+- Add [`capital_state.py`](nexus/core/domain/capital_state.py) with mutable `CapitalState` dataclass and derived `available` property
+- Add [`risk_state.py`](nexus/core/domain/risk_state.py) with `RiskState` and `StrategyRiskState` (instance-level losses derived from per-strategy state)
+- Add [`operational_mode.py`](nexus/core/domain/operational_mode.py) with `ModeState` and `StrategyModeState` (composes `ModeState`)
+- Add [`instance_state.py`](nexus/core/domain/instance_state.py) composing all state with `from_config` factory
+- Wire [`nexus/core/domain/__init__.py`](nexus/core/domain/__init__.py) re-exports
+- Add 34 tests covering enums, position, capital state, risk state, operational mode, and instance state composition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Add [`enums.py`](nexus/core/domain/enums.py) with `OperationalMode`, `OrderSide`, `BreachLevel`
 - Add [`instance_state.py`](nexus/core/domain/instance_state.py) composing all state with `from_config` factory
 - Add [`operational_mode.py`](nexus/core/domain/operational_mode.py) with `ModeState` and `StrategyModeState` (composes `ModeState`)
-- Add [`position.py`](nexus/core/domain/position.py) with mutable `Position` dataclass (trade_id, strategy_id, size, entry_price, pending_exit)
+- Add [`position.py`](nexus/core/domain/position.py) with mutable `Position` dataclass (trade_id, strategy_id, symbol, side, size, entry_price, unrealized_pnl, pending_exit)
 - Add [`risk_state.py`](nexus/core/domain/risk_state.py) with `RiskState` and `StrategyRiskState` (instance-level losses derived from per-strategy state)
 - Add [`nexus/core/domain/__init__.py`](nexus/core/domain/__init__.py) re-exports
 - Add 34 tests covering enums, position, capital state, risk state, operational mode, and instance state composition

--- a/nexus/core/domain/__init__.py
+++ b/nexus/core/domain/__init__.py
@@ -1,0 +1,27 @@
+'''Domain dataclasses for the Nexus Manager sub-system.
+
+Re-exports all domain types: enums, capital state, risk state,
+positions, operational mode, and composite instance state.
+'''
+
+from __future__ import annotations
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import BreachLevel, OperationalMode, OrderSide
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.operational_mode import ModeState, StrategyModeState
+from nexus.core.domain.position import Position
+from nexus.core.domain.risk_state import RiskState, StrategyRiskState
+
+__all__ = [
+    'BreachLevel',
+    'CapitalState',
+    'InstanceState',
+    'ModeState',
+    'OperationalMode',
+    'OrderSide',
+    'Position',
+    'RiskState',
+    'StrategyModeState',
+    'StrategyRiskState',
+]

--- a/nexus/core/domain/capital_state.py
+++ b/nexus/core/domain/capital_state.py
@@ -1,0 +1,71 @@
+'''Capital state tracked by the Capital Controller.
+
+Mutable dataclass holding all capital-related fields for a Manager
+instance. The ``available`` property is derived — never stored directly.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+__all__ = ['CapitalState']
+
+_ZERO = Decimal(0)
+
+
+@dataclass
+class CapitalState:
+    '''Runtime capital state for one Manager instance.
+
+    Args:
+        capital_pool: Static budget ceiling in quote asset from manifest.
+        position_notional: Sum of open positions at cost.
+        working_order_notional: Sum of resting BUY orders on venue.
+        in_flight_order_notional: Sum of BUY orders sent but not acked.
+        fee_reserve: Reserved for transaction costs.
+        reservation_notional: Sum of active TOCTOU locks (BUY-side).
+    '''
+
+    capital_pool: Decimal
+    position_notional: Decimal = _ZERO
+    working_order_notional: Decimal = _ZERO
+    in_flight_order_notional: Decimal = _ZERO
+    fee_reserve: Decimal = _ZERO
+    reservation_notional: Decimal = _ZERO
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if self.capital_pool <= _ZERO:
+            msg = 'CapitalState.capital_pool must be positive'
+            raise ValueError(msg)
+
+        for field_name in (
+            'position_notional',
+            'working_order_notional',
+            'in_flight_order_notional',
+            'fee_reserve',
+            'reservation_notional',
+        ):
+            val = getattr(self, field_name)
+            if val < _ZERO:
+                msg = f'CapitalState.{field_name} must be non-negative'
+                raise ValueError(msg)
+
+    @property
+    def available(self) -> Decimal:
+        '''Compute available capital for new BUY orders.
+
+        Returns:
+            Quote capital not committed to positions, orders, or reserves.
+        '''
+
+        return (
+            self.capital_pool
+            - self.position_notional
+            - self.working_order_notional
+            - self.in_flight_order_notional
+            - self.fee_reserve
+            - self.reservation_notional
+        )

--- a/nexus/core/domain/capital_state.py
+++ b/nexus/core/domain/capital_state.py
@@ -37,8 +37,8 @@ class CapitalState:
     def __post_init__(self) -> None:
         '''Validate invariants at construction time.'''
 
-        if self.capital_pool <= _ZERO:
-            msg = 'CapitalState.capital_pool must be positive'
+        if not self.capital_pool.is_finite() or self.capital_pool <= _ZERO:
+            msg = 'CapitalState.capital_pool must be a finite positive value'
             raise ValueError(msg)
 
         for field_name in (
@@ -49,8 +49,8 @@ class CapitalState:
             'reservation_notional',
         ):
             val = getattr(self, field_name)
-            if val < _ZERO:
-                msg = f'CapitalState.{field_name} must be non-negative'
+            if not val.is_finite() or val < _ZERO:
+                msg = f'CapitalState.{field_name} must be a finite non-negative value'
                 raise ValueError(msg)
 
     @property

--- a/nexus/core/domain/enums.py
+++ b/nexus/core/domain/enums.py
@@ -1,0 +1,44 @@
+'''Enumerated types for the Nexus Manager domain.
+
+Defines operational mode, order side, and breach level enums
+used across Instance State, Capital Controller, Validator, and Strategy Runner.
+'''
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = ['BreachLevel', 'OperationalMode', 'OrderSide']
+
+
+class OperationalMode(Enum):
+    '''Instance or strategy operational state.
+
+    ACTIVE allows all trading. REDUCE_ONLY blocks new entries
+    but allows closes. HALTED stops all trading until manual
+    approval to resume.
+    '''
+
+    ACTIVE = 'ACTIVE'
+    REDUCE_ONLY = 'REDUCE_ONLY'
+    HALTED = 'HALTED'
+
+
+class OrderSide(Enum):
+    '''Buy or sell direction for orders and positions.'''
+
+    BUY = 'BUY'
+    SELL = 'SELL'
+
+
+class BreachLevel(Enum):
+    '''Risk limit breach severity.
+
+    NONE is normal. WARN triggers alerts. BREACH triggers
+    breach_action (reduce_only or reject). HALT stops trading.
+    '''
+
+    NONE = 'NONE'
+    WARN = 'WARN'
+    BREACH = 'BREACH'
+    HALT = 'HALT'

--- a/nexus/core/domain/instance_state.py
+++ b/nexus/core/domain/instance_state.py
@@ -7,7 +7,6 @@ single top-level container. Created from InstanceConfig at startup.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from decimal import Decimal
 
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.operational_mode import ModeState, StrategyModeState
@@ -48,5 +47,5 @@ class InstanceState:
         '''
 
         return cls(
-            capital=CapitalState(capital_pool=Decimal(config.allocated_capital)),
+            capital=CapitalState(capital_pool=config.allocated_capital),
         )

--- a/nexus/core/domain/instance_state.py
+++ b/nexus/core/domain/instance_state.py
@@ -1,0 +1,52 @@
+'''Composite runtime state for a Manager instance.
+
+Composes capital, risk, positions, and operational mode into a
+single top-level container. Created from InstanceConfig at startup.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.operational_mode import ModeState, StrategyModeState
+from nexus.core.domain.position import Position
+from nexus.core.domain.risk_state import RiskState
+from nexus.instance_config import InstanceConfig
+
+__all__ = ['InstanceState']
+
+
+@dataclass
+class InstanceState:
+    '''Top-level runtime state for one Manager instance.
+
+    Args:
+        capital: Capital tracking state.
+        risk: Instance-level and per-strategy risk metrics.
+        positions: Open positions keyed by trade_id.
+        mode: Instance-level operational mode.
+        strategy_modes: Per-strategy operational modes keyed by strategy_id.
+    '''
+
+    capital: CapitalState
+    risk: RiskState = field(default_factory=RiskState)
+    positions: dict[str, Position] = field(default_factory=dict)
+    mode: ModeState = field(default_factory=ModeState)
+    strategy_modes: dict[str, StrategyModeState] = field(default_factory=dict)
+
+    @classmethod
+    def from_config(cls, config: InstanceConfig) -> InstanceState:
+        '''Create initial state from instance configuration.
+
+        Args:
+            config: Identity and capital ceiling for this instance.
+
+        Returns:
+            Fresh InstanceState with capital pool set and everything else zeroed.
+        '''
+
+        return cls(
+            capital=CapitalState(capital_pool=Decimal(config.allocated_capital)),
+        )

--- a/nexus/core/domain/instance_state.py
+++ b/nexus/core/domain/instance_state.py
@@ -39,11 +39,17 @@ class InstanceState:
         '''Validate that dict keys match their value identifiers.'''
 
         for key, pos in self.positions.items():
+            if not isinstance(pos, Position):
+                msg = f'InstanceState.positions value for key {key!r} must be a Position'
+                raise ValueError(msg)
             if key != pos.trade_id:
                 msg = f'InstanceState.positions key {key!r} does not match trade_id {pos.trade_id!r}'
                 raise ValueError(msg)
 
         for key, sms in self.strategy_modes.items():
+            if not isinstance(sms, StrategyModeState):
+                msg = f'InstanceState.strategy_modes value for key {key!r} must be a StrategyModeState'
+                raise ValueError(msg)
             if key != sms.strategy_id:
                 msg = f'InstanceState.strategy_modes key {key!r} does not match strategy_id {sms.strategy_id!r}'
                 raise ValueError(msg)

--- a/nexus/core/domain/instance_state.py
+++ b/nexus/core/domain/instance_state.py
@@ -35,6 +35,19 @@ class InstanceState:
     mode: ModeState = field(default_factory=ModeState)
     strategy_modes: dict[str, StrategyModeState] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        '''Validate that dict keys match their value identifiers.'''
+
+        for key, pos in self.positions.items():
+            if key != pos.trade_id:
+                msg = f'InstanceState.positions key {key!r} does not match trade_id {pos.trade_id!r}'
+                raise ValueError(msg)
+
+        for key, sms in self.strategy_modes.items():
+            if key != sms.strategy_id:
+                msg = f'InstanceState.strategy_modes key {key!r} does not match strategy_id {sms.strategy_id!r}'
+                raise ValueError(msg)
+
     @classmethod
     def from_config(cls, config: InstanceConfig) -> InstanceState:
         '''Create initial state from instance configuration.

--- a/nexus/core/domain/operational_mode.py
+++ b/nexus/core/domain/operational_mode.py
@@ -28,6 +28,21 @@ class ModeState:
     trigger: str = 'init'
     transitioned_at: datetime = datetime.min
 
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if not isinstance(self.mode, OperationalMode):
+            msg = 'ModeState.mode must be an OperationalMode member'
+            raise ValueError(msg)
+
+        if not isinstance(self.trigger, str) or not self.trigger.strip():
+            msg = 'ModeState.trigger must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.transitioned_at, datetime):
+            msg = 'ModeState.transitioned_at must be a datetime'
+            raise ValueError(msg)
+
 
 @dataclass
 class StrategyModeState:
@@ -46,4 +61,8 @@ class StrategyModeState:
 
         if not isinstance(self.strategy_id, str) or not self.strategy_id.strip():
             msg = 'StrategyModeState.strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.state, ModeState):
+            msg = 'StrategyModeState.state must be a ModeState instance'
             raise ValueError(msg)

--- a/nexus/core/domain/operational_mode.py
+++ b/nexus/core/domain/operational_mode.py
@@ -1,0 +1,49 @@
+'''Operational mode state for instance and per-strategy tracking.
+
+Mutable dataclasses holding current mode and what triggered
+the most recent transition.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from nexus.core.domain.enums import OperationalMode
+
+__all__ = ['ModeState', 'StrategyModeState']
+
+
+@dataclass
+class ModeState:
+    '''Instance-level operational mode with transition tracking.
+
+    Args:
+        mode: Current operational mode.
+        trigger: What caused the most recent mode transition.
+        transitioned_at: When the most recent transition occurred.
+    '''
+
+    mode: OperationalMode = OperationalMode.ACTIVE
+    trigger: str = 'init'
+    transitioned_at: datetime = datetime.min
+
+
+@dataclass
+class StrategyModeState:
+    '''Per-strategy operational mode with transition tracking.
+
+    Args:
+        strategy_id: Which strategy this mode belongs to.
+        state: Operational mode state for this strategy.
+    '''
+
+    strategy_id: str
+    state: ModeState = field(default_factory=ModeState)
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if not isinstance(self.strategy_id, str) or not self.strategy_id.strip():
+            msg = 'StrategyModeState.strategy_id must be a non-empty string'
+            raise ValueError(msg)

--- a/nexus/core/domain/position.py
+++ b/nexus/core/domain/position.py
@@ -1,0 +1,69 @@
+'''Position dataclass representing an open trade within a Manager instance.
+
+Positions are mutable: size and unrealized_pnl change as fills arrive
+and market price moves. Mutation logic belongs in Capital Controller
+and Praxis Connector, not here.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from nexus.core.domain.enums import OrderSide
+
+__all__ = ['Position']
+
+_ZERO = Decimal(0)
+
+
+@dataclass
+class Position:
+    '''An open position tracked per trade_id within a Manager instance.
+
+    Args:
+        trade_id: Manager-assigned trade lifecycle identifier.
+        strategy_id: Which strategy owns this trade.
+        symbol: Trading pair symbol.
+        side: Position direction.
+        size: Current position size in base asset, must be non-negative.
+        entry_price: Volume-weighted average entry price in quote asset.
+        unrealized_pnl: Mark-to-market P&L in quote asset.
+        pending_exit: Size of SELL orders in-flight or resting for this trade.
+    '''
+
+    trade_id: str
+    strategy_id: str
+    symbol: str
+    side: OrderSide
+    size: Decimal
+    entry_price: Decimal
+    unrealized_pnl: Decimal = _ZERO
+    pending_exit: Decimal = _ZERO
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        for field_name in ('trade_id', 'strategy_id', 'symbol'):
+            val = getattr(self, field_name)
+            if not isinstance(val, str) or not val.strip():
+                msg = f'Position.{field_name} must be a non-empty string'
+                raise ValueError(msg)
+
+        if self.size < _ZERO:
+            msg = 'Position.size must be non-negative'
+            raise ValueError(msg)
+
+        if self.entry_price <= _ZERO:
+            msg = 'Position.entry_price must be positive'
+            raise ValueError(msg)
+
+        if self.pending_exit < _ZERO:
+            msg = 'Position.pending_exit must be non-negative'
+            raise ValueError(msg)
+
+    @property
+    def is_closed(self) -> bool:
+        '''Return True if position size has reached zero.'''
+
+        return self.size == _ZERO

--- a/nexus/core/domain/position.py
+++ b/nexus/core/domain/position.py
@@ -50,16 +50,16 @@ class Position:
                 msg = f'Position.{field_name} must be a non-empty string'
                 raise ValueError(msg)
 
-        if self.size < _ZERO:
-            msg = 'Position.size must be non-negative'
+        if not self.size.is_finite() or self.size < _ZERO:
+            msg = 'Position.size must be a finite non-negative value'
             raise ValueError(msg)
 
-        if self.entry_price <= _ZERO:
-            msg = 'Position.entry_price must be positive'
+        if not self.entry_price.is_finite() or self.entry_price <= _ZERO:
+            msg = 'Position.entry_price must be a finite positive value'
             raise ValueError(msg)
 
-        if self.pending_exit < _ZERO:
-            msg = 'Position.pending_exit must be non-negative'
+        if not self.pending_exit.is_finite() or self.pending_exit < _ZERO:
+            msg = 'Position.pending_exit must be a finite non-negative value'
             raise ValueError(msg)
 
     @property

--- a/nexus/core/domain/position.py
+++ b/nexus/core/domain/position.py
@@ -62,6 +62,10 @@ class Position:
             msg = 'Position.pending_exit must be a finite non-negative value'
             raise ValueError(msg)
 
+        if not self.unrealized_pnl.is_finite():
+            msg = 'Position.unrealized_pnl must be finite'
+            raise ValueError(msg)
+
     @property
     def is_closed(self) -> bool:
         '''Return True if position size has reached zero.'''

--- a/nexus/core/domain/position.py
+++ b/nexus/core/domain/position.py
@@ -29,7 +29,7 @@ class Position:
         size: Current position size in base asset, must be non-negative.
         entry_price: Volume-weighted average entry price in quote asset.
         unrealized_pnl: Mark-to-market P&L in quote asset.
-        pending_exit: Size of SELL orders in-flight or resting for this trade.
+        pending_exit: Size of exit orders (opposite side) in-flight or resting for this trade.
     '''
 
     trade_id: str
@@ -49,6 +49,10 @@ class Position:
             if not isinstance(val, str) or not val.strip():
                 msg = f'Position.{field_name} must be a non-empty string'
                 raise ValueError(msg)
+
+        if not isinstance(self.side, OrderSide):
+            msg = 'Position.side must be an OrderSide member'
+            raise ValueError(msg)
 
         if not self.size.is_finite() or self.size < _ZERO:
             msg = 'Position.size must be a finite non-negative value'

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -1,0 +1,84 @@
+'''Risk tracking state for a Manager instance.
+
+Mutable dataclasses holding instance-level and per-strategy risk
+metrics. Updated by Praxis Connector on fills, checked by Validator
+on every action.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+__all__ = ['RiskState', 'StrategyRiskState']
+
+_ZERO = Decimal(0)
+
+
+@dataclass
+class StrategyRiskState:
+    '''Per-strategy risk metrics keyed by strategy_id.
+
+    Args:
+        strategy_id: Which strategy this state belongs to.
+        high_water_mark: Lifetime peak equity for this strategy.
+        rolling_loss_24h: Rolling 24-hour realized loss.
+        rolling_loss_7d: Rolling 7-day realized loss (optional).
+        rolling_loss_30d: Rolling 30-day realized loss (optional).
+        strategy_realized_pnl: Cumulative realized P&L for this strategy.
+    '''
+
+    strategy_id: str
+    high_water_mark: Decimal = _ZERO
+    rolling_loss_24h: Decimal = _ZERO
+    rolling_loss_7d: Decimal = _ZERO
+    rolling_loss_30d: Decimal = _ZERO
+    strategy_realized_pnl: Decimal = _ZERO
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if not isinstance(self.strategy_id, str) or not self.strategy_id.strip():
+            msg = 'StrategyRiskState.strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+
+@dataclass
+class RiskState:
+    '''Instance-level risk metrics for a Manager instance.
+
+    Rolling losses and realized P&L are derived from per-strategy state.
+    High water mark tracks lifetime peak total equity independently
+    (not a sum of per-strategy HWMs — they peak at different times).
+
+    Args:
+        high_water_mark: Lifetime peak total equity.
+        per_strategy: Per-strategy risk state keyed by strategy_id.
+    '''
+
+    high_water_mark: Decimal = _ZERO
+    per_strategy: dict[str, StrategyRiskState] = field(default_factory=dict)
+
+    @property
+    def rolling_loss_24h(self) -> Decimal:
+        '''Sum of per-strategy 24-hour rolling losses.'''
+
+        return sum((s.rolling_loss_24h for s in self.per_strategy.values()), _ZERO)
+
+    @property
+    def rolling_loss_7d(self) -> Decimal:
+        '''Sum of per-strategy 7-day rolling losses.'''
+
+        return sum((s.rolling_loss_7d for s in self.per_strategy.values()), _ZERO)
+
+    @property
+    def rolling_loss_30d(self) -> Decimal:
+        '''Sum of per-strategy 30-day rolling losses.'''
+
+        return sum((s.rolling_loss_30d for s in self.per_strategy.values()), _ZERO)
+
+    @property
+    def realized_pnl(self) -> Decimal:
+        '''Sum of per-strategy cumulative realized P&L.'''
+
+        return sum((s.strategy_realized_pnl for s in self.per_strategy.values()), _ZERO)

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -42,6 +42,20 @@ class StrategyRiskState:
             msg = 'StrategyRiskState.strategy_id must be a non-empty string'
             raise ValueError(msg)
 
+        if not self.high_water_mark.is_finite() or self.high_water_mark < _ZERO:
+            msg = 'StrategyRiskState.high_water_mark must be a finite non-negative value'
+            raise ValueError(msg)
+
+        for field_name in ('rolling_loss_24h', 'rolling_loss_7d', 'rolling_loss_30d'):
+            val = getattr(self, field_name)
+            if not val.is_finite():
+                msg = f'StrategyRiskState.{field_name} must be finite'
+                raise ValueError(msg)
+
+        if not self.strategy_realized_pnl.is_finite():
+            msg = 'StrategyRiskState.strategy_realized_pnl must be finite'
+            raise ValueError(msg)
+
 
 @dataclass
 class RiskState:
@@ -60,7 +74,11 @@ class RiskState:
     per_strategy: dict[str, StrategyRiskState] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        '''Validate that dict keys match strategy_id fields.'''
+        '''Validate invariants at construction time.'''
+
+        if not self.high_water_mark.is_finite() or self.high_water_mark < _ZERO:
+            msg = 'RiskState.high_water_mark must be a finite non-negative value'
+            raise ValueError(msg)
 
         for key, state in self.per_strategy.items():
             if key != state.strategy_id:

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -59,6 +59,14 @@ class RiskState:
     high_water_mark: Decimal = _ZERO
     per_strategy: dict[str, StrategyRiskState] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        '''Validate that dict keys match strategy_id fields.'''
+
+        for key, state in self.per_strategy.items():
+            if key != state.strategy_id:
+                msg = f'RiskState.per_strategy key {key!r} does not match strategy_id {state.strategy_id!r}'
+                raise ValueError(msg)
+
     @property
     def rolling_loss_24h(self) -> Decimal:
         '''Sum of per-strategy 24-hour rolling losses.'''

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -81,6 +81,9 @@ class RiskState:
             raise ValueError(msg)
 
         for key, state in self.per_strategy.items():
+            if not isinstance(state, StrategyRiskState):
+                msg = f'RiskState.per_strategy value for key {key!r} must be a StrategyRiskState'
+                raise ValueError(msg)
             if key != state.strategy_id:
                 msg = f'RiskState.per_strategy key {key!r} does not match strategy_id {state.strategy_id!r}'
                 raise ValueError(msg)

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -48,8 +48,8 @@ class StrategyRiskState:
 
         for field_name in ('rolling_loss_24h', 'rolling_loss_7d', 'rolling_loss_30d'):
             val = getattr(self, field_name)
-            if not val.is_finite():
-                msg = f'StrategyRiskState.{field_name} must be finite'
+            if not val.is_finite() or val < _ZERO:
+                msg = f'StrategyRiskState.{field_name} must be a finite non-negative value'
                 raise ValueError(msg)
 
         if not self.strategy_realized_pnl.is_finite():

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -40,6 +40,6 @@ class InstanceConfig:
             msg = 'InstanceConfig.venue must be a non-empty string'
             raise ValueError(msg)
 
-        if self.allocated_capital <= 0:
-            msg = 'InstanceConfig.allocated_capital must be positive'
+        if not self.allocated_capital.is_finite() or self.allocated_capital <= 0:
+            msg = 'InstanceConfig.allocated_capital must be a finite positive value'
             raise ValueError(msg)

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -40,6 +40,6 @@ class InstanceConfig:
             msg = 'InstanceConfig.venue must be a non-empty string'
             raise ValueError(msg)
 
-        if not self.allocated_capital.is_finite() or self.allocated_capital <= 0:
-            msg = 'InstanceConfig.allocated_capital must be a finite positive value'
+        if self.allocated_capital <= 0:
+            msg = 'InstanceConfig.allocated_capital must be positive'
             raise ValueError(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.2.0"
+version = "0.3.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_capital_state.py
+++ b/tests/test_capital_state.py
@@ -1,0 +1,87 @@
+'''Verify CapitalState creation, validation, and available property.'''
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from nexus.core.domain.capital_state import CapitalState
+
+
+def test_valid_creation() -> None:
+    '''Verify a valid capital state is created with defaults.'''
+
+    cs = CapitalState(capital_pool=Decimal('10000'))
+    assert cs.capital_pool == Decimal('10000')
+    assert cs.position_notional == Decimal(0)
+    assert cs.working_order_notional == Decimal(0)
+    assert cs.in_flight_order_notional == Decimal(0)
+    assert cs.fee_reserve == Decimal(0)
+    assert cs.reservation_notional == Decimal(0)
+
+
+def test_available_all_zero() -> None:
+    '''Verify available equals capital_pool when nothing is deployed.'''
+
+    cs = CapitalState(capital_pool=Decimal('10000'))
+    assert cs.available == Decimal('10000')
+
+
+def test_available_with_deductions() -> None:
+    '''Verify available subtracts all commitments.'''
+
+    cs = CapitalState(
+        capital_pool=Decimal('10000'),
+        position_notional=Decimal('3000'),
+        working_order_notional=Decimal('1000'),
+        in_flight_order_notional=Decimal('500'),
+        fee_reserve=Decimal('100'),
+        reservation_notional=Decimal('400'),
+    )
+    assert cs.available == Decimal('5000')
+
+
+def test_available_negative_after_pool_reduction() -> None:
+
+    '''Verify available can go negative when pool shrinks below deployment via hot-reload.'''
+
+    cs = CapitalState(
+        capital_pool=Decimal('1000'),
+        position_notional=Decimal('1500'),
+    )
+    assert cs.available == Decimal('-500')
+
+
+def test_zero_capital_pool_rejected() -> None:
+    '''Verify zero capital_pool raises ValueError.'''
+
+    with pytest.raises(ValueError, match='capital_pool'):
+        CapitalState(capital_pool=Decimal(0))
+
+
+def test_negative_capital_pool_rejected() -> None:
+    '''Verify negative capital_pool raises ValueError.'''
+
+    with pytest.raises(ValueError, match='capital_pool'):
+        CapitalState(capital_pool=Decimal('-1000'))
+
+
+def test_negative_position_notional_rejected() -> None:
+    '''Verify negative position_notional raises ValueError.'''
+
+    with pytest.raises(ValueError, match='position_notional'):
+        CapitalState(
+            capital_pool=Decimal('10000'),
+            position_notional=Decimal('-1'),
+        )
+
+
+def test_negative_fee_reserve_rejected() -> None:
+    '''Verify negative fee_reserve raises ValueError.'''
+
+    with pytest.raises(ValueError, match='fee_reserve'):
+        CapitalState(
+            capital_pool=Decimal('10000'),
+            fee_reserve=Decimal('-1'),
+        )

--- a/tests/test_capital_state.py
+++ b/tests/test_capital_state.py
@@ -43,7 +43,6 @@ def test_available_with_deductions() -> None:
 
 
 def test_available_negative_after_pool_reduction() -> None:
-
     '''Verify available can go negative when pool shrinks below deployment via hot-reload.'''
 
     cs = CapitalState(

--- a/tests/test_capital_state.py
+++ b/tests/test_capital_state.py
@@ -84,3 +84,27 @@ def test_negative_fee_reserve_rejected() -> None:
             capital_pool=Decimal('10000'),
             fee_reserve=Decimal('-1'),
         )
+
+
+def test_nan_capital_pool_rejected() -> None:
+    '''Verify NaN capital_pool raises ValueError.'''
+
+    with pytest.raises(ValueError, match='capital_pool'):
+        CapitalState(capital_pool=Decimal('NaN'))
+
+
+def test_infinity_capital_pool_rejected() -> None:
+    '''Verify Infinity capital_pool raises ValueError.'''
+
+    with pytest.raises(ValueError, match='capital_pool'):
+        CapitalState(capital_pool=Decimal('Infinity'))
+
+
+def test_nan_notional_rejected() -> None:
+    '''Verify NaN position_notional raises ValueError.'''
+
+    with pytest.raises(ValueError, match='position_notional'):
+        CapitalState(
+            capital_pool=Decimal('10000'),
+            position_notional=Decimal('NaN'),
+        )

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,40 @@
+'''Verify domain enum members and values.'''
+
+from __future__ import annotations
+
+from nexus.core.domain.enums import BreachLevel, OperationalMode, OrderSide
+
+
+def test_operational_mode_members() -> None:
+    '''Verify OperationalMode has exactly three members.'''
+
+    assert set(OperationalMode) == {
+        OperationalMode.ACTIVE,
+        OperationalMode.REDUCE_ONLY,
+        OperationalMode.HALTED,
+    }
+
+
+def test_operational_mode_values() -> None:
+    '''Verify OperationalMode string values.'''
+
+    assert OperationalMode.ACTIVE.value == 'ACTIVE'
+    assert OperationalMode.REDUCE_ONLY.value == 'REDUCE_ONLY'
+    assert OperationalMode.HALTED.value == 'HALTED'
+
+
+def test_order_side_members() -> None:
+    '''Verify OrderSide has exactly two members.'''
+
+    assert set(OrderSide) == {OrderSide.BUY, OrderSide.SELL}
+
+
+def test_breach_level_members() -> None:
+    '''Verify BreachLevel has exactly four members.'''
+
+    assert set(BreachLevel) == {
+        BreachLevel.NONE,
+        BreachLevel.WARN,
+        BreachLevel.BREACH,
+        BreachLevel.HALT,
+    }

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -87,27 +87,3 @@ def test_negative_capital_rejected() -> None:
             venue='binance_spot',
             allocated_capital=Decimal('-100'),
         )
-
-
-def test_nan_capital_rejected() -> None:
-
-    '''Verify NaN allocated_capital raises ValueError.'''
-
-    with pytest.raises(ValueError, match='allocated_capital'):
-        InstanceConfig(
-            account_id='acc_001',
-            venue='binance_spot',
-            allocated_capital=Decimal('NaN'),
-        )
-
-
-def test_infinity_capital_rejected() -> None:
-
-    '''Verify Infinity allocated_capital raises ValueError.'''
-
-    with pytest.raises(ValueError, match='allocated_capital'):
-        InstanceConfig(
-            account_id='acc_001',
-            venue='binance_spot',
-            allocated_capital=Decimal('Infinity'),
-        )

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -87,3 +87,25 @@ def test_negative_capital_rejected() -> None:
             venue='binance_spot',
             allocated_capital=Decimal('-100'),
         )
+
+
+def test_nan_capital_rejected() -> None:
+    '''Verify NaN allocated_capital raises ValueError.'''
+
+    with pytest.raises(ValueError, match='allocated_capital'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('NaN'),
+        )
+
+
+def test_infinity_capital_rejected() -> None:
+    '''Verify Infinity allocated_capital raises ValueError.'''
+
+    with pytest.raises(ValueError, match='allocated_capital'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('Infinity'),
+        )

--- a/tests/test_instance_state.py
+++ b/tests/test_instance_state.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+import pytest
+
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
@@ -37,3 +39,39 @@ def test_from_config() -> None:
     assert state.risk.realized_pnl == Decimal(0)
     assert state.positions == {}
     assert state.mode.mode == OperationalMode.ACTIVE
+
+
+def test_positions_key_mismatch_rejected() -> None:
+    '''Verify positions dict key not matching trade_id raises ValueError.'''
+
+    from nexus.core.domain.enums import OrderSide
+    from nexus.core.domain.position import Position
+
+    with pytest.raises(ValueError, match='does not match trade_id'):
+        InstanceState(
+            capital=CapitalState(capital_pool=Decimal('10000')),
+            positions={
+                'wrong': Position(
+                    trade_id='t1',
+                    strategy_id='momentum',
+                    symbol='BTCUSDT',
+                    side=OrderSide.BUY,
+                    size=Decimal('0.5'),
+                    entry_price=Decimal('50000'),
+                ),
+            },
+        )
+
+
+def test_strategy_modes_key_mismatch_rejected() -> None:
+    '''Verify strategy_modes dict key not matching strategy_id raises ValueError.'''
+
+    from nexus.core.domain.operational_mode import StrategyModeState
+
+    with pytest.raises(ValueError, match='does not match strategy_id'):
+        InstanceState(
+            capital=CapitalState(capital_pool=Decimal('10000')),
+            strategy_modes={
+                'wrong': StrategyModeState(strategy_id='momentum'),
+            },
+        )

--- a/tests/test_instance_state.py
+++ b/tests/test_instance_state.py
@@ -1,0 +1,39 @@
+'''Verify InstanceState composition and factory method.'''
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.instance_state import InstanceState
+from nexus.instance_config import InstanceConfig
+
+
+def test_direct_creation() -> None:
+    '''Verify InstanceState can be created with explicit components.'''
+
+    state = InstanceState(
+        capital=CapitalState(capital_pool=Decimal('10000')),
+    )
+    assert state.capital.capital_pool == Decimal('10000')
+    assert state.risk.high_water_mark == Decimal(0)
+    assert state.positions == {}
+    assert state.mode.mode == OperationalMode.ACTIVE
+    assert state.strategy_modes == {}
+
+
+def test_from_config() -> None:
+    '''Verify factory creates state from InstanceConfig.'''
+
+    config = InstanceConfig(
+        account_id='acc_001',
+        venue='binance_spot',
+        allocated_capital=Decimal('50000'),
+    )
+    state = InstanceState.from_config(config)
+    assert state.capital.capital_pool == Decimal('50000')
+    assert state.capital.available == Decimal('50000')
+    assert state.risk.realized_pnl == Decimal(0)
+    assert state.positions == {}
+    assert state.mode.mode == OperationalMode.ACTIVE

--- a/tests/test_operational_mode.py
+++ b/tests/test_operational_mode.py
@@ -1,0 +1,57 @@
+'''Verify ModeState and StrategyModeState creation and defaults.'''
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.operational_mode import ModeState, StrategyModeState
+
+
+def test_mode_state_defaults() -> None:
+    '''Verify ModeState defaults to ACTIVE with init trigger.'''
+
+    ms = ModeState()
+    assert ms.mode == OperationalMode.ACTIVE
+    assert ms.trigger == 'init'
+    assert ms.transitioned_at == datetime.min
+
+
+def test_mode_state_custom() -> None:
+    '''Verify ModeState accepts custom values.'''
+
+    now = datetime(2026, 3, 17, 12, 0, 0)
+    ms = ModeState(
+        mode=OperationalMode.HALTED,
+        trigger='reconciliation_mismatch',
+        transitioned_at=now,
+    )
+    assert ms.mode == OperationalMode.HALTED
+    assert ms.trigger == 'reconciliation_mismatch'
+    assert ms.transitioned_at == now
+
+
+def test_mode_state_mutable() -> None:
+    '''Verify ModeState fields can be mutated for transitions.'''
+
+    ms = ModeState()
+    ms.mode = OperationalMode.REDUCE_ONLY
+    ms.trigger = 'gateway_rejection'
+    assert ms.mode == OperationalMode.REDUCE_ONLY
+
+
+def test_strategy_mode_state_defaults() -> None:
+    '''Verify StrategyModeState defaults to ACTIVE via ModeState.'''
+
+    sms = StrategyModeState(strategy_id='momentum')
+    assert sms.state.mode == OperationalMode.ACTIVE
+    assert sms.state.trigger == 'init'
+
+
+def test_strategy_mode_state_empty_id_rejected() -> None:
+    '''Verify empty strategy_id raises ValueError.'''
+
+    with pytest.raises(ValueError, match='strategy_id'):
+        StrategyModeState(strategy_id='')

--- a/tests/test_position.py
+++ b/tests/test_position.py
@@ -1,0 +1,145 @@
+'''Verify Position dataclass creation and validation.'''
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from nexus.core.domain.enums import OrderSide
+from nexus.core.domain.position import Position
+
+
+def test_valid_creation() -> None:
+    '''Verify a valid position is created without error.'''
+
+    pos = Position(
+        trade_id='t1',
+        strategy_id='momentum',
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        size=Decimal('0.5'),
+        entry_price=Decimal('50000'),
+    )
+    assert pos.trade_id == 't1'
+    assert pos.strategy_id == 'momentum'
+    assert pos.symbol == 'BTCUSDT'
+    assert pos.side == OrderSide.BUY
+    assert pos.size == Decimal('0.5')
+    assert pos.entry_price == Decimal('50000')
+    assert pos.unrealized_pnl == Decimal(0)
+    assert pos.pending_exit == Decimal(0)
+
+
+def test_is_closed() -> None:
+    '''Verify is_closed returns True when size is zero.'''
+
+    pos = Position(
+        trade_id='t1',
+        strategy_id='momentum',
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        size=Decimal(0),
+        entry_price=Decimal('50000'),
+    )
+    assert pos.is_closed is True
+
+
+def test_is_not_closed() -> None:
+    '''Verify is_closed returns False when size is positive.'''
+
+    pos = Position(
+        trade_id='t1',
+        strategy_id='momentum',
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        size=Decimal('0.1'),
+        entry_price=Decimal('50000'),
+    )
+    assert pos.is_closed is False
+
+
+def test_empty_trade_id_rejected() -> None:
+    '''Verify empty trade_id raises ValueError.'''
+
+    with pytest.raises(ValueError, match='trade_id'):
+        Position(
+            trade_id='',
+            strategy_id='momentum',
+            symbol='BTCUSDT',
+            side=OrderSide.BUY,
+            size=Decimal('0.5'),
+            entry_price=Decimal('50000'),
+        )
+
+
+def test_empty_strategy_id_rejected() -> None:
+    '''Verify empty strategy_id raises ValueError.'''
+
+    with pytest.raises(ValueError, match='strategy_id'):
+        Position(
+            trade_id='t1',
+            strategy_id='',
+            symbol='BTCUSDT',
+            side=OrderSide.BUY,
+            size=Decimal('0.5'),
+            entry_price=Decimal('50000'),
+        )
+
+
+def test_negative_size_rejected() -> None:
+    '''Verify negative size raises ValueError.'''
+
+    with pytest.raises(ValueError, match='size'):
+        Position(
+            trade_id='t1',
+            strategy_id='momentum',
+            symbol='BTCUSDT',
+            side=OrderSide.BUY,
+            size=Decimal('-1'),
+            entry_price=Decimal('50000'),
+        )
+
+
+def test_zero_entry_price_rejected() -> None:
+    '''Verify zero entry_price raises ValueError.'''
+
+    with pytest.raises(ValueError, match='entry_price'):
+        Position(
+            trade_id='t1',
+            strategy_id='momentum',
+            symbol='BTCUSDT',
+            side=OrderSide.BUY,
+            size=Decimal('0.5'),
+            entry_price=Decimal(0),
+        )
+
+
+def test_negative_pending_exit_rejected() -> None:
+    '''Verify negative pending_exit raises ValueError.'''
+
+    with pytest.raises(ValueError, match='pending_exit'):
+        Position(
+            trade_id='t1',
+            strategy_id='momentum',
+            symbol='BTCUSDT',
+            side=OrderSide.BUY,
+            size=Decimal('0.5'),
+            entry_price=Decimal('50000'),
+            pending_exit=Decimal('-1'),
+        )
+
+
+def test_mutable() -> None:
+    '''Verify position fields can be mutated.'''
+
+    pos = Position(
+        trade_id='t1',
+        strategy_id='momentum',
+        symbol='BTCUSDT',
+        side=OrderSide.BUY,
+        size=Decimal('0.5'),
+        entry_price=Decimal('50000'),
+    )
+    pos.size = Decimal('0.3')
+    assert pos.size == Decimal('0.3')

--- a/tests/test_position.py
+++ b/tests/test_position.py
@@ -143,3 +143,31 @@ def test_mutable() -> None:
     )
     pos.size = Decimal('0.3')
     assert pos.size == Decimal('0.3')
+
+
+def test_nan_size_rejected() -> None:
+    '''Verify NaN size raises ValueError.'''
+
+    with pytest.raises(ValueError, match='size'):
+        Position(
+            trade_id='t1',
+            strategy_id='momentum',
+            symbol='BTCUSDT',
+            side=OrderSide.BUY,
+            size=Decimal('NaN'),
+            entry_price=Decimal('50000'),
+        )
+
+
+def test_infinity_entry_price_rejected() -> None:
+    '''Verify Infinity entry_price raises ValueError.'''
+
+    with pytest.raises(ValueError, match='entry_price'):
+        Position(
+            trade_id='t1',
+            strategy_id='momentum',
+            symbol='BTCUSDT',
+            side=OrderSide.BUY,
+            size=Decimal('0.5'),
+            entry_price=Decimal('Infinity'),
+        )

--- a/tests/test_position.py
+++ b/tests/test_position.py
@@ -171,3 +171,18 @@ def test_infinity_entry_price_rejected() -> None:
             size=Decimal('0.5'),
             entry_price=Decimal('Infinity'),
         )
+
+
+def test_nan_unrealized_pnl_rejected() -> None:
+    '''Verify NaN unrealized_pnl raises ValueError.'''
+
+    with pytest.raises(ValueError, match='unrealized_pnl'):
+        Position(
+            trade_id='t1',
+            strategy_id='momentum',
+            symbol='BTCUSDT',
+            side=OrderSide.BUY,
+            size=Decimal('0.5'),
+            entry_price=Decimal('50000'),
+            unrealized_pnl=Decimal('NaN'),
+        )

--- a/tests/test_risk_state.py
+++ b/tests/test_risk_state.py
@@ -92,3 +92,45 @@ def test_key_mismatch_rejected() -> None:
                 'wrong_key': StrategyRiskState(strategy_id='momentum'),
             },
         )
+
+
+def test_nan_strategy_hwm_rejected() -> None:
+    '''Verify NaN high_water_mark in StrategyRiskState raises ValueError.'''
+
+    with pytest.raises(ValueError, match='high_water_mark'):
+        StrategyRiskState(strategy_id='momentum', high_water_mark=Decimal('NaN'))
+
+
+def test_negative_strategy_hwm_rejected() -> None:
+    '''Verify negative high_water_mark in StrategyRiskState raises ValueError.'''
+
+    with pytest.raises(ValueError, match='high_water_mark'):
+        StrategyRiskState(strategy_id='momentum', high_water_mark=Decimal('-1'))
+
+
+def test_nan_rolling_loss_rejected() -> None:
+    '''Verify NaN rolling_loss_24h in StrategyRiskState raises ValueError.'''
+
+    with pytest.raises(ValueError, match='rolling_loss_24h'):
+        StrategyRiskState(strategy_id='momentum', rolling_loss_24h=Decimal('NaN'))
+
+
+def test_nan_strategy_pnl_rejected() -> None:
+    '''Verify NaN strategy_realized_pnl raises ValueError.'''
+
+    with pytest.raises(ValueError, match='strategy_realized_pnl'):
+        StrategyRiskState(strategy_id='momentum', strategy_realized_pnl=Decimal('Infinity'))
+
+
+def test_nan_instance_hwm_rejected() -> None:
+    '''Verify NaN high_water_mark in RiskState raises ValueError.'''
+
+    with pytest.raises(ValueError, match='high_water_mark'):
+        RiskState(high_water_mark=Decimal('NaN'))
+
+
+def test_negative_instance_hwm_rejected() -> None:
+    '''Verify negative high_water_mark in RiskState raises ValueError.'''
+
+    with pytest.raises(ValueError, match='high_water_mark'):
+        RiskState(high_water_mark=Decimal('-1'))

--- a/tests/test_risk_state.py
+++ b/tests/test_risk_state.py
@@ -81,3 +81,14 @@ def test_risk_state_hwm_independent() -> None:
     )
     assert rs.high_water_mark == Decimal('50000')
     assert rs.high_water_mark != Decimal('55000')
+
+
+def test_key_mismatch_rejected() -> None:
+    '''Verify dict key not matching strategy_id raises ValueError.'''
+
+    with pytest.raises(ValueError, match='does not match'):
+        RiskState(
+            per_strategy={
+                'wrong_key': StrategyRiskState(strategy_id='momentum'),
+            },
+        )

--- a/tests/test_risk_state.py
+++ b/tests/test_risk_state.py
@@ -115,8 +115,15 @@ def test_nan_rolling_loss_rejected() -> None:
         StrategyRiskState(strategy_id='momentum', rolling_loss_24h=Decimal('NaN'))
 
 
-def test_nan_strategy_pnl_rejected() -> None:
-    '''Verify NaN strategy_realized_pnl raises ValueError.'''
+def test_negative_rolling_loss_rejected() -> None:
+    '''Verify negative rolling_loss_24h raises ValueError.'''
+
+    with pytest.raises(ValueError, match='rolling_loss_24h'):
+        StrategyRiskState(strategy_id='momentum', rolling_loss_24h=Decimal('-50'))
+
+
+def test_infinity_strategy_pnl_rejected() -> None:
+    '''Verify Infinity strategy_realized_pnl raises ValueError.'''
 
     with pytest.raises(ValueError, match='strategy_realized_pnl'):
         StrategyRiskState(strategy_id='momentum', strategy_realized_pnl=Decimal('Infinity'))

--- a/tests/test_risk_state.py
+++ b/tests/test_risk_state.py
@@ -1,0 +1,83 @@
+'''Verify RiskState and StrategyRiskState creation and derived properties.'''
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from nexus.core.domain.risk_state import RiskState, StrategyRiskState
+
+
+def test_strategy_risk_state_creation() -> None:
+    '''Verify a valid per-strategy risk state is created.'''
+
+    srs = StrategyRiskState(strategy_id='momentum')
+    assert srs.high_water_mark == Decimal(0)
+    assert srs.rolling_loss_24h == Decimal(0)
+    assert srs.strategy_realized_pnl == Decimal(0)
+
+
+def test_strategy_risk_state_empty_id_rejected() -> None:
+    '''Verify empty strategy_id raises ValueError.'''
+
+    with pytest.raises(ValueError, match='strategy_id'):
+        StrategyRiskState(strategy_id='')
+
+
+def test_risk_state_empty() -> None:
+    '''Verify instance-level risk state with no strategies.'''
+
+    rs = RiskState()
+    assert rs.high_water_mark == Decimal(0)
+    assert rs.rolling_loss_24h == Decimal(0)
+    assert rs.rolling_loss_7d == Decimal(0)
+    assert rs.rolling_loss_30d == Decimal(0)
+    assert rs.realized_pnl == Decimal(0)
+
+
+def test_risk_state_derived_from_strategies() -> None:
+    '''Verify instance-level losses are summed from per-strategy state.'''
+
+    rs = RiskState(
+        per_strategy={
+            'momentum': StrategyRiskState(
+                strategy_id='momentum',
+                rolling_loss_24h=Decimal('100'),
+                rolling_loss_7d=Decimal('500'),
+                rolling_loss_30d=Decimal('2000'),
+                strategy_realized_pnl=Decimal('800'),
+            ),
+            'mean_rev': StrategyRiskState(
+                strategy_id='mean_rev',
+                rolling_loss_24h=Decimal('50'),
+                rolling_loss_7d=Decimal('200'),
+                rolling_loss_30d=Decimal('1000'),
+                strategy_realized_pnl=Decimal('-300'),
+            ),
+        },
+    )
+    assert rs.rolling_loss_24h == Decimal('150')
+    assert rs.rolling_loss_7d == Decimal('700')
+    assert rs.rolling_loss_30d == Decimal('3000')
+    assert rs.realized_pnl == Decimal('500')
+
+
+def test_risk_state_hwm_independent() -> None:
+    '''Verify instance HWM is stored independently, not derived.'''
+
+    rs = RiskState(
+        high_water_mark=Decimal('50000'),
+        per_strategy={
+            'momentum': StrategyRiskState(
+                strategy_id='momentum',
+                high_water_mark=Decimal('30000'),
+            ),
+            'mean_rev': StrategyRiskState(
+                strategy_id='mean_rev',
+                high_water_mark=Decimal('25000'),
+            ),
+        },
+    )
+    assert rs.high_water_mark == Decimal('50000')
+    assert rs.high_water_mark != Decimal('55000')


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Domain dataclasses for Instance State (RFC-3001 phase 1.1). Adds `OperationalMode`, `OrderSide`, `BreachLevel` enums. Adds mutable `Position` dataclass with `entry_price > 0` and `size >= 0` validation. Adds `CapitalState` with derived `available` property (capital_pool minus all notional reserves). Adds `RiskState` composing per-strategy `StrategyRiskState` with instance-level `rolling_loss_24h/7d/30d` and `realized_pnl` as `@property` derived from strategy dict. Adds `ModeState` and `StrategyModeState` (composes `ModeState` + strategy_id). Adds `InstanceState` composing all state types with `from_config` factory. Wires `nexus/core/domain/__init__.py` re-exports. Adds 34 new tests (51 total passing). Bumps to v0.3.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (51 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable