### PR TITLE
feat: 1.2 WAL-based persistence (codec, WAL, snapshots, state store)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,15 @@
 - Add [`risk_state.py`](nexus/core/domain/risk_state.py) with `RiskState` and `StrategyRiskState` (instance-level losses derived from per-strategy state)
 - Add [`nexus/core/domain/__init__.py`](nexus/core/domain/__init__.py) re-exports
 - Add 34 tests covering enums, position, capital state, risk state, operational mode, and instance state composition
+
+## v0.4.0 on 18th of March, 2026
+
+- Add `msgpack>=1.0` as runtime dependency
+- Add [`wal_entry.py`](nexus/infrastructure/wal_entry.py) with `WALEntryType` enum (SNAPSHOT, STATE_MUTATION, STRATEGY_EVENT) and frozen `WALEntry` dataclass
+- Add [`wal_codec.py`](nexus/infrastructure/wal_codec.py) with explicit per-type `serialize_state` / `deserialize_state` for InstanceState via msgpack, codec version embedding
+- Add [`wal.py`](nexus/infrastructure/wal.py) with `WriteAheadLog` — append-only binary log with 8-byte magic header, per-record CRC32 integrity, length-prefixed msgpack records, fsync durability
+- Add [`snapshot.py`](nexus/infrastructure/snapshot.py) with atomic `save_snapshot` (tmp+rename+fsync, WAL truncation) and `load_snapshot`
+- Add [`state_store.py`](nexus/infrastructure/state_store.py) with `StateStore` facade — manages `snapshots/` and `wal/` subdirectories, `checkpoint`, `append_mutation`, `recover` via snapshot + WAL replay
+- Add [`docs/TechnicalDebt.md`](docs/TechnicalDebt.md) with TD-001 (codec version-dispatched deserialization)
+- Add mypy override for msgpack missing stubs
+- Add 64 tests covering WAL entries, codec round-trip, Decimal precision, codec versioning, WAL append/read/truncate, magic header validation, CRC32 corruption detection, snapshot save/load, state store checkpoint/recover cycles

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -1,0 +1,16 @@
+# Technical Debt
+
+Known technical debt in shipped code. Each item includes origin, severity, and migration path.
+
+---
+
+## TD-001: WAL codec lacks version-dispatched deserialization
+
+**Origin**: 1.2.1 (WAL entry types and serialization)
+**Severity**: Low (only v1 exists)
+**Module**: `nexus/infrastructure/wal_codec.py`
+
+`deserialize_state` performs a strict equality check against `_CODEC_VERSION`. When v2 is introduced (e.g. adding a field to a domain dataclass), all data serialized with v1 becomes unreadable. WAL entries are ephemeral (truncated on snapshot), but snapshots persist — a codec bump without migration makes existing snapshots unrecoverable.
+
+**When to fix**: Before any change to serialized domain dataclass fields.
+**Migration**: Add version-dispatched deserialization (`_decode_v1()`, `_decode_v2()`, etc.) that routes on the embedded `_v` field so older snapshots remain readable across codec upgrades.

--- a/nexus/infrastructure/snapshot.py
+++ b/nexus/infrastructure/snapshot.py
@@ -32,7 +32,7 @@ def save_snapshot(state: InstanceState, path: Path, wal: WriteAheadLog) -> None:
     tmp.write_bytes(data)
     with tmp.open('rb') as f:
         os.fsync(f.fileno())
-    tmp.rename(path)
+    tmp.replace(path)
     wal.truncate()
 
 

--- a/nexus/infrastructure/snapshot.py
+++ b/nexus/infrastructure/snapshot.py
@@ -16,6 +16,14 @@ from nexus.infrastructure.wal_codec import deserialize_state, serialize_state
 __all__ = ['load_snapshot', 'save_snapshot']
 
 
+def _fsync_directory(dir_path: Path) -> None:
+    fd = os.open(str(dir_path), os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
 def save_snapshot(state: InstanceState, path: Path, wal: WriteAheadLog) -> None:
     '''Serialize full InstanceState to disk and truncate the WAL.
 
@@ -33,6 +41,7 @@ def save_snapshot(state: InstanceState, path: Path, wal: WriteAheadLog) -> None:
     with tmp.open('rb') as f:
         os.fsync(f.fileno())
     tmp.replace(path)
+    _fsync_directory(path.parent)
     wal.truncate()
 
 

--- a/nexus/infrastructure/snapshot.py
+++ b/nexus/infrastructure/snapshot.py
@@ -1,0 +1,51 @@
+'''Snapshot manager for persisting full InstanceState to disk.
+
+Saves and loads complete InstanceState snapshots via the WAL codec.
+A save triggers WAL truncation to keep the log bounded.
+'''
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from nexus.core.domain.instance_state import InstanceState
+from nexus.infrastructure.wal import WriteAheadLog
+from nexus.infrastructure.wal_codec import deserialize_state, serialize_state
+
+__all__ = ['load_snapshot', 'save_snapshot']
+
+
+def save_snapshot(state: InstanceState, path: Path, wal: WriteAheadLog) -> None:
+    '''Serialize full InstanceState to disk and truncate the WAL.
+
+    Writes to a temporary file then atomically renames for crash safety.
+
+    Args:
+        state: The instance state to persist.
+        path: Destination file path for the snapshot.
+        wal: The write-ahead log to truncate after saving.
+    '''
+
+    data = serialize_state(state)
+    tmp = path.with_suffix('.tmp')
+    tmp.write_bytes(data)
+    with tmp.open('rb') as f:
+        os.fsync(f.fileno())
+    tmp.rename(path)
+    wal.truncate()
+
+
+def load_snapshot(path: Path) -> InstanceState | None:
+    '''Load an InstanceState snapshot from disk.
+
+    Args:
+        path: File path to the snapshot.
+
+    Returns:
+        Deserialized InstanceState, or None if file does not exist.
+    '''
+
+    if not path.exists():
+        return None
+    return deserialize_state(path.read_bytes())

--- a/nexus/infrastructure/snapshot.py
+++ b/nexus/infrastructure/snapshot.py
@@ -17,6 +17,8 @@ __all__ = ['load_snapshot', 'save_snapshot']
 
 
 def _fsync_directory(dir_path: Path) -> None:
+    '''Fsync a directory to make rename/replace durable across power loss.'''
+
     fd = os.open(str(dir_path), os.O_RDONLY)
     try:
         os.fsync(fd)

--- a/nexus/infrastructure/state_store.py
+++ b/nexus/infrastructure/state_store.py
@@ -46,7 +46,8 @@ class StateStore:
         wal_dir.mkdir(parents=True, exist_ok=True)
         self._wal = WriteAheadLog(wal_dir / _WAL_FILENAME)
         self._snapshot_path = snap_dir / _SNAPSHOT_FILENAME
-        self._sequence = 0
+        existing = self._wal.read_all()
+        self._sequence = existing[-1].sequence + 1 if existing else 0
 
     @property
     def base_path(self) -> Path:

--- a/nexus/infrastructure/state_store.py
+++ b/nexus/infrastructure/state_store.py
@@ -1,0 +1,104 @@
+'''Unified persistence facade combining WAL and snapshots.
+
+StateStore manages the directory layout under a base path,
+coordinates snapshot saves with WAL truncation, and provides
+crash recovery via snapshot + WAL replay.
+
+Directory layout:
+    {base_path}/
+        snapshots/
+            snapshot.bin   — latest full InstanceState
+        wal/
+            wal.bin        — write-ahead log since last snapshot
+'''
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from nexus.core.domain.instance_state import InstanceState
+from nexus.infrastructure.snapshot import load_snapshot, save_snapshot
+from nexus.infrastructure.wal import WriteAheadLog
+from nexus.infrastructure.wal_codec import deserialize_state, serialize_state
+from nexus.infrastructure.wal_entry import WALEntry, WALEntryType
+
+__all__ = ['StateStore']
+
+_SNAPSHOTS_DIR = 'snapshots'
+_WAL_DIR = 'wal'
+_SNAPSHOT_FILENAME = 'snapshot.bin'
+_WAL_FILENAME = 'wal.bin'
+
+
+class StateStore:
+    '''Unified persistence facade for Manager instance state.
+
+    Args:
+        base_path: Directory for snapshot and WAL files. Created if absent.
+    '''
+
+    def __init__(self, base_path: Path) -> None:
+        self._base_path = base_path
+        snap_dir = self._base_path / _SNAPSHOTS_DIR
+        wal_dir = self._base_path / _WAL_DIR
+        snap_dir.mkdir(parents=True, exist_ok=True)
+        wal_dir.mkdir(parents=True, exist_ok=True)
+        self._wal = WriteAheadLog(wal_dir / _WAL_FILENAME)
+        self._snapshot_path = snap_dir / _SNAPSHOT_FILENAME
+        self._sequence = 0
+
+    @property
+    def base_path(self) -> Path:
+        '''Return the base directory path.'''
+
+        return self._base_path
+
+    def checkpoint(self, state: InstanceState) -> None:
+        '''Save a full snapshot and truncate the WAL.
+
+        Args:
+            state: The current instance state to persist.
+        '''
+
+        save_snapshot(state, self._snapshot_path, self._wal)
+
+    def append_mutation(self, state: InstanceState) -> None:
+        '''Append a full state entry to the WAL.
+
+        Args:
+            state: The current instance state after mutation.
+        '''
+
+        payload = serialize_state(state)
+        entry = WALEntry(
+            sequence=self._sequence,
+            timestamp=datetime.now(tz=timezone.utc),
+            entry_type=WALEntryType.STATE_MUTATION,
+            payload=payload,
+        )
+        self._wal.append(entry)
+        self._sequence += 1
+
+    def recover(self) -> InstanceState | None:
+        '''Recover instance state from snapshot and WAL.
+
+        Loads the snapshot, then replays WAL entries to reach the
+        latest persisted state. WAL STATE_MUTATION entries contain
+        full serialized state; the last entry wins.
+
+        Returns:
+            Recovered InstanceState, or None if no persisted state exists.
+        '''
+
+        state = load_snapshot(self._snapshot_path)
+        wal_entries = self._wal.read_all()
+
+        for entry in wal_entries:
+            if entry.entry_type == WALEntryType.STATE_MUTATION:
+                state = deserialize_state(entry.payload)
+
+        if wal_entries:
+            self._sequence = wal_entries[-1].sequence + 1
+
+        return state

--- a/nexus/infrastructure/wal.py
+++ b/nexus/infrastructure/wal.py
@@ -62,6 +62,13 @@ class WriteAheadLog:
         header = struct.pack(_RECORD_HEADER_FMT, len(payload), crc)
 
         repair = not self._path.exists() or self._path.stat().st_size < _MAGIC_SIZE
+        if not repair:
+            with self._path.open('rb') as f:
+                if f.read(_MAGIC_SIZE) != _MAGIC:
+                    msg = (
+                        f"Cannot append to WAL with invalid magic header: {self._path}"
+                    )
+                    raise ValueError(msg)
         with self._path.open('wb' if repair else 'ab') as f:
             if repair:
                 f.write(_MAGIC)
@@ -136,9 +143,16 @@ def _deserialize_entry(data: bytes) -> WALEntry:
     '''Deserialize msgpack bytes to a WALEntry.'''
 
     d = msgpack.unpackb(data, raw=False)
-    return WALEntry(
-        sequence=d['seq'],
-        timestamp=datetime.fromisoformat(d['ts']),
-        entry_type=WALEntryType(d['type']),
-        payload=d['payload'],
-    )
+    if not isinstance(d, dict):
+        msg = f'Expected dict from WAL entry, got {type(d).__name__}'
+        raise ValueError(msg)
+    try:
+        return WALEntry(
+            sequence=d['seq'],
+            timestamp=datetime.fromisoformat(d['ts']),
+            entry_type=WALEntryType(d['type']),
+            payload=d['payload'],
+        )
+    except KeyError as exc:
+        msg = f'WAL entry missing required field: {exc}'
+        raise ValueError(msg) from exc

--- a/nexus/infrastructure/wal.py
+++ b/nexus/infrastructure/wal.py
@@ -1,0 +1,142 @@
+'''Write-ahead log for Manager instance state persistence.
+
+Append-only binary log with magic header, CRC32 integrity checks,
+and length-prefixed records. Each record is a msgpack-serialized
+WALEntry.
+
+File format:
+    Header (written once):
+        [8 bytes: magic b'NXWAL\\x00\\x01\\x00']
+
+    Per record:
+        [4-byte big-endian payload length]
+        [4-byte big-endian CRC32 of payload]
+        [msgpack payload bytes]
+'''
+
+from __future__ import annotations
+
+import os
+import struct
+import zlib
+from pathlib import Path
+
+import msgpack
+
+from nexus.infrastructure.wal_entry import WALEntry, WALEntryType
+
+__all__ = ['WriteAheadLog']
+
+_MAGIC = b'NXWAL\x00\x01\x00'
+_MAGIC_SIZE = len(_MAGIC)
+_RECORD_HEADER_FMT = '>II'
+_RECORD_HEADER_SIZE = struct.calcsize(_RECORD_HEADER_FMT)
+
+
+class WriteAheadLog:
+    '''Append-only write-ahead log backed by a binary file.
+
+    Args:
+        path: File path for the WAL. Created on first append if absent.
+    '''
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    @property
+    def path(self) -> Path:
+        '''Return the WAL file path.'''
+
+        return self._path
+
+    def append(self, entry: WALEntry) -> None:
+        '''Append a single entry to the WAL and fsync.
+
+        Args:
+            entry: The WAL entry to persist.
+        '''
+
+        payload = _serialize_entry(entry)
+        crc = zlib.crc32(payload) & 0xFFFFFFFF
+        header = struct.pack(_RECORD_HEADER_FMT, len(payload), crc)
+
+        with self._path.open('ab') as f:
+            if f.tell() == 0:
+                f.write(_MAGIC)
+            f.write(header)
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+
+    def read_all(self) -> list[WALEntry]:
+        '''Read all entries from the WAL file.
+
+        Returns:
+            List of WALEntry in append order. Empty list if file missing.
+        '''
+
+        if not self._path.exists():
+            return []
+
+        with self._path.open('rb') as f:
+            file_magic = f.read(_MAGIC_SIZE)
+            if not file_magic:
+                return []
+            if file_magic != _MAGIC:
+                msg = f"Invalid WAL magic header: {file_magic!r}"
+                raise ValueError(msg)
+
+            entries: list[WALEntry] = []
+            while True:
+                record_header = f.read(_RECORD_HEADER_SIZE)
+                if not record_header:
+                    break
+                if len(record_header) < _RECORD_HEADER_SIZE:
+                    msg = 'Truncated WAL record header'
+                    raise ValueError(msg)
+                length, expected_crc = struct.unpack(_RECORD_HEADER_FMT, record_header)
+                payload = f.read(length)
+                if len(payload) < length:
+                    msg = 'Truncated WAL record payload'
+                    raise ValueError(msg)
+                actual_crc = zlib.crc32(payload) & 0xFFFFFFFF
+                if actual_crc != expected_crc:
+                    msg = f"WAL record CRC32 mismatch: expected {expected_crc:#010x}, got {actual_crc:#010x}"
+                    raise ValueError(msg)
+                entries.append(_deserialize_entry(payload))
+        return entries
+
+    def truncate(self) -> None:
+        '''Truncate the WAL file to zero bytes.
+
+        Used after a snapshot has been saved. No-op if file missing.
+        '''
+
+        if self._path.exists():
+            self._path.write_bytes(b'')
+
+
+def _serialize_entry(entry: WALEntry) -> bytes:
+    '''Serialize a WALEntry to msgpack bytes.'''
+
+    d = {
+        'seq': entry.sequence,
+        'ts': entry.timestamp.isoformat(),
+        'type': entry.entry_type.value,
+        'payload': entry.payload,
+    }
+    return bytes(msgpack.packb(d))
+
+
+def _deserialize_entry(data: bytes) -> WALEntry:
+    '''Deserialize msgpack bytes to a WALEntry.'''
+
+    from datetime import datetime
+
+    d = msgpack.unpackb(data, raw=False)
+    return WALEntry(
+        sequence=d['seq'],
+        timestamp=datetime.fromisoformat(d['ts']),
+        entry_type=WALEntryType(d['type']),
+        payload=d['payload'],
+    )

--- a/nexus/infrastructure/wal.py
+++ b/nexus/infrastructure/wal.py
@@ -93,13 +93,11 @@ class WriteAheadLog:
                 if not record_header:
                     break
                 if len(record_header) < _RECORD_HEADER_SIZE:
-                    msg = 'Truncated WAL record header'
-                    raise ValueError(msg)
+                    break
                 length, expected_crc = struct.unpack(_RECORD_HEADER_FMT, record_header)
                 payload = f.read(length)
                 if len(payload) < length:
-                    msg = 'Truncated WAL record payload'
-                    raise ValueError(msg)
+                    break
                 actual_crc = zlib.crc32(payload) & 0xFFFFFFFF
                 if actual_crc != expected_crc:
                     msg = f"WAL record CRC32 mismatch: expected {expected_crc:#010x}, got {actual_crc:#010x}"
@@ -114,7 +112,9 @@ class WriteAheadLog:
         '''
 
         if self._path.exists():
-            self._path.write_bytes(b'')
+            with self._path.open('wb') as f:
+                f.flush()
+                os.fsync(f.fileno())
 
 
 def _serialize_entry(entry: WALEntry) -> bytes:

--- a/nexus/infrastructure/wal.py
+++ b/nexus/infrastructure/wal.py
@@ -61,8 +61,9 @@ class WriteAheadLog:
         crc = zlib.crc32(payload) & 0xFFFFFFFF
         header = struct.pack(_RECORD_HEADER_FMT, len(payload), crc)
 
-        with self._path.open('ab') as f:
-            if f.tell() == 0:
+        repair = not self._path.exists() or self._path.stat().st_size < _MAGIC_SIZE
+        with self._path.open('wb' if repair else 'ab') as f:
+            if repair:
                 f.write(_MAGIC)
             f.write(header)
             f.write(payload)
@@ -82,6 +83,8 @@ class WriteAheadLog:
         with self._path.open('rb') as f:
             file_magic = f.read(_MAGIC_SIZE)
             if not file_magic:
+                return []
+            if len(file_magic) < _MAGIC_SIZE:
                 return []
             if file_magic != _MAGIC:
                 msg = f"Invalid WAL magic header: {file_magic!r}"

--- a/nexus/infrastructure/wal.py
+++ b/nexus/infrastructure/wal.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import os
 import struct
 import zlib
+from datetime import datetime
 from pathlib import Path
 
 import msgpack
@@ -130,8 +131,6 @@ def _serialize_entry(entry: WALEntry) -> bytes:
 
 def _deserialize_entry(data: bytes) -> WALEntry:
     '''Deserialize msgpack bytes to a WALEntry.'''
-
-    from datetime import datetime
 
     d = msgpack.unpackb(data, raw=False)
     return WALEntry(

--- a/nexus/infrastructure/wal.py
+++ b/nexus/infrastructure/wal.py
@@ -83,6 +83,8 @@ class WriteAheadLog:
             f.write(payload)
             f.flush()
             os.fsync(f.fileno())
+        if repair:
+            _fsync_directory(self._path.parent)
 
     def _find_valid_end(self) -> int:
         '''Return the file offset after the last fully valid record.'''
@@ -153,6 +155,16 @@ class WriteAheadLog:
             with self._path.open('wb') as f:
                 f.flush()
                 os.fsync(f.fileno())
+
+
+def _fsync_directory(dir_path: Path) -> None:
+    '''Fsync a directory to make rename/create durable across power loss.'''
+
+    fd = os.open(str(dir_path), os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
 
 
 def _serialize_entry(entry: WALEntry) -> bytes:

--- a/nexus/infrastructure/wal.py
+++ b/nexus/infrastructure/wal.py
@@ -69,6 +69,13 @@ class WriteAheadLog:
                         f"Cannot append to WAL with invalid magic header: {self._path}"
                     )
                     raise ValueError(msg)
+            valid_end = self._find_valid_end()
+            file_size = self._path.stat().st_size
+            if valid_end < file_size:
+                with self._path.open('r+b') as f:
+                    f.truncate(valid_end)
+                    f.flush()
+                    os.fsync(f.fileno())
         with self._path.open('wb' if repair else 'ab') as f:
             if repair:
                 f.write(_MAGIC)
@@ -76,6 +83,27 @@ class WriteAheadLog:
             f.write(payload)
             f.flush()
             os.fsync(f.fileno())
+
+    def _find_valid_end(self) -> int:
+        '''Return the file offset after the last fully valid record.'''
+
+        with self._path.open('rb') as f:
+            magic = f.read(_MAGIC_SIZE)
+            if len(magic) < _MAGIC_SIZE or magic != _MAGIC:
+                return 0
+            while True:
+                pos = f.tell()
+                record_header = f.read(_RECORD_HEADER_SIZE)
+                if not record_header or len(record_header) < _RECORD_HEADER_SIZE:
+                    return pos
+                length, expected_crc = struct.unpack(_RECORD_HEADER_FMT, record_header)
+                payload = f.read(length)
+                if len(payload) < length:
+                    return pos
+                actual_crc = zlib.crc32(payload) & 0xFFFFFFFF
+                if actual_crc != expected_crc:
+                    return pos
+        return pos  # pragma: no cover
 
     def read_all(self) -> list[WALEntry]:
         '''Read all entries from the WAL file.

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -67,15 +67,20 @@ def deserialize_state(data: bytes) -> InstanceState:
         msg = f'Unsupported WAL codec version: {version}'
         raise ValueError(msg)
 
-    return InstanceState(
-        capital=_decode_capital_state(d['capital']),
-        risk=_decode_risk_state(d['risk']),
-        positions={k: _decode_position(v) for k, v in d['positions'].items()},
-        mode=_decode_mode_state(d['mode']),
-        strategy_modes={
-            k: _decode_strategy_mode_state(v) for k, v in d['strategy_modes'].items()
-        },
-    )
+    try:
+        return InstanceState(
+            capital=_decode_capital_state(d['capital']),
+            risk=_decode_risk_state(d['risk']),
+            positions={k: _decode_position(v) for k, v in d['positions'].items()},
+            mode=_decode_mode_state(d['mode']),
+            strategy_modes={
+                k: _decode_strategy_mode_state(v)
+                for k, v in d['strategy_modes'].items()
+            },
+        )
+    except (KeyError, TypeError) as exc:
+        msg = f'Malformed WAL codec payload: {exc}'
+        raise ValueError(msg) from exc
 
 
 def _encode_capital_state(cs: CapitalState) -> dict[str, str]:

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -1,0 +1,193 @@
+'''Serialization codec for InstanceState to/from bytes via msgpack.
+
+Explicit per-type encode/decode for full type safety. Each domain
+dataclass has a paired _encode / _decode function. Codec version
+is embedded for forward compatibility.
+'''
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+import msgpack
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OperationalMode, OrderSide
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.operational_mode import ModeState, StrategyModeState
+from nexus.core.domain.position import Position
+from nexus.core.domain.risk_state import RiskState, StrategyRiskState
+
+__all__ = ['deserialize_state', 'serialize_state']
+
+_CODEC_VERSION = 1
+
+
+def serialize_state(state: InstanceState) -> bytes:
+    '''Serialize InstanceState to compact binary format.
+
+    Args:
+        state: The instance state to serialize.
+
+    Returns:
+        Msgpack-encoded bytes.
+    '''
+
+    d: dict[str, Any] = {
+        '_v': _CODEC_VERSION,
+        'capital': _encode_capital_state(state.capital),
+        'risk': _encode_risk_state(state.risk),
+        'positions': {k: _encode_position(v) for k, v in state.positions.items()},
+        'mode': _encode_mode_state(state.mode),
+        'strategy_modes': {
+            k: _encode_strategy_mode_state(v) for k, v in state.strategy_modes.items()
+        },
+    }
+    return bytes(msgpack.packb(d))
+
+
+def deserialize_state(data: bytes) -> InstanceState:
+    '''Deserialize InstanceState from compact binary format.
+
+    Args:
+        data: Msgpack-encoded bytes.
+
+    Returns:
+        Reconstructed InstanceState.
+    '''
+
+    d = msgpack.unpackb(data, raw=False)
+    version = d.get('_v', 0)
+    if version != _CODEC_VERSION:
+        msg = f'Unsupported WAL codec version: {version}'
+        raise ValueError(msg)
+
+    return InstanceState(
+        capital=_decode_capital_state(d['capital']),
+        risk=_decode_risk_state(d['risk']),
+        positions={k: _decode_position(v) for k, v in d['positions'].items()},
+        mode=_decode_mode_state(d['mode']),
+        strategy_modes={
+            k: _decode_strategy_mode_state(v) for k, v in d['strategy_modes'].items()
+        },
+    )
+
+
+def _encode_capital_state(cs: CapitalState) -> dict[str, str]:
+    return {
+        'capital_pool': str(cs.capital_pool),
+        'position_notional': str(cs.position_notional),
+        'working_order_notional': str(cs.working_order_notional),
+        'in_flight_order_notional': str(cs.in_flight_order_notional),
+        'fee_reserve': str(cs.fee_reserve),
+        'reservation_notional': str(cs.reservation_notional),
+    }
+
+
+def _decode_capital_state(d: dict[str, str]) -> CapitalState:
+    return CapitalState(
+        capital_pool=Decimal(d['capital_pool']),
+        position_notional=Decimal(d['position_notional']),
+        working_order_notional=Decimal(d['working_order_notional']),
+        in_flight_order_notional=Decimal(d['in_flight_order_notional']),
+        fee_reserve=Decimal(d['fee_reserve']),
+        reservation_notional=Decimal(d['reservation_notional']),
+    )
+
+
+def _encode_strategy_risk_state(srs: StrategyRiskState) -> dict[str, str]:
+    return {
+        'strategy_id': srs.strategy_id,
+        'high_water_mark': str(srs.high_water_mark),
+        'rolling_loss_24h': str(srs.rolling_loss_24h),
+        'rolling_loss_7d': str(srs.rolling_loss_7d),
+        'rolling_loss_30d': str(srs.rolling_loss_30d),
+        'strategy_realized_pnl': str(srs.strategy_realized_pnl),
+    }
+
+
+def _decode_strategy_risk_state(d: dict[str, str]) -> StrategyRiskState:
+    return StrategyRiskState(
+        strategy_id=d['strategy_id'],
+        high_water_mark=Decimal(d['high_water_mark']),
+        rolling_loss_24h=Decimal(d['rolling_loss_24h']),
+        rolling_loss_7d=Decimal(d['rolling_loss_7d']),
+        rolling_loss_30d=Decimal(d['rolling_loss_30d']),
+        strategy_realized_pnl=Decimal(d['strategy_realized_pnl']),
+    )
+
+
+def _encode_risk_state(rs: RiskState) -> dict[str, Any]:
+    return {
+        'high_water_mark': str(rs.high_water_mark),
+        'per_strategy': {
+            k: _encode_strategy_risk_state(v) for k, v in rs.per_strategy.items()
+        },
+    }
+
+
+def _decode_risk_state(d: dict[str, Any]) -> RiskState:
+    return RiskState(
+        high_water_mark=Decimal(d['high_water_mark']),
+        per_strategy={
+            k: _decode_strategy_risk_state(v) for k, v in d['per_strategy'].items()
+        },
+    )
+
+
+def _encode_position(pos: Position) -> dict[str, str]:
+    return {
+        'trade_id': pos.trade_id,
+        'strategy_id': pos.strategy_id,
+        'symbol': pos.symbol,
+        'side': pos.side.value,
+        'size': str(pos.size),
+        'entry_price': str(pos.entry_price),
+        'unrealized_pnl': str(pos.unrealized_pnl),
+        'pending_exit': str(pos.pending_exit),
+    }
+
+
+def _decode_position(d: dict[str, str]) -> Position:
+    return Position(
+        trade_id=d['trade_id'],
+        strategy_id=d['strategy_id'],
+        symbol=d['symbol'],
+        side=OrderSide(d['side']),
+        size=Decimal(d['size']),
+        entry_price=Decimal(d['entry_price']),
+        unrealized_pnl=Decimal(d['unrealized_pnl']),
+        pending_exit=Decimal(d['pending_exit']),
+    )
+
+
+def _encode_mode_state(ms: ModeState) -> dict[str, str]:
+    return {
+        'mode': ms.mode.value,
+        'trigger': ms.trigger,
+        'transitioned_at': ms.transitioned_at.isoformat(),
+    }
+
+
+def _decode_mode_state(d: dict[str, str]) -> ModeState:
+    return ModeState(
+        mode=OperationalMode(d['mode']),
+        trigger=d['trigger'],
+        transitioned_at=datetime.fromisoformat(d['transitioned_at']),
+    )
+
+
+def _encode_strategy_mode_state(sms: StrategyModeState) -> dict[str, Any]:
+    return {
+        'strategy_id': sms.strategy_id,
+        'state': _encode_mode_state(sms.state),
+    }
+
+
+def _decode_strategy_mode_state(d: dict[str, Any]) -> StrategyModeState:
+    return StrategyModeState(
+        strategy_id=d['strategy_id'],
+        state=_decode_mode_state(d['state']),
+    )

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -29,10 +29,10 @@ def serialize_state(state: InstanceState) -> bytes:
     '''Serialize InstanceState to compact binary format.
 
     Args:
-        state (InstanceState): The instance state to serialize
+        state: The instance state to serialize.
 
     Returns:
-        bytes: Msgpack-encoded bytes
+        Msgpack-encoded bytes.
     '''
 
     d: dict[str, Any] = {
@@ -52,13 +52,16 @@ def deserialize_state(data: bytes) -> InstanceState:
     '''Deserialize InstanceState from compact binary format.
 
     Args:
-        data (bytes): Msgpack-encoded bytes
+        data: Msgpack-encoded bytes.
 
     Returns:
-        InstanceState: Reconstructed InstanceState
+        Reconstructed InstanceState.
     '''
 
     d = msgpack.unpackb(data, raw=False)
+    if not isinstance(d, dict):
+        msg = f'Expected dict from WAL payload, got {type(d).__name__}'
+        raise ValueError(msg)
     version = d.get('_v', 0)
     if version != _CODEC_VERSION:
         msg = f'Unsupported WAL codec version: {version}'
@@ -76,14 +79,13 @@ def deserialize_state(data: bytes) -> InstanceState:
 
 
 def _encode_capital_state(cs: CapitalState) -> dict[str, str]:
-
     '''Encode CapitalState to string-valued dict for msgpack.
 
     Args:
-        cs (CapitalState): Capital state to encode
+        cs: Capital state to encode.
 
     Returns:
-        dict[str, str]: String-keyed dict with Decimal values as strings
+        String-keyed dict with Decimal values as strings.
     '''
 
     return {
@@ -97,14 +99,13 @@ def _encode_capital_state(cs: CapitalState) -> dict[str, str]:
 
 
 def _decode_capital_state(d: dict[str, str]) -> CapitalState:
-
     '''Decode string-valued dict to CapitalState.
 
     Args:
-        d (dict[str, str]): Encoded capital state dict
+        d: Encoded capital state dict.
 
     Returns:
-        CapitalState: Reconstructed capital state
+        Reconstructed capital state.
     '''
 
     return CapitalState(
@@ -118,14 +119,13 @@ def _decode_capital_state(d: dict[str, str]) -> CapitalState:
 
 
 def _encode_strategy_risk_state(srs: StrategyRiskState) -> dict[str, str]:
-
     '''Encode StrategyRiskState to string-valued dict for msgpack.
 
     Args:
-        srs (StrategyRiskState): Strategy risk state to encode
+        srs: Strategy risk state to encode.
 
     Returns:
-        dict[str, str]: String-keyed dict with Decimal values as strings
+        String-keyed dict with Decimal values as strings.
     '''
 
     return {
@@ -139,14 +139,13 @@ def _encode_strategy_risk_state(srs: StrategyRiskState) -> dict[str, str]:
 
 
 def _decode_strategy_risk_state(d: dict[str, str]) -> StrategyRiskState:
-
     '''Decode string-valued dict to StrategyRiskState.
 
     Args:
-        d (dict[str, str]): Encoded strategy risk state dict
+        d: Encoded strategy risk state dict.
 
     Returns:
-        StrategyRiskState: Reconstructed strategy risk state
+        Reconstructed strategy risk state.
     '''
 
     return StrategyRiskState(
@@ -160,14 +159,13 @@ def _decode_strategy_risk_state(d: dict[str, str]) -> StrategyRiskState:
 
 
 def _encode_risk_state(rs: RiskState) -> dict[str, Any]:
-
     '''Encode RiskState to nested dict for msgpack.
 
     Args:
-        rs (RiskState): Risk state to encode
+        rs: Risk state to encode.
 
     Returns:
-        dict[str, Any]: Nested dict with per-strategy risk states
+        Nested dict with per-strategy risk states.
     '''
 
     return {
@@ -179,14 +177,13 @@ def _encode_risk_state(rs: RiskState) -> dict[str, Any]:
 
 
 def _decode_risk_state(d: dict[str, Any]) -> RiskState:
-
     '''Decode nested dict to RiskState.
 
     Args:
-        d (dict[str, Any]): Encoded risk state dict
+        d: Encoded risk state dict.
 
     Returns:
-        RiskState: Reconstructed risk state with per-strategy entries
+        Reconstructed risk state with per-strategy entries.
     '''
 
     return RiskState(
@@ -198,14 +195,13 @@ def _decode_risk_state(d: dict[str, Any]) -> RiskState:
 
 
 def _encode_position(pos: Position) -> dict[str, str]:
-
     '''Encode Position to string-valued dict for msgpack.
 
     Args:
-        pos (Position): Position to encode
+        pos: Position to encode.
 
     Returns:
-        dict[str, str]: String-keyed dict with Decimal and enum values as strings
+        String-keyed dict with Decimal and enum values as strings.
     '''
 
     return {
@@ -221,14 +217,13 @@ def _encode_position(pos: Position) -> dict[str, str]:
 
 
 def _decode_position(d: dict[str, str]) -> Position:
-
     '''Decode string-valued dict to Position.
 
     Args:
-        d (dict[str, str]): Encoded position dict
+        d: Encoded position dict.
 
     Returns:
-        Position: Reconstructed position
+        Reconstructed position.
     '''
 
     return Position(
@@ -244,14 +239,13 @@ def _decode_position(d: dict[str, str]) -> Position:
 
 
 def _encode_mode_state(ms: ModeState) -> dict[str, str]:
-
     '''Encode ModeState to string-valued dict for msgpack.
 
     Args:
-        ms (ModeState): Mode state to encode
+        ms: Mode state to encode.
 
     Returns:
-        dict[str, str]: String-keyed dict with enum and datetime as strings
+        String-keyed dict with enum and datetime as strings.
     '''
 
     return {
@@ -262,14 +256,13 @@ def _encode_mode_state(ms: ModeState) -> dict[str, str]:
 
 
 def _decode_mode_state(d: dict[str, str]) -> ModeState:
-
     '''Decode string-valued dict to ModeState.
 
     Args:
-        d (dict[str, str]): Encoded mode state dict
+        d: Encoded mode state dict.
 
     Returns:
-        ModeState: Reconstructed mode state
+        Reconstructed mode state.
     '''
 
     return ModeState(
@@ -280,14 +273,13 @@ def _decode_mode_state(d: dict[str, str]) -> ModeState:
 
 
 def _encode_strategy_mode_state(sms: StrategyModeState) -> dict[str, Any]:
-
     '''Encode StrategyModeState to nested dict for msgpack.
 
     Args:
-        sms (StrategyModeState): Strategy mode state to encode
+        sms: Strategy mode state to encode.
 
     Returns:
-        dict[str, Any]: Nested dict with encoded mode state
+        Nested dict with encoded mode state.
     '''
 
     return {
@@ -297,14 +289,13 @@ def _encode_strategy_mode_state(sms: StrategyModeState) -> dict[str, Any]:
 
 
 def _decode_strategy_mode_state(d: dict[str, Any]) -> StrategyModeState:
-
     '''Decode nested dict to StrategyModeState.
 
     Args:
-        d (dict[str, Any]): Encoded strategy mode state dict
+        d: Encoded strategy mode state dict.
 
     Returns:
-        StrategyModeState: Reconstructed strategy mode state
+        Reconstructed strategy mode state.
     '''
 
     return StrategyModeState(

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -29,10 +29,10 @@ def serialize_state(state: InstanceState) -> bytes:
     '''Serialize InstanceState to compact binary format.
 
     Args:
-        state: The instance state to serialize.
+        state (InstanceState): The instance state to serialize
 
     Returns:
-        Msgpack-encoded bytes.
+        bytes: Msgpack-encoded bytes
     '''
 
     d: dict[str, Any] = {
@@ -52,10 +52,10 @@ def deserialize_state(data: bytes) -> InstanceState:
     '''Deserialize InstanceState from compact binary format.
 
     Args:
-        data: Msgpack-encoded bytes.
+        data (bytes): Msgpack-encoded bytes
 
     Returns:
-        Reconstructed InstanceState.
+        InstanceState: Reconstructed InstanceState
     '''
 
     d = msgpack.unpackb(data, raw=False)
@@ -76,6 +76,16 @@ def deserialize_state(data: bytes) -> InstanceState:
 
 
 def _encode_capital_state(cs: CapitalState) -> dict[str, str]:
+
+    '''Encode CapitalState to string-valued dict for msgpack.
+
+    Args:
+        cs (CapitalState): Capital state to encode
+
+    Returns:
+        dict[str, str]: String-keyed dict with Decimal values as strings
+    '''
+
     return {
         'capital_pool': str(cs.capital_pool),
         'position_notional': str(cs.position_notional),
@@ -87,6 +97,16 @@ def _encode_capital_state(cs: CapitalState) -> dict[str, str]:
 
 
 def _decode_capital_state(d: dict[str, str]) -> CapitalState:
+
+    '''Decode string-valued dict to CapitalState.
+
+    Args:
+        d (dict[str, str]): Encoded capital state dict
+
+    Returns:
+        CapitalState: Reconstructed capital state
+    '''
+
     return CapitalState(
         capital_pool=Decimal(d['capital_pool']),
         position_notional=Decimal(d['position_notional']),
@@ -98,6 +118,16 @@ def _decode_capital_state(d: dict[str, str]) -> CapitalState:
 
 
 def _encode_strategy_risk_state(srs: StrategyRiskState) -> dict[str, str]:
+
+    '''Encode StrategyRiskState to string-valued dict for msgpack.
+
+    Args:
+        srs (StrategyRiskState): Strategy risk state to encode
+
+    Returns:
+        dict[str, str]: String-keyed dict with Decimal values as strings
+    '''
+
     return {
         'strategy_id': srs.strategy_id,
         'high_water_mark': str(srs.high_water_mark),
@@ -109,6 +139,16 @@ def _encode_strategy_risk_state(srs: StrategyRiskState) -> dict[str, str]:
 
 
 def _decode_strategy_risk_state(d: dict[str, str]) -> StrategyRiskState:
+
+    '''Decode string-valued dict to StrategyRiskState.
+
+    Args:
+        d (dict[str, str]): Encoded strategy risk state dict
+
+    Returns:
+        StrategyRiskState: Reconstructed strategy risk state
+    '''
+
     return StrategyRiskState(
         strategy_id=d['strategy_id'],
         high_water_mark=Decimal(d['high_water_mark']),
@@ -120,6 +160,16 @@ def _decode_strategy_risk_state(d: dict[str, str]) -> StrategyRiskState:
 
 
 def _encode_risk_state(rs: RiskState) -> dict[str, Any]:
+
+    '''Encode RiskState to nested dict for msgpack.
+
+    Args:
+        rs (RiskState): Risk state to encode
+
+    Returns:
+        dict[str, Any]: Nested dict with per-strategy risk states
+    '''
+
     return {
         'high_water_mark': str(rs.high_water_mark),
         'per_strategy': {
@@ -129,6 +179,16 @@ def _encode_risk_state(rs: RiskState) -> dict[str, Any]:
 
 
 def _decode_risk_state(d: dict[str, Any]) -> RiskState:
+
+    '''Decode nested dict to RiskState.
+
+    Args:
+        d (dict[str, Any]): Encoded risk state dict
+
+    Returns:
+        RiskState: Reconstructed risk state with per-strategy entries
+    '''
+
     return RiskState(
         high_water_mark=Decimal(d['high_water_mark']),
         per_strategy={
@@ -138,6 +198,16 @@ def _decode_risk_state(d: dict[str, Any]) -> RiskState:
 
 
 def _encode_position(pos: Position) -> dict[str, str]:
+
+    '''Encode Position to string-valued dict for msgpack.
+
+    Args:
+        pos (Position): Position to encode
+
+    Returns:
+        dict[str, str]: String-keyed dict with Decimal and enum values as strings
+    '''
+
     return {
         'trade_id': pos.trade_id,
         'strategy_id': pos.strategy_id,
@@ -151,6 +221,16 @@ def _encode_position(pos: Position) -> dict[str, str]:
 
 
 def _decode_position(d: dict[str, str]) -> Position:
+
+    '''Decode string-valued dict to Position.
+
+    Args:
+        d (dict[str, str]): Encoded position dict
+
+    Returns:
+        Position: Reconstructed position
+    '''
+
     return Position(
         trade_id=d['trade_id'],
         strategy_id=d['strategy_id'],
@@ -164,6 +244,16 @@ def _decode_position(d: dict[str, str]) -> Position:
 
 
 def _encode_mode_state(ms: ModeState) -> dict[str, str]:
+
+    '''Encode ModeState to string-valued dict for msgpack.
+
+    Args:
+        ms (ModeState): Mode state to encode
+
+    Returns:
+        dict[str, str]: String-keyed dict with enum and datetime as strings
+    '''
+
     return {
         'mode': ms.mode.value,
         'trigger': ms.trigger,
@@ -172,6 +262,16 @@ def _encode_mode_state(ms: ModeState) -> dict[str, str]:
 
 
 def _decode_mode_state(d: dict[str, str]) -> ModeState:
+
+    '''Decode string-valued dict to ModeState.
+
+    Args:
+        d (dict[str, str]): Encoded mode state dict
+
+    Returns:
+        ModeState: Reconstructed mode state
+    '''
+
     return ModeState(
         mode=OperationalMode(d['mode']),
         trigger=d['trigger'],
@@ -180,6 +280,16 @@ def _decode_mode_state(d: dict[str, str]) -> ModeState:
 
 
 def _encode_strategy_mode_state(sms: StrategyModeState) -> dict[str, Any]:
+
+    '''Encode StrategyModeState to nested dict for msgpack.
+
+    Args:
+        sms (StrategyModeState): Strategy mode state to encode
+
+    Returns:
+        dict[str, Any]: Nested dict with encoded mode state
+    '''
+
     return {
         'strategy_id': sms.strategy_id,
         'state': _encode_mode_state(sms.state),
@@ -187,6 +297,16 @@ def _encode_strategy_mode_state(sms: StrategyModeState) -> dict[str, Any]:
 
 
 def _decode_strategy_mode_state(d: dict[str, Any]) -> StrategyModeState:
+
+    '''Decode nested dict to StrategyModeState.
+
+    Args:
+        d (dict[str, Any]): Encoded strategy mode state dict
+
+    Returns:
+        StrategyModeState: Reconstructed strategy mode state
+    '''
+
     return StrategyModeState(
         strategy_id=d['strategy_id'],
         state=_decode_mode_state(d['state']),

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -78,7 +78,7 @@ def deserialize_state(data: bytes) -> InstanceState:
                 for k, v in d['strategy_modes'].items()
             },
         )
-    except (KeyError, TypeError) as exc:
+    except (KeyError, TypeError, AttributeError) as exc:
         msg = f'Malformed WAL codec payload: {exc}'
         raise ValueError(msg) from exc
 

--- a/nexus/infrastructure/wal_entry.py
+++ b/nexus/infrastructure/wal_entry.py
@@ -1,0 +1,57 @@
+'''WAL entry types for Manager instance state persistence.
+
+Defines the entry type enum and frozen dataclass representing
+a single record in the write-ahead log.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+__all__ = ['WALEntry', 'WALEntryType']
+
+
+class WALEntryType(Enum):
+    '''Types of entries in the write-ahead log.'''
+
+    SNAPSHOT = 'snapshot'
+    STATE_MUTATION = 'state_mutation'
+    STRATEGY_EVENT = 'strategy_event'
+
+
+@dataclass(frozen=True)
+class WALEntry:
+    '''A single immutable entry in the write-ahead log.
+
+    Args:
+        sequence: Monotonically increasing sequence number.
+        timestamp: When this entry was created.
+        entry_type: What kind of entry this is.
+        payload: Serialized content.
+    '''
+
+    sequence: int
+    timestamp: datetime
+    entry_type: WALEntryType
+    payload: bytes
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if self.sequence < 0:
+            msg = 'WALEntry.sequence must be non-negative'
+            raise ValueError(msg)
+
+        if not isinstance(self.timestamp, datetime):
+            msg = 'WALEntry.timestamp must be a datetime'
+            raise ValueError(msg)
+
+        if not isinstance(self.entry_type, WALEntryType):
+            msg = 'WALEntry.entry_type must be a WALEntryType member'
+            raise ValueError(msg)
+
+        if not isinstance(self.payload, bytes):
+            msg = 'WALEntry.payload must be bytes'
+            raise ValueError(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.3.0"
+version = "0.4.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.10"
-dependencies = ["structlog>=24.0", "orjson>=3.10"]
+dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0"]
 
 [project.optional-dependencies]
 dev = [
@@ -122,6 +122,10 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 check_untyped_defs = true
 no_implicit_optional = true
+
+[[tool.mypy.overrides]]
+module = ["msgpack", "msgpack.*"]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,223 @@
+'''Verify snapshot save/load round-trip and WAL truncation.'''
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OperationalMode, OrderSide
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.operational_mode import ModeState, StrategyModeState
+from nexus.core.domain.position import Position
+from nexus.core.domain.risk_state import RiskState, StrategyRiskState
+from nexus.infrastructure.snapshot import load_snapshot, save_snapshot
+from nexus.infrastructure.wal import WriteAheadLog
+from nexus.infrastructure.wal_entry import WALEntry, WALEntryType
+
+
+def _make_minimal_state() -> InstanceState:
+    '''Build a minimal InstanceState with only capital.'''
+
+    return InstanceState(capital=CapitalState(capital_pool=Decimal('10000')))
+
+
+def _make_full_state() -> InstanceState:
+    '''Build a fully populated InstanceState.'''
+
+    return InstanceState(
+        capital=CapitalState(
+            capital_pool=Decimal('100000'),
+            position_notional=Decimal('25000.50'),
+            working_order_notional=Decimal('5000'),
+            in_flight_order_notional=Decimal('1000.75'),
+            fee_reserve=Decimal('200'),
+            reservation_notional=Decimal('3000'),
+        ),
+        risk=RiskState(
+            high_water_mark=Decimal('110000'),
+            per_strategy={
+                'momentum': StrategyRiskState(
+                    strategy_id='momentum',
+                    high_water_mark=Decimal('60000'),
+                    rolling_loss_24h=Decimal('150.25'),
+                    rolling_loss_7d=Decimal('800'),
+                    rolling_loss_30d=Decimal('2500'),
+                    strategy_realized_pnl=Decimal('-500.75'),
+                ),
+            },
+        ),
+        positions={
+            't1': Position(
+                trade_id='t1',
+                strategy_id='momentum',
+                symbol='BTCUSDT',
+                side=OrderSide.BUY,
+                size=Decimal('0.5'),
+                entry_price=Decimal('50000'),
+                unrealized_pnl=Decimal('1250.50'),
+            ),
+        },
+        mode=ModeState(
+            mode=OperationalMode.REDUCE_ONLY,
+            trigger='risk_breach',
+            transitioned_at=datetime(2025, 6, 15, 14, 30, 0),
+        ),
+        strategy_modes={
+            'momentum': StrategyModeState(
+                strategy_id='momentum',
+                state=ModeState(
+                    mode=OperationalMode.HALTED,
+                    trigger='manual_halt',
+                    transitioned_at=datetime(2025, 6, 15, 15, 0, 0),
+                ),
+            ),
+        },
+    )
+
+
+class TestSaveAndLoad:
+    '''Verify save_snapshot and load_snapshot round-trip.'''
+
+    def test_minimal_state(self, tmp_path: Path) -> None:
+        '''Verify minimal state survives save/load.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        snap_path = tmp_path / 'snapshot.bin'
+        original = _make_minimal_state()
+
+        save_snapshot(original, snap_path, wal)
+        restored = load_snapshot(snap_path)
+
+        assert restored is not None
+        assert restored.capital.capital_pool == original.capital.capital_pool
+
+    def test_full_state(self, tmp_path: Path) -> None:
+        '''Verify fully populated state survives save/load.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        snap_path = tmp_path / 'snapshot.bin'
+        original = _make_full_state()
+
+        save_snapshot(original, snap_path, wal)
+        restored = load_snapshot(snap_path)
+
+        assert restored is not None
+        assert restored.capital.capital_pool == original.capital.capital_pool
+        assert restored.risk.high_water_mark == original.risk.high_water_mark
+        assert 't1' in restored.positions
+        assert restored.positions['t1'].side == OrderSide.BUY
+        assert restored.mode.mode == OperationalMode.REDUCE_ONLY
+        assert 'momentum' in restored.strategy_modes
+
+    def test_snapshot_creates_file(self, tmp_path: Path) -> None:
+        '''Verify save_snapshot creates the snapshot file.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        snap_path = tmp_path / 'snapshot.bin'
+
+        assert not snap_path.exists()
+        save_snapshot(_make_minimal_state(), snap_path, wal)
+        assert snap_path.exists()
+
+    def test_snapshot_overwrites_previous(self, tmp_path: Path) -> None:
+        '''Verify save_snapshot replaces an existing snapshot.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        snap_path = tmp_path / 'snapshot.bin'
+
+        save_snapshot(
+            InstanceState(capital=CapitalState(capital_pool=Decimal('1000'))),
+            snap_path,
+            wal,
+        )
+        save_snapshot(
+            InstanceState(capital=CapitalState(capital_pool=Decimal('2000'))),
+            snap_path,
+            wal,
+        )
+
+        restored = load_snapshot(snap_path)
+        assert restored is not None
+        assert restored.capital.capital_pool == Decimal('2000')
+
+
+class TestLoadMissing:
+    '''Verify load_snapshot behavior for missing files.'''
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        '''Verify load_snapshot returns None when file does not exist.'''
+
+        assert load_snapshot(tmp_path / 'nonexistent.bin') is None
+
+
+class TestWalTruncation:
+    '''Verify save_snapshot truncates the WAL.'''
+
+    def test_wal_truncated_after_save(self, tmp_path: Path) -> None:
+        '''Verify WAL is empty after save_snapshot.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        wal.append(
+            WALEntry(
+                sequence=0,
+                timestamp=datetime(2025, 1, 1),
+                entry_type=WALEntryType.STATE_MUTATION,
+                payload=b'\x00',
+            )
+        )
+        wal.append(
+            WALEntry(
+                sequence=1,
+                timestamp=datetime(2025, 1, 1),
+                entry_type=WALEntryType.STATE_MUTATION,
+                payload=b'\x01',
+            )
+        )
+        assert len(wal.read_all()) == 2
+
+        save_snapshot(_make_minimal_state(), tmp_path / 'snapshot.bin', wal)
+        assert wal.read_all() == []
+
+    def test_wal_appendable_after_truncation(self, tmp_path: Path) -> None:
+        '''Verify WAL accepts new entries after snapshot truncation.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        wal.append(
+            WALEntry(
+                sequence=0,
+                timestamp=datetime(2025, 1, 1),
+                entry_type=WALEntryType.STATE_MUTATION,
+                payload=b'\x00',
+            )
+        )
+
+        save_snapshot(_make_minimal_state(), tmp_path / 'snapshot.bin', wal)
+        wal.append(
+            WALEntry(
+                sequence=1,
+                timestamp=datetime(2025, 1, 2),
+                entry_type=WALEntryType.STATE_MUTATION,
+                payload=b'\x01',
+            )
+        )
+
+        entries = wal.read_all()
+        assert len(entries) == 1
+        assert entries[0].sequence == 1
+
+
+class TestAtomicWrite:
+    '''Verify snapshot write does not leave temp files.'''
+
+    def test_no_tmp_file_after_save(self, tmp_path: Path) -> None:
+        '''Verify .tmp file is cleaned up after save.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        snap_path = tmp_path / 'snapshot.bin'
+        save_snapshot(_make_minimal_state(), snap_path, wal)
+
+        tmp_file = snap_path.with_suffix('.tmp')
+        assert not tmp_file.exists()
+        assert snap_path.exists()

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -99,7 +99,6 @@ class TestAppendMutation:
     def test_sequence_increments(self, tmp_path: Path) -> None:
         '''Verify WAL entry sequence numbers increment.'''
 
-
         store = StateStore(tmp_path / 'state')
         store.append_mutation(_make_state('1000'))
         store.append_mutation(_make_state('2000'))
@@ -108,6 +107,20 @@ class TestAppendMutation:
         entries = wal.read_all()
         assert entries[0].sequence == 0
         assert entries[1].sequence == 1
+
+    def test_sequence_continues_without_recover(self, tmp_path: Path) -> None:
+        '''Verify new StateStore on existing WAL continues sequence.'''
+
+        store = StateStore(tmp_path / 'state')
+        store.append_mutation(_make_state('1000'))
+        store.append_mutation(_make_state('2000'))
+
+        store2 = StateStore(tmp_path / 'state')
+        store2.append_mutation(_make_state('3000'))
+
+        wal = WriteAheadLog(tmp_path / 'state' / 'wal' / 'wal.bin')
+        entries = wal.read_all()
+        assert entries[-1].sequence == 2
 
 
 class TestRecover:
@@ -156,7 +169,6 @@ class TestRecover:
 
     def test_sequence_resumes_after_recover(self, tmp_path: Path) -> None:
         '''Verify sequence counter resumes from WAL after recovery.'''
-
 
         store = StateStore(tmp_path / 'state')
         store.append_mutation(_make_state('1000'))

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,0 +1,197 @@
+'''Verify StateStore checkpoint, append_mutation, and recover.'''
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.instance_state import InstanceState
+from nexus.infrastructure.state_store import StateStore
+
+
+def _make_state(pool: str = '10000') -> InstanceState:
+    '''Build an InstanceState with the given capital pool.'''
+
+    return InstanceState(capital=CapitalState(capital_pool=Decimal(pool)))
+
+
+class TestDirectoryLayout:
+    '''Verify StateStore creates and manages its directory.'''
+
+    def test_creates_base_directory(self, tmp_path: Path) -> None:
+        '''Verify StateStore creates the base directory if absent.'''
+
+        base = tmp_path / 'state'
+        assert not base.exists()
+        StateStore(base)
+        assert base.is_dir()
+
+    def test_base_path_property(self, tmp_path: Path) -> None:
+        '''Verify base_path returns the configured path.'''
+
+        base = tmp_path / 'state'
+        store = StateStore(base)
+        assert store.base_path == base
+
+
+class TestCheckpoint:
+    '''Verify checkpoint saves snapshot and truncates WAL.'''
+
+    def test_checkpoint_creates_snapshot(self, tmp_path: Path) -> None:
+        '''Verify checkpoint creates the snapshot file.'''
+
+        store = StateStore(tmp_path / 'state')
+        store.checkpoint(_make_state())
+        assert (tmp_path / 'state' / 'snapshots' / 'snapshot.bin').exists()
+
+    def test_checkpoint_truncates_wal(self, tmp_path: Path) -> None:
+        '''Verify WAL is empty after checkpoint.'''
+
+        store = StateStore(tmp_path / 'state')
+        store.append_mutation(_make_state('5000'))
+        store.checkpoint(_make_state('10000'))
+
+        restored = store.recover()
+        assert restored is not None
+        assert restored.capital.capital_pool == Decimal('10000')
+
+    def test_checkpoint_overwrites_previous(self, tmp_path: Path) -> None:
+        '''Verify second checkpoint replaces the first.'''
+
+        store = StateStore(tmp_path / 'state')
+        store.checkpoint(_make_state('1000'))
+        store.checkpoint(_make_state('2000'))
+
+        restored = store.recover()
+        assert restored is not None
+        assert restored.capital.capital_pool == Decimal('2000')
+
+
+class TestAppendMutation:
+    '''Verify append_mutation writes state to WAL.'''
+
+    def test_single_mutation_recoverable(self, tmp_path: Path) -> None:
+        '''Verify single mutation is recoverable without snapshot.'''
+
+        store = StateStore(tmp_path / 'state')
+        store.append_mutation(_make_state('7500'))
+
+        store2 = StateStore(tmp_path / 'state')
+        restored = store2.recover()
+        assert restored is not None
+        assert restored.capital.capital_pool == Decimal('7500')
+
+    def test_multiple_mutations_last_wins(self, tmp_path: Path) -> None:
+        '''Verify last mutation is the recovered state.'''
+
+        store = StateStore(tmp_path / 'state')
+        store.append_mutation(_make_state('1000'))
+        store.append_mutation(_make_state('2000'))
+        store.append_mutation(_make_state('3000'))
+
+        store2 = StateStore(tmp_path / 'state')
+        restored = store2.recover()
+        assert restored is not None
+        assert restored.capital.capital_pool == Decimal('3000')
+
+    def test_sequence_increments(self, tmp_path: Path) -> None:
+        '''Verify WAL entry sequence numbers increment.'''
+
+        from nexus.infrastructure.wal import WriteAheadLog
+
+        store = StateStore(tmp_path / 'state')
+        store.append_mutation(_make_state('1000'))
+        store.append_mutation(_make_state('2000'))
+
+        wal = WriteAheadLog(tmp_path / 'state' / 'wal' / 'wal.bin')
+        entries = wal.read_all()
+        assert entries[0].sequence == 0
+        assert entries[1].sequence == 1
+
+
+class TestRecover:
+    '''Verify recover behavior across scenarios.'''
+
+    def test_no_state_returns_none(self, tmp_path: Path) -> None:
+        '''Verify recover returns None with no snapshot and no WAL.'''
+
+        store = StateStore(tmp_path / 'state')
+        assert store.recover() is None
+
+    def test_snapshot_only(self, tmp_path: Path) -> None:
+        '''Verify recover from snapshot with no WAL entries.'''
+
+        store = StateStore(tmp_path / 'state')
+        store.checkpoint(_make_state('50000'))
+
+        store2 = StateStore(tmp_path / 'state')
+        restored = store2.recover()
+        assert restored is not None
+        assert restored.capital.capital_pool == Decimal('50000')
+
+    def test_snapshot_plus_wal(self, tmp_path: Path) -> None:
+        '''Verify WAL entries override snapshot state.'''
+
+        store = StateStore(tmp_path / 'state')
+        store.checkpoint(_make_state('10000'))
+        store.append_mutation(_make_state('15000'))
+        store.append_mutation(_make_state('20000'))
+
+        store2 = StateStore(tmp_path / 'state')
+        restored = store2.recover()
+        assert restored is not None
+        assert restored.capital.capital_pool == Decimal('20000')
+
+    def test_wal_only_no_snapshot(self, tmp_path: Path) -> None:
+        '''Verify recover from WAL entries without a snapshot.'''
+
+        store = StateStore(tmp_path / 'state')
+        store.append_mutation(_make_state('8000'))
+
+        store2 = StateStore(tmp_path / 'state')
+        restored = store2.recover()
+        assert restored is not None
+        assert restored.capital.capital_pool == Decimal('8000')
+
+    def test_sequence_resumes_after_recover(self, tmp_path: Path) -> None:
+        '''Verify sequence counter resumes from WAL after recovery.'''
+
+        from nexus.infrastructure.wal import WriteAheadLog
+
+        store = StateStore(tmp_path / 'state')
+        store.append_mutation(_make_state('1000'))
+        store.append_mutation(_make_state('2000'))
+
+        store2 = StateStore(tmp_path / 'state')
+        store2.recover()
+        store2.append_mutation(_make_state('3000'))
+
+        wal = WriteAheadLog(tmp_path / 'state' / 'wal' / 'wal.bin')
+        entries = wal.read_all()
+        assert entries[-1].sequence == 2
+
+
+class TestCheckpointRecoverCycle:
+    '''Verify full checkpoint-mutate-recover cycles.'''
+
+    def test_full_cycle(self, tmp_path: Path) -> None:
+        '''Verify checkpoint, mutate, recover, checkpoint cycle.'''
+
+        store = StateStore(tmp_path / 'state')
+
+        store.checkpoint(_make_state('10000'))
+        store.append_mutation(_make_state('12000'))
+        store.append_mutation(_make_state('14000'))
+
+        store2 = StateStore(tmp_path / 'state')
+        recovered = store2.recover()
+        assert recovered is not None
+        assert recovered.capital.capital_pool == Decimal('14000')
+
+        store2.checkpoint(recovered)
+
+        store3 = StateStore(tmp_path / 'state')
+        final = store3.recover()
+        assert final is not None
+        assert final.capital.capital_pool == Decimal('14000')

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.state_store import StateStore
+from nexus.infrastructure.wal import WriteAheadLog
 
 
 def _make_state(pool: str = '10000') -> InstanceState:
@@ -98,7 +99,6 @@ class TestAppendMutation:
     def test_sequence_increments(self, tmp_path: Path) -> None:
         '''Verify WAL entry sequence numbers increment.'''
 
-        from nexus.infrastructure.wal import WriteAheadLog
 
         store = StateStore(tmp_path / 'state')
         store.append_mutation(_make_state('1000'))
@@ -157,7 +157,6 @@ class TestRecover:
     def test_sequence_resumes_after_recover(self, tmp_path: Path) -> None:
         '''Verify sequence counter resumes from WAL after recovery.'''
 
-        from nexus.infrastructure.wal import WriteAheadLog
 
         store = StateStore(tmp_path / 'state')
         store.append_mutation(_make_state('1000'))

--- a/tests/test_wal.py
+++ b/tests/test_wal.py
@@ -1,0 +1,299 @@
+'''Verify WriteAheadLog append, read, truncate, file format, and integrity.'''
+
+from __future__ import annotations
+
+import struct
+import zlib
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from nexus.infrastructure.wal import WriteAheadLog, _MAGIC, _RECORD_HEADER_FMT
+from nexus.infrastructure.wal_entry import WALEntry, WALEntryType
+
+
+def _make_entry(seq: int = 0) -> WALEntry:
+    '''Build a WALEntry with the given sequence number.'''
+
+    return WALEntry(
+        sequence=seq,
+        timestamp=datetime(2025, 6, 15, 12, 0, 0),
+        entry_type=WALEntryType.STATE_MUTATION,
+        payload=b'\x01\x02\x03',
+    )
+
+
+class TestAppendAndRead:
+    '''Verify append persists entries and read_all recovers them.'''
+
+    def test_single_entry(self, tmp_path: Path) -> None:
+        '''Verify single append and read_all round-trip.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        entry = _make_entry(0)
+        wal.append(entry)
+
+        entries = wal.read_all()
+        assert len(entries) == 1
+        assert entries[0].sequence == 0
+        assert entries[0].timestamp == entry.timestamp
+        assert entries[0].entry_type == WALEntryType.STATE_MUTATION
+        assert entries[0].payload == b'\x01\x02\x03'
+
+    def test_multiple_entries(self, tmp_path: Path) -> None:
+        '''Verify multiple appends are read back in order.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        for i in range(5):
+            wal.append(_make_entry(i))
+
+        entries = wal.read_all()
+        assert len(entries) == 5
+        assert [e.sequence for e in entries] == [0, 1, 2, 3, 4]
+
+    def test_all_entry_types(self, tmp_path: Path) -> None:
+        '''Verify all WALEntryType values survive round-trip.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        for i, et in enumerate(WALEntryType):
+            wal.append(
+                WALEntry(
+                    sequence=i,
+                    timestamp=datetime.min,
+                    entry_type=et,
+                    payload=b'',
+                )
+            )
+
+        entries = wal.read_all()
+        assert [e.entry_type for e in entries] == list(WALEntryType)
+
+    def test_empty_payload(self, tmp_path: Path) -> None:
+        '''Verify zero-length payload survives round-trip.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        wal.append(
+            WALEntry(
+                sequence=0,
+                timestamp=datetime.min,
+                entry_type=WALEntryType.SNAPSHOT,
+                payload=b'',
+            )
+        )
+
+        entries = wal.read_all()
+        assert entries[0].payload == b''
+
+    def test_large_payload(self, tmp_path: Path) -> None:
+        '''Verify large payload survives round-trip.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        big_payload = b'\xff' * 100_000
+        wal.append(
+            WALEntry(
+                sequence=0,
+                timestamp=datetime.min,
+                entry_type=WALEntryType.SNAPSHOT,
+                payload=big_payload,
+            )
+        )
+
+        entries = wal.read_all()
+        assert entries[0].payload == big_payload
+
+
+class TestReadEmptyOrMissing:
+    '''Verify read_all behavior for missing or empty files.'''
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        '''Verify read_all returns empty list when file does not exist.'''
+
+        wal = WriteAheadLog(tmp_path / 'nonexistent.wal')
+        assert wal.read_all() == []
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        '''Verify read_all returns empty list for zero-byte file.'''
+
+        path = tmp_path / 'empty.wal'
+        path.write_bytes(b'')
+        wal = WriteAheadLog(path)
+        assert wal.read_all() == []
+
+
+class TestTruncate:
+    '''Verify WAL truncation behavior.'''
+
+    def test_truncate_clears_entries(self, tmp_path: Path) -> None:
+        '''Verify truncate removes all entries.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        wal.append(_make_entry(0))
+        wal.append(_make_entry(1))
+        assert len(wal.read_all()) == 2
+
+        wal.truncate()
+        assert wal.read_all() == []
+
+    def test_truncate_missing_file_noop(self, tmp_path: Path) -> None:
+        '''Verify truncate on missing file does not raise.'''
+
+        wal = WriteAheadLog(tmp_path / 'nonexistent.wal')
+        wal.truncate()
+
+    def test_append_after_truncate(self, tmp_path: Path) -> None:
+        '''Verify append works after truncation.'''
+
+        wal = WriteAheadLog(tmp_path / 'test.wal')
+        wal.append(_make_entry(0))
+        wal.truncate()
+        wal.append(_make_entry(10))
+
+        entries = wal.read_all()
+        assert len(entries) == 1
+        assert entries[0].sequence == 10
+
+
+class TestMagicHeader:
+    '''Verify magic header behavior.'''
+
+    def test_file_starts_with_magic(self, tmp_path: Path) -> None:
+        '''Verify WAL file begins with the magic header bytes.'''
+
+        path = tmp_path / 'test.wal'
+        wal = WriteAheadLog(path)
+        wal.append(_make_entry(0))
+
+        raw = path.read_bytes()
+        assert raw[:8] == _MAGIC
+
+    def test_magic_written_once(self, tmp_path: Path) -> None:
+        '''Verify magic header is not duplicated on subsequent appends.'''
+
+        path = tmp_path / 'test.wal'
+        wal = WriteAheadLog(path)
+        wal.append(_make_entry(0))
+        wal.append(_make_entry(1))
+
+        raw = path.read_bytes()
+        assert raw[:8] == _MAGIC
+        assert raw.count(_MAGIC) == 1
+
+    def test_invalid_magic_rejected(self, tmp_path: Path) -> None:
+        '''Verify read_all rejects file with wrong magic header.'''
+
+        path = tmp_path / 'bad.wal'
+        path.write_bytes(b'BADMAGIC' + b'\x00' * 20)
+        wal = WriteAheadLog(path)
+
+        with pytest.raises(ValueError, match='Invalid WAL magic header'):
+            wal.read_all()
+
+    def test_magic_rewritten_after_truncate(self, tmp_path: Path) -> None:
+        '''Verify magic header is rewritten after truncate + append.'''
+
+        path = tmp_path / 'test.wal'
+        wal = WriteAheadLog(path)
+        wal.append(_make_entry(0))
+        wal.truncate()
+        wal.append(_make_entry(1))
+
+        raw = path.read_bytes()
+        assert raw[:8] == _MAGIC
+
+
+class TestFileFormat:
+    '''Verify binary record format integrity.'''
+
+    def test_record_header_after_magic(self, tmp_path: Path) -> None:
+        '''Verify first record starts immediately after magic header.'''
+
+        path = tmp_path / 'test.wal'
+        wal = WriteAheadLog(path)
+        wal.append(_make_entry(0))
+
+        raw = path.read_bytes()
+        record_data = raw[8:]
+        length, crc = struct.unpack(_RECORD_HEADER_FMT, record_data[:8])
+        payload = record_data[8:]
+        assert length == len(payload)
+        assert crc == zlib.crc32(payload) & 0xFFFFFFFF
+
+    def test_multiple_records_contiguous(self, tmp_path: Path) -> None:
+        '''Verify multiple records are packed contiguously after magic.'''
+
+        path = tmp_path / 'test.wal'
+        wal = WriteAheadLog(path)
+        wal.append(_make_entry(0))
+        wal.append(_make_entry(1))
+
+        raw = path.read_bytes()
+        offset = 8
+        len1, _ = struct.unpack(_RECORD_HEADER_FMT, raw[offset : offset + 8])
+        offset += 8 + len1
+        len2, _ = struct.unpack(_RECORD_HEADER_FMT, raw[offset : offset + 8])
+        assert offset + 8 + len2 == len(raw)
+
+
+class TestCorruptionDetection:
+    '''Verify read_all detects corruption and truncation.'''
+
+    def test_truncated_record_header(self, tmp_path: Path) -> None:
+        '''Verify truncated record header raises ValueError.'''
+
+        path = tmp_path / 'corrupt.wal'
+        path.write_bytes(_MAGIC + b'\x00\x00')
+        wal = WriteAheadLog(path)
+
+        with pytest.raises(ValueError, match='Truncated WAL record header'):
+            wal.read_all()
+
+    def test_truncated_record_payload(self, tmp_path: Path) -> None:
+        '''Verify truncated record payload raises ValueError.'''
+
+        path = tmp_path / 'corrupt.wal'
+        header = struct.pack(_RECORD_HEADER_FMT, 100, 0)
+        path.write_bytes(_MAGIC + header + b'\x00' * 10)
+        wal = WriteAheadLog(path)
+
+        with pytest.raises(ValueError, match='Truncated WAL record payload'):
+            wal.read_all()
+
+    def test_crc_mismatch_detected(self, tmp_path: Path) -> None:
+        '''Verify flipped bit in payload triggers CRC mismatch.'''
+
+        path = tmp_path / 'test.wal'
+        wal = WriteAheadLog(path)
+        wal.append(_make_entry(0))
+
+        raw = bytearray(path.read_bytes())
+        raw[-1] ^= 0xFF
+        path.write_bytes(bytes(raw))
+
+        with pytest.raises(ValueError, match='CRC32 mismatch'):
+            wal.read_all()
+
+    def test_crc_mismatch_in_header_field(self, tmp_path: Path) -> None:
+        '''Verify corrupted CRC field itself triggers mismatch.'''
+
+        path = tmp_path / 'test.wal'
+        wal = WriteAheadLog(path)
+        wal.append(_make_entry(0))
+
+        raw = bytearray(path.read_bytes())
+        raw[8 + 4] ^= 0xFF
+        path.write_bytes(bytes(raw))
+
+        with pytest.raises(ValueError, match='CRC32 mismatch'):
+            wal.read_all()
+
+
+class TestPathProperty:
+    '''Verify path accessor.'''
+
+    def test_path_returns_configured_path(self, tmp_path: Path) -> None:
+        '''Verify path property returns the path passed to constructor.'''
+
+        p = tmp_path / 'my.wal'
+        wal = WriteAheadLog(p)
+        assert wal.path == p

--- a/tests/test_wal.py
+++ b/tests/test_wal.py
@@ -238,26 +238,40 @@ class TestFileFormat:
 class TestCorruptionDetection:
     '''Verify read_all detects corruption and truncation.'''
 
-    def test_truncated_record_header(self, tmp_path: Path) -> None:
-        '''Verify truncated record header raises ValueError.'''
+    def test_truncated_record_header_discarded(self, tmp_path: Path) -> None:
+        '''Verify truncated tail record header is silently discarded.'''
 
         path = tmp_path / 'corrupt.wal'
         path.write_bytes(_MAGIC + b'\x00\x00')
         wal = WriteAheadLog(path)
 
-        with pytest.raises(ValueError, match='Truncated WAL record header'):
-            wal.read_all()
+        assert wal.read_all() == []
 
-    def test_truncated_record_payload(self, tmp_path: Path) -> None:
-        '''Verify truncated record payload raises ValueError.'''
+    def test_truncated_record_payload_discarded(self, tmp_path: Path) -> None:
+        '''Verify truncated tail record payload is silently discarded.'''
 
         path = tmp_path / 'corrupt.wal'
         header = struct.pack(_RECORD_HEADER_FMT, 100, 0)
         path.write_bytes(_MAGIC + header + b'\x00' * 10)
         wal = WriteAheadLog(path)
 
-        with pytest.raises(ValueError, match='Truncated WAL record payload'):
-            wal.read_all()
+        assert wal.read_all() == []
+
+    def test_truncated_tail_preserves_valid_entries(self, tmp_path: Path) -> None:
+        '''Verify valid entries before truncated tail are returned.'''
+
+        path = tmp_path / 'test.wal'
+        wal = WriteAheadLog(path)
+        wal.append(_make_entry(0))
+        wal.append(_make_entry(1))
+
+        raw = path.read_bytes()
+        path.write_bytes(raw + b'\x00\x00')
+
+        entries = wal.read_all()
+        assert len(entries) == 2
+        assert entries[0].sequence == 0
+        assert entries[1].sequence == 1
 
     def test_crc_mismatch_detected(self, tmp_path: Path) -> None:
         '''Verify flipped bit in payload triggers CRC mismatch.'''

--- a/tests/test_wal.py
+++ b/tests/test_wal.py
@@ -238,6 +238,27 @@ class TestFileFormat:
 class TestCorruptionDetection:
     '''Verify read_all detects corruption and truncation.'''
 
+    def test_partial_magic_returns_empty(self, tmp_path: Path) -> None:
+        '''Verify partial magic header from crash is treated as empty WAL.'''
+
+        path = tmp_path / 'partial.wal'
+        path.write_bytes(b'NXWAL')
+        wal = WriteAheadLog(path)
+
+        assert wal.read_all() == []
+
+    def test_append_repairs_partial_magic(self, tmp_path: Path) -> None:
+        '''Verify append rewrites a partial magic header file.'''
+
+        path = tmp_path / 'partial.wal'
+        path.write_bytes(b'NXW')
+        wal = WriteAheadLog(path)
+        wal.append(_make_entry(0))
+
+        entries = wal.read_all()
+        assert len(entries) == 1
+        assert entries[0].sequence == 0
+
     def test_truncated_record_header_discarded(self, tmp_path: Path) -> None:
         '''Verify truncated tail record header is silently discarded.'''
 

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -241,6 +241,20 @@ class TestCodecVersioning:
             deserialize_state(bad_data)
 
 
+class TestMalformedPayload:
+    '''Verify deserialize_state rejects non-dict payloads.'''
+
+    def test_non_dict_payload_raises(self) -> None:
+        '''Verify non-dict msgpack payload raises ValueError.'''
+
+        import msgpack
+
+        bad_data = bytes(msgpack.packb([1, 2, 3]))
+
+        with pytest.raises(ValueError, match='Expected dict from WAL payload'):
+            deserialize_state(bad_data)
+
+
 class TestSerializationOutput:
     '''Verify serialization produces expected binary format.'''
 

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -1,0 +1,270 @@
+'''Verify WAL codec round-trip serialization for InstanceState.'''
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OperationalMode, OrderSide
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.operational_mode import ModeState, StrategyModeState
+from nexus.core.domain.position import Position
+from nexus.core.domain.risk_state import RiskState, StrategyRiskState
+from nexus.infrastructure.wal_codec import deserialize_state, serialize_state
+
+
+def _make_minimal_state() -> InstanceState:
+    '''Build a minimal InstanceState with only capital.'''
+
+    return InstanceState(capital=CapitalState(capital_pool=Decimal('10000')))
+
+
+def _make_full_state() -> InstanceState:
+    '''Build a fully populated InstanceState with all fields non-default.'''
+
+    return InstanceState(
+        capital=CapitalState(
+            capital_pool=Decimal('100000'),
+            position_notional=Decimal('25000.50'),
+            working_order_notional=Decimal('5000'),
+            in_flight_order_notional=Decimal('1000.75'),
+            fee_reserve=Decimal('200'),
+            reservation_notional=Decimal('3000'),
+        ),
+        risk=RiskState(
+            high_water_mark=Decimal('110000'),
+            per_strategy={
+                'momentum': StrategyRiskState(
+                    strategy_id='momentum',
+                    high_water_mark=Decimal('60000'),
+                    rolling_loss_24h=Decimal('150.25'),
+                    rolling_loss_7d=Decimal('800'),
+                    rolling_loss_30d=Decimal('2500'),
+                    strategy_realized_pnl=Decimal('-500.75'),
+                ),
+            },
+        ),
+        positions={
+            't1': Position(
+                trade_id='t1',
+                strategy_id='momentum',
+                symbol='BTCUSDT',
+                side=OrderSide.BUY,
+                size=Decimal('0.5'),
+                entry_price=Decimal('50000'),
+                unrealized_pnl=Decimal('1250.50'),
+                pending_exit=Decimal('0.25'),
+            ),
+            't2': Position(
+                trade_id='t2',
+                strategy_id='momentum',
+                symbol='ETHUSDT',
+                side=OrderSide.SELL,
+                size=Decimal('10'),
+                entry_price=Decimal('3000'),
+                unrealized_pnl=Decimal('-200'),
+            ),
+        },
+        mode=ModeState(
+            mode=OperationalMode.REDUCE_ONLY,
+            trigger='risk_breach',
+            transitioned_at=datetime(2025, 6, 15, 14, 30, 0),
+        ),
+        strategy_modes={
+            'momentum': StrategyModeState(
+                strategy_id='momentum',
+                state=ModeState(
+                    mode=OperationalMode.HALTED,
+                    trigger='manual_halt',
+                    transitioned_at=datetime(2025, 6, 15, 15, 0, 0),
+                ),
+            ),
+        },
+    )
+
+
+class TestRoundTrip:
+    '''Verify serialize → deserialize produces identical state.'''
+
+    def test_minimal_state(self) -> None:
+        '''Verify round-trip for minimal (defaults-only) InstanceState.'''
+
+        original = _make_minimal_state()
+        restored = deserialize_state(serialize_state(original))
+
+        assert restored.capital.capital_pool == original.capital.capital_pool
+        assert restored.capital.position_notional == Decimal(0)
+        assert restored.risk.high_water_mark == Decimal(0)
+        assert restored.positions == {}
+        assert restored.mode.mode == OperationalMode.ACTIVE
+        assert restored.strategy_modes == {}
+
+    def test_full_state_capital(self) -> None:
+        '''Verify capital fields survive round-trip.'''
+
+        original = _make_full_state()
+        restored = deserialize_state(serialize_state(original))
+
+        assert restored.capital.capital_pool == original.capital.capital_pool
+        assert restored.capital.position_notional == original.capital.position_notional
+        assert (
+            restored.capital.working_order_notional
+            == original.capital.working_order_notional
+        )
+        assert (
+            restored.capital.in_flight_order_notional
+            == original.capital.in_flight_order_notional
+        )
+        assert restored.capital.fee_reserve == original.capital.fee_reserve
+        assert (
+            restored.capital.reservation_notional
+            == original.capital.reservation_notional
+        )
+
+    def test_full_state_risk(self) -> None:
+        '''Verify risk fields survive round-trip.'''
+
+        original = _make_full_state()
+        restored = deserialize_state(serialize_state(original))
+
+        assert restored.risk.high_water_mark == original.risk.high_water_mark
+        assert 'momentum' in restored.risk.per_strategy
+
+        orig_srs = original.risk.per_strategy['momentum']
+        rest_srs = restored.risk.per_strategy['momentum']
+        assert rest_srs.strategy_id == orig_srs.strategy_id
+        assert rest_srs.high_water_mark == orig_srs.high_water_mark
+        assert rest_srs.rolling_loss_24h == orig_srs.rolling_loss_24h
+        assert rest_srs.rolling_loss_7d == orig_srs.rolling_loss_7d
+        assert rest_srs.rolling_loss_30d == orig_srs.rolling_loss_30d
+        assert rest_srs.strategy_realized_pnl == orig_srs.strategy_realized_pnl
+
+    def test_full_state_positions(self) -> None:
+        '''Verify position fields survive round-trip.'''
+
+        original = _make_full_state()
+        restored = deserialize_state(serialize_state(original))
+
+        assert set(restored.positions.keys()) == {'t1', 't2'}
+
+        for tid in ('t1', 't2'):
+            orig_pos = original.positions[tid]
+            rest_pos = restored.positions[tid]
+            assert rest_pos.trade_id == orig_pos.trade_id
+            assert rest_pos.strategy_id == orig_pos.strategy_id
+            assert rest_pos.symbol == orig_pos.symbol
+            assert rest_pos.side == orig_pos.side
+            assert rest_pos.size == orig_pos.size
+            assert rest_pos.entry_price == orig_pos.entry_price
+            assert rest_pos.unrealized_pnl == orig_pos.unrealized_pnl
+            assert rest_pos.pending_exit == orig_pos.pending_exit
+
+    def test_full_state_mode(self) -> None:
+        '''Verify mode fields survive round-trip.'''
+
+        original = _make_full_state()
+        restored = deserialize_state(serialize_state(original))
+
+        assert restored.mode.mode == original.mode.mode
+        assert restored.mode.trigger == original.mode.trigger
+        assert restored.mode.transitioned_at == original.mode.transitioned_at
+
+    def test_full_state_strategy_modes(self) -> None:
+        '''Verify strategy mode fields survive round-trip.'''
+
+        original = _make_full_state()
+        restored = deserialize_state(serialize_state(original))
+
+        assert 'momentum' in restored.strategy_modes
+        orig_sm = original.strategy_modes['momentum']
+        rest_sm = restored.strategy_modes['momentum']
+        assert rest_sm.strategy_id == orig_sm.strategy_id
+        assert rest_sm.state.mode == orig_sm.state.mode
+        assert rest_sm.state.trigger == orig_sm.state.trigger
+        assert rest_sm.state.transitioned_at == orig_sm.state.transitioned_at
+
+
+class TestDecimalPrecision:
+    '''Verify Decimal precision is not lost through serialization.'''
+
+    def test_high_precision_decimal(self) -> None:
+        '''Verify Decimal with many significant digits survives round-trip.'''
+
+        state = InstanceState(
+            capital=CapitalState(capital_pool=Decimal('99999.123456789012345678')),
+        )
+        restored = deserialize_state(serialize_state(state))
+        assert restored.capital.capital_pool == Decimal('99999.123456789012345678')
+
+    def test_negative_pnl_preserved(self) -> None:
+        '''Verify negative realized PnL survives round-trip.'''
+
+        state = InstanceState(
+            capital=CapitalState(capital_pool=Decimal('10000')),
+            risk=RiskState(
+                per_strategy={
+                    'arb': StrategyRiskState(
+                        strategy_id='arb',
+                        strategy_realized_pnl=Decimal('-12345.6789'),
+                    ),
+                },
+            ),
+        )
+        restored = deserialize_state(serialize_state(state))
+        assert restored.risk.per_strategy['arb'].strategy_realized_pnl == Decimal(
+            '-12345.6789'
+        )
+
+
+class TestCodecVersioning:
+    '''Verify codec version enforcement.'''
+
+    def test_unsupported_version_rejected(self) -> None:
+        '''Verify deserialize rejects unknown codec version.'''
+
+        import msgpack
+
+        bad_data = msgpack.packb({'_v': 999})
+        with pytest.raises(ValueError, match='Unsupported WAL codec version'):
+            deserialize_state(bad_data)
+
+    def test_missing_version_rejected(self) -> None:
+        '''Verify deserialize rejects payload with no version field.'''
+
+        import msgpack
+
+        bad_data = msgpack.packb({'capital': {}})
+        with pytest.raises(ValueError, match='Unsupported WAL codec version'):
+            deserialize_state(bad_data)
+
+
+class TestSerializationOutput:
+    '''Verify serialization produces expected binary format.'''
+
+    def test_output_is_bytes(self) -> None:
+        '''Verify serialize_state returns bytes.'''
+
+        state = _make_minimal_state()
+        result = serialize_state(state)
+        assert isinstance(result, bytes)
+
+    def test_output_is_non_empty(self) -> None:
+        '''Verify serialized output is non-empty.'''
+
+        state = _make_minimal_state()
+        result = serialize_state(state)
+        assert len(result) > 0
+
+    def test_output_is_valid_msgpack(self) -> None:
+        '''Verify serialized bytes are valid msgpack.'''
+
+        import msgpack
+
+        state = _make_minimal_state()
+        result = serialize_state(state)
+        unpacked = msgpack.unpackb(result, raw=False)
+        assert isinstance(unpacked, dict)
+        assert unpacked['_v'] == 1

--- a/tests/test_wal_entry.py
+++ b/tests/test_wal_entry.py
@@ -1,0 +1,104 @@
+'''Verify WALEntry and WALEntryType construction and validation.'''
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from nexus.infrastructure.wal_entry import WALEntry, WALEntryType
+
+
+def test_entry_type_members() -> None:
+    '''Verify WALEntryType has exactly three members.'''
+
+    assert set(WALEntryType) == {
+        WALEntryType.SNAPSHOT,
+        WALEntryType.STATE_MUTATION,
+        WALEntryType.STRATEGY_EVENT,
+    }
+
+
+def test_entry_type_values() -> None:
+    '''Verify WALEntryType string values.'''
+
+    assert WALEntryType.SNAPSHOT.value == 'snapshot'
+    assert WALEntryType.STATE_MUTATION.value == 'state_mutation'
+    assert WALEntryType.STRATEGY_EVENT.value == 'strategy_event'
+
+
+def test_valid_entry() -> None:
+    '''Verify WALEntry accepts valid construction arguments.'''
+
+    ts = datetime(2025, 1, 1, 12, 0, 0)
+    entry = WALEntry(
+        sequence=0,
+        timestamp=ts,
+        entry_type=WALEntryType.SNAPSHOT,
+        payload=b'\x00\x01',
+    )
+    assert entry.sequence == 0
+    assert entry.timestamp == ts
+    assert entry.entry_type == WALEntryType.SNAPSHOT
+    assert entry.payload == b'\x00\x01'
+
+
+def test_entry_is_frozen() -> None:
+    '''Verify WALEntry is immutable.'''
+
+    entry = WALEntry(
+        sequence=1,
+        timestamp=datetime.min,
+        entry_type=WALEntryType.STATE_MUTATION,
+        payload=b'',
+    )
+    with pytest.raises(AttributeError):
+        entry.sequence = 2  # type: ignore[misc]
+
+
+def test_negative_sequence_rejected() -> None:
+    '''Verify negative sequence number raises ValueError.'''
+
+    with pytest.raises(ValueError, match='non-negative'):
+        WALEntry(
+            sequence=-1,
+            timestamp=datetime.min,
+            entry_type=WALEntryType.SNAPSHOT,
+            payload=b'',
+        )
+
+
+def test_invalid_timestamp_rejected() -> None:
+    '''Verify non-datetime timestamp raises ValueError.'''
+
+    with pytest.raises(ValueError, match='datetime'):
+        WALEntry(
+            sequence=0,
+            timestamp='not-a-datetime',  # type: ignore[arg-type]
+            entry_type=WALEntryType.SNAPSHOT,
+            payload=b'',
+        )
+
+
+def test_invalid_entry_type_rejected() -> None:
+    '''Verify non-WALEntryType raises ValueError.'''
+
+    with pytest.raises(ValueError, match='WALEntryType'):
+        WALEntry(
+            sequence=0,
+            timestamp=datetime.min,
+            entry_type='snapshot',  # type: ignore[arg-type]
+            payload=b'',
+        )
+
+
+def test_invalid_payload_rejected() -> None:
+    '''Verify non-bytes payload raises ValueError.'''
+
+    with pytest.raises(ValueError, match='bytes'):
+        WALEntry(
+            sequence=0,
+            timestamp=datetime.min,
+            entry_type=WALEntryType.SNAPSHOT,
+            payload='not-bytes',  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements RFC-3001 phase 1.2 (WAL-based persistence) end-to-end. Adds `WALEntryType` and frozen `WALEntry` with invariant checks, msgpack-based state codec with explicit per-type encode/decode and version embedding, `WriteAheadLog` with magic header + per-record CRC32 + length-prefixed records + fsync durability, snapshot manager with atomic save/load and WAL truncation, and `StateStore` facade managing `snapshots/` and `wal/` subdirectories with recover via snapshot + WAL replay. Adds technical debt note for version-dispatched deserialization. Includes 64 new tests across WAL entry/codec/WAL/snapshot/state store and bumps project to v0.4.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `pytest -q` locally without errors (133 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable

Part of https://github.com/Vaquum/Nexus/issues/16