### PR TITLE
feat: Phase 1.3 — State recovery with rolling loss re-derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@
 - Add [`nexus/core/domain/__init__.py`](nexus/core/domain/__init__.py) re-exports
 - Add 34 tests covering enums, position, capital state, risk state, operational mode, and instance state composition
 
+## v0.5.0 on 19th of March, 2026
+
+- Add [`strategy_event.py`](nexus/infrastructure/strategy_event.py) with frozen `StrategyEvent` dataclass (strategy_id, event_type, realized_pnl, timestamp)
+- Add `serialize_event` / `deserialize_event` to [`wal_codec.py`](nexus/infrastructure/wal_codec.py) with versioned msgpack format, Decimal-as-string precision
+- Add `StateStore.append_event()` for writing `STRATEGY_EVENT` WAL entries alongside `STATE_MUTATION` entries
+- Add [`loss_derivation.py`](nexus/infrastructure/loss_derivation.py) with `derive_rolling_losses()` pure function — scans strategy events by 24h/7d/30d windows, sums negative realized P&L per strategy
+- Enhance `StateStore.recover()` with two-pass recovery: (1) snapshot + STATE_MUTATION replay, (2) STRATEGY_EVENT scan to re-derive and overwrite rolling loss counters
+- Add 44 tests covering strategy event construction/validation, event codec round-trip, loss derivation window boundaries, and enhanced recovery with checkpoint boundary handling
+
 ## v0.4.0 on 18th of March, 2026
 
 - Add `msgpack>=1.0` as runtime dependency

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -14,3 +14,16 @@ Known technical debt in shipped code. Each item includes origin, severity, and m
 
 **When to fix**: Before any change to serialized domain dataclass fields.
 **Migration**: Add version-dispatched deserialization (`_decode_v1()`, `_decode_v2()`, etc.) that routes on the embedded `_v` field so older snapshots remain readable across codec upgrades.
+
+---
+
+## TD-002: Checkpoint truncates strategy events needed for rolling loss windows
+
+**Origin**: 1.3.4 (two-pass recovery with loss re-derivation)
+**Severity**: Medium (losses undercounted after checkpoint)
+**Module**: `nexus/infrastructure/state_store.py`
+
+`checkpoint()` truncates the entire WAL including STRATEGY_EVENT entries. On recovery, `derive_rolling_losses()` only sees post-checkpoint events. Losses that occurred before the checkpoint but within the 24h/7d/30d windows are lost, causing rolling loss counters to undercount.
+
+**When to fix**: Before periodic checkpoint scheduling (Phase 9).
+**Migration**: Either (a) retain STRATEGY_EVENT entries for the longest window (30d) across checkpoints by truncating by age instead of full truncation, or (b) bake accurate rolling loss values into the snapshot at checkpoint time so they serve as baseline, with post-checkpoint events adjusting rather than overwriting.

--- a/nexus/infrastructure/loss_derivation.py
+++ b/nexus/infrastructure/loss_derivation.py
@@ -1,0 +1,91 @@
+'''Re-derive rolling loss counters from strategy events.
+
+Pure function that scans StrategyEvent records and computes
+per-strategy rolling losses over 24h, 7d, and 30d windows
+relative to a recovery timestamp.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from nexus.infrastructure.strategy_event import StrategyEvent
+
+__all__ = ['RollingLosses', 'derive_rolling_losses']
+
+_ZERO = Decimal(0)
+_WINDOW_24H = timedelta(hours=24)
+_WINDOW_7D = timedelta(days=7)
+_WINDOW_30D = timedelta(days=30)
+
+
+@dataclass(frozen=True)
+class RollingLosses:
+    '''Computed rolling loss values for a single strategy.
+
+    Args:
+        rolling_loss_24h: Sum of negative realized P&L in the last 24 hours.
+        rolling_loss_7d: Sum of negative realized P&L in the last 7 days.
+        rolling_loss_30d: Sum of negative realized P&L in the last 30 days.
+    '''
+
+    rolling_loss_24h: Decimal = _ZERO
+    rolling_loss_7d: Decimal = _ZERO
+    rolling_loss_30d: Decimal = _ZERO
+
+
+def derive_rolling_losses(
+    events: list[StrategyEvent],
+    recovery_time: datetime,
+) -> dict[str, RollingLosses]:
+    '''Compute per-strategy rolling losses from strategy events.
+
+    Scans events whose realized_pnl is negative and whose timestamp
+    falls within each rolling window relative to recovery_time.
+
+    Args:
+        events: Strategy events to scan.
+        recovery_time: Reference time for window boundaries.
+
+    Returns:
+        Mapping of strategy_id to computed rolling losses.
+    '''
+
+    cutoff_24h = recovery_time - _WINDOW_24H
+    cutoff_7d = recovery_time - _WINDOW_7D
+    cutoff_30d = recovery_time - _WINDOW_30D
+
+    accum: dict[str, list[Decimal]] = {}
+
+    for event in events:
+        if event.realized_pnl >= _ZERO:
+            continue
+
+        if event.timestamp < cutoff_30d:
+            continue
+
+        loss = abs(event.realized_pnl)
+        sid = event.strategy_id
+
+        if sid not in accum:
+            accum[sid] = [_ZERO, _ZERO, _ZERO]
+
+        buckets = accum[sid]
+        buckets[2] += loss
+
+        if event.timestamp >= cutoff_7d:
+            buckets[1] += loss
+
+        if event.timestamp >= cutoff_24h:
+            buckets[0] += loss
+
+    return {
+        sid: RollingLosses(
+            rolling_loss_24h=b[0],
+            rolling_loss_7d=b[1],
+            rolling_loss_30d=b[2],
+        )
+        for sid, b in accum.items()
+    }

--- a/nexus/infrastructure/loss_derivation.py
+++ b/nexus/infrastructure/loss_derivation.py
@@ -53,6 +53,13 @@ def derive_rolling_losses(
         Mapping of strategy_id to computed rolling losses.
     '''
 
+    if (
+        recovery_time.tzinfo is None
+        or recovery_time.tzinfo.utcoffset(recovery_time) is None
+    ):
+        msg = 'recovery_time must be timezone-aware'
+        raise ValueError(msg)
+
     cutoff_24h = recovery_time - _WINDOW_24H
     cutoff_7d = recovery_time - _WINDOW_7D
     cutoff_30d = recovery_time - _WINDOW_30D

--- a/nexus/infrastructure/state_store.py
+++ b/nexus/infrastructure/state_store.py
@@ -21,7 +21,9 @@ from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.snapshot import load_snapshot, save_snapshot
 from nexus.infrastructure.wal import WriteAheadLog
 from nexus.infrastructure.strategy_event import StrategyEvent
+from nexus.infrastructure.loss_derivation import derive_rolling_losses
 from nexus.infrastructure.wal_codec import (
+    deserialize_event,
     deserialize_state,
     serialize_event,
     serialize_state,
@@ -106,22 +108,40 @@ class StateStore:
     def recover(self) -> InstanceState | None:
         '''Recover instance state from snapshot and WAL.
 
-        Loads the snapshot, then replays WAL entries to reach the
-        latest persisted state. WAL STATE_MUTATION entries contain
-        full serialized state; the last entry wins.
+        Two-pass recovery:
+        1. Load snapshot, replay STATE_MUTATION entries (last wins).
+        2. Scan STRATEGY_EVENT entries, re-derive rolling loss counters.
 
         Returns:
-            Recovered InstanceState, or None if no persisted state exists.
+            Recovered InstanceState with accurate loss counters,
+            or None if no persisted state exists.
         '''
 
         state = load_snapshot(self._snapshot_path)
         wal_entries = self._wal.read_all()
 
+        events = []
+
         for entry in wal_entries:
             if entry.entry_type == WALEntryType.STATE_MUTATION:
                 state = deserialize_state(entry.payload)
+            elif entry.entry_type == WALEntryType.STRATEGY_EVENT:
+                events.append(deserialize_event(entry.payload))
 
         if wal_entries:
             self._sequence = wal_entries[-1].sequence + 1
+
+        if state is None or not events:
+            return state
+
+        recovery_time = datetime.now(tz=timezone.utc)
+        losses = derive_rolling_losses(events, recovery_time)
+
+        for sid, rolling in losses.items():
+            if sid in state.risk.per_strategy:
+                srs = state.risk.per_strategy[sid]
+                srs.rolling_loss_24h = rolling.rolling_loss_24h
+                srs.rolling_loss_7d = rolling.rolling_loss_7d
+                srs.rolling_loss_30d = rolling.rolling_loss_30d
 
         return state

--- a/nexus/infrastructure/state_store.py
+++ b/nexus/infrastructure/state_store.py
@@ -20,7 +20,12 @@ from pathlib import Path
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.snapshot import load_snapshot, save_snapshot
 from nexus.infrastructure.wal import WriteAheadLog
-from nexus.infrastructure.wal_codec import deserialize_state, serialize_state
+from nexus.infrastructure.strategy_event import StrategyEvent
+from nexus.infrastructure.wal_codec import (
+    deserialize_state,
+    serialize_event,
+    serialize_state,
+)
 from nexus.infrastructure.wal_entry import WALEntry, WALEntryType
 
 __all__ = ['StateStore']
@@ -76,6 +81,23 @@ class StateStore:
             sequence=self._sequence,
             timestamp=datetime.now(tz=timezone.utc),
             entry_type=WALEntryType.STATE_MUTATION,
+            payload=payload,
+        )
+        self._wal.append(entry)
+        self._sequence += 1
+
+    def append_event(self, event: StrategyEvent) -> None:
+        '''Append a strategy event entry to the WAL.
+
+        Args:
+            event: The strategy event to persist.
+        '''
+
+        payload = serialize_event(event)
+        entry = WALEntry(
+            sequence=self._sequence,
+            timestamp=datetime.now(tz=timezone.utc),
+            entry_type=WALEntryType.STRATEGY_EVENT,
             payload=payload,
         )
         self._wal.append(entry)

--- a/nexus/infrastructure/state_store.py
+++ b/nexus/infrastructure/state_store.py
@@ -15,6 +15,7 @@ Directory layout:
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from decimal import Decimal
 from pathlib import Path
 
 from nexus.core.domain.instance_state import InstanceState
@@ -31,6 +32,8 @@ from nexus.infrastructure.wal_codec import (
 from nexus.infrastructure.wal_entry import WALEntry, WALEntryType
 
 __all__ = ['StateStore']
+
+_ZERO = Decimal(0)
 
 _SNAPSHOTS_DIR = 'snapshots'
 _WAL_DIR = 'wal'
@@ -136,12 +139,21 @@ class StateStore:
 
         recovery_time = datetime.now(tz=timezone.utc)
         losses = derive_rolling_losses(events, recovery_time)
+        seen_strategies = {e.strategy_id for e in events}
 
-        for sid, rolling in losses.items():
-            if sid in state.risk.per_strategy:
-                srs = state.risk.per_strategy[sid]
-                srs.rolling_loss_24h = rolling.rolling_loss_24h
-                srs.rolling_loss_7d = rolling.rolling_loss_7d
-                srs.rolling_loss_30d = rolling.rolling_loss_30d
+        for sid in seen_strategies:
+            if sid not in state.risk.per_strategy:
+                continue
+
+            srs = state.risk.per_strategy[sid]
+
+            if sid in losses:
+                srs.rolling_loss_24h = losses[sid].rolling_loss_24h
+                srs.rolling_loss_7d = losses[sid].rolling_loss_7d
+                srs.rolling_loss_30d = losses[sid].rolling_loss_30d
+            else:
+                srs.rolling_loss_24h = _ZERO
+                srs.rolling_loss_7d = _ZERO
+                srs.rolling_loss_30d = _ZERO
 
         return state

--- a/nexus/infrastructure/state_store.py
+++ b/nexus/infrastructure/state_store.py
@@ -20,8 +20,8 @@ from pathlib import Path
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.snapshot import load_snapshot, save_snapshot
 from nexus.infrastructure.wal import WriteAheadLog
-from nexus.infrastructure.strategy_event import StrategyEvent
 from nexus.infrastructure.loss_derivation import derive_rolling_losses
+from nexus.infrastructure.strategy_event import StrategyEvent
 from nexus.infrastructure.wal_codec import (
     deserialize_event,
     deserialize_state,

--- a/nexus/infrastructure/strategy_event.py
+++ b/nexus/infrastructure/strategy_event.py
@@ -53,3 +53,10 @@ class StrategyEvent:
         if not isinstance(self.timestamp, datetime):
             msg = 'StrategyEvent.timestamp must be a datetime'
             raise ValueError(msg)
+
+        if (
+            self.timestamp.tzinfo is None
+            or self.timestamp.tzinfo.utcoffset(self.timestamp) is None
+        ):
+            msg = 'StrategyEvent.timestamp must be timezone-aware'
+            raise ValueError(msg)

--- a/nexus/infrastructure/strategy_event.py
+++ b/nexus/infrastructure/strategy_event.py
@@ -13,8 +13,6 @@ from decimal import Decimal
 
 __all__ = ['StrategyEvent']
 
-_ZERO = Decimal(0)
-
 
 @dataclass(frozen=True)
 class StrategyEvent:

--- a/nexus/infrastructure/strategy_event.py
+++ b/nexus/infrastructure/strategy_event.py
@@ -1,0 +1,55 @@
+'''Strategy event record for WAL-based loss counter recovery.
+
+Lightweight record of a trade outcome delivered to a strategy callback.
+Written to WAL as STRATEGY_EVENT entries, replayed during recovery to
+re-derive rolling loss counters.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+__all__ = ['StrategyEvent']
+
+_ZERO = Decimal(0)
+
+
+@dataclass(frozen=True)
+class StrategyEvent:
+    '''An immutable record of a strategy trade outcome.
+
+    Args:
+        strategy_id: Which strategy produced this event.
+        event_type: Kind of event (e.g. 'trade_outcome').
+        realized_pnl: Realized profit or loss from the event.
+        timestamp: When this event occurred.
+    '''
+
+    strategy_id: str
+    event_type: str
+    realized_pnl: Decimal
+    timestamp: datetime
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if not isinstance(self.strategy_id, str) or not self.strategy_id.strip():
+            msg = 'StrategyEvent.strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.event_type, str) or not self.event_type.strip():
+            msg = 'StrategyEvent.event_type must be a non-empty string'
+            raise ValueError(msg)
+
+        if (
+            not isinstance(self.realized_pnl, Decimal)
+            or not self.realized_pnl.is_finite()
+        ):
+            msg = 'StrategyEvent.realized_pnl must be a finite Decimal'
+            raise ValueError(msg)
+
+        if not isinstance(self.timestamp, datetime):
+            msg = 'StrategyEvent.timestamp must be a datetime'
+            raise ValueError(msg)

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -1,4 +1,4 @@
-'''Serialization codec for InstanceState to/from bytes via msgpack.
+'''Serialization codec for InstanceState and StrategyEvent via msgpack.
 
 Explicit per-type encode/decode for full type safety. Each domain
 dataclass has a paired _encode / _decode function. Codec version
@@ -19,10 +19,17 @@ from nexus.core.domain.instance_state import InstanceState
 from nexus.core.domain.operational_mode import ModeState, StrategyModeState
 from nexus.core.domain.position import Position
 from nexus.core.domain.risk_state import RiskState, StrategyRiskState
+from nexus.infrastructure.strategy_event import StrategyEvent
 
-__all__ = ['deserialize_state', 'serialize_state']
+__all__ = [
+    'deserialize_event',
+    'deserialize_state',
+    'serialize_event',
+    'serialize_state',
+]
 
 _CODEC_VERSION = 1
+_EVENT_CODEC_VERSION = 1
 
 
 def serialize_state(state: InstanceState) -> bytes:
@@ -307,3 +314,54 @@ def _decode_strategy_mode_state(d: dict[str, Any]) -> StrategyModeState:
         strategy_id=d['strategy_id'],
         state=_decode_mode_state(d['state']),
     )
+
+
+def serialize_event(event: StrategyEvent) -> bytes:
+    '''Serialize a StrategyEvent to compact binary format.
+
+    Args:
+        event: The strategy event to serialize.
+
+    Returns:
+        Msgpack-encoded bytes.
+    '''
+
+    d: dict[str, str] = {
+        '_v': str(_EVENT_CODEC_VERSION),
+        'strategy_id': event.strategy_id,
+        'event_type': event.event_type,
+        'realized_pnl': str(event.realized_pnl),
+        'timestamp': event.timestamp.isoformat(),
+    }
+    return bytes(msgpack.packb(d))
+
+
+def deserialize_event(data: bytes) -> StrategyEvent:
+    '''Deserialize a StrategyEvent from compact binary format.
+
+    Args:
+        data: Msgpack-encoded bytes.
+
+    Returns:
+        Reconstructed StrategyEvent.
+    '''
+
+    d = msgpack.unpackb(data, raw=False)
+    if not isinstance(d, dict):
+        msg = f'Expected dict from event payload, got {type(d).__name__}'
+        raise ValueError(msg)
+    version = int(d.get('_v', 0))
+    if version != _EVENT_CODEC_VERSION:
+        msg = f'Unsupported event codec version: {version}'
+        raise ValueError(msg)
+
+    try:
+        return StrategyEvent(
+            strategy_id=d['strategy_id'],
+            event_type=d['event_type'],
+            realized_pnl=Decimal(d['realized_pnl']),
+            timestamp=datetime.fromisoformat(d['timestamp']),
+        )
+    except (KeyError, TypeError, AttributeError) as exc:
+        msg = f'Malformed event codec payload: {exc}'
+        raise ValueError(msg) from exc

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -8,7 +8,7 @@ is embedded for forward compatibility.
 from __future__ import annotations
 
 from datetime import datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 import msgpack
@@ -367,6 +367,6 @@ def deserialize_event(data: bytes) -> StrategyEvent:
             realized_pnl=Decimal(d['realized_pnl']),
             timestamp=datetime.fromisoformat(d['timestamp']),
         )
-    except (KeyError, TypeError, AttributeError) as exc:
+    except (KeyError, TypeError, AttributeError, ValueError, InvalidOperation) as exc:
         msg = f'Malformed event codec payload: {exc}'
         raise ValueError(msg) from exc

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -326,8 +326,8 @@ def serialize_event(event: StrategyEvent) -> bytes:
         Msgpack-encoded bytes.
     '''
 
-    d: dict[str, str] = {
-        '_v': str(_EVENT_CODEC_VERSION),
+    d: dict[str, str | int] = {
+        '_v': _EVENT_CODEC_VERSION,
         'strategy_id': event.strategy_id,
         'event_type': event.event_type,
         'realized_pnl': str(event.realized_pnl),
@@ -350,7 +350,12 @@ def deserialize_event(data: bytes) -> StrategyEvent:
     if not isinstance(d, dict):
         msg = f'Expected dict from event payload, got {type(d).__name__}'
         raise ValueError(msg)
-    version = int(d.get('_v', 0))
+    try:
+        version = int(d.get('_v', 0))
+    except (ValueError, TypeError) as exc:
+        msg = f'Malformed event codec version: {exc}'
+        raise ValueError(msg) from exc
+
     if version != _EVENT_CODEC_VERSION:
         msg = f'Unsupported event codec version: {version}'
         raise ValueError(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.4.0"
+version = "0.5.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_loss_derivation.py
+++ b/tests/test_loss_derivation.py
@@ -1,0 +1,135 @@
+'''Verify rolling loss re-derivation from strategy events.'''
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from nexus.infrastructure.loss_derivation import RollingLosses, derive_rolling_losses
+from nexus.infrastructure.strategy_event import StrategyEvent
+
+_NOW = datetime(2026, 3, 19, 12, 0, 0)
+_ZERO = Decimal(0)
+
+
+def _event(
+    pnl: str,
+    hours_ago: float,
+    strategy_id: str = 'strat_a',
+) -> StrategyEvent:
+    return StrategyEvent(
+        strategy_id=strategy_id,
+        event_type='trade_outcome',
+        realized_pnl=Decimal(pnl),
+        timestamp=_NOW - timedelta(hours=hours_ago),
+    )
+
+
+class TestEmptyInput:
+    def test_no_events_returns_empty(self) -> None:
+        result = derive_rolling_losses([], _NOW)
+        assert result == {}
+
+    def test_only_positive_pnl_returns_empty(self) -> None:
+        events = [_event('100', 1), _event('50', 2)]
+        result = derive_rolling_losses(events, _NOW)
+        assert result == {}
+
+    def test_zero_pnl_returns_empty(self) -> None:
+        events = [_event('0', 1)]
+        result = derive_rolling_losses(events, _NOW)
+        assert result == {}
+
+
+class TestSingleWindow:
+    def test_loss_within_24h(self) -> None:
+        events = [_event('-50', 1)]
+        result = derive_rolling_losses(events, _NOW)
+        assert result['strat_a'].rolling_loss_24h == Decimal('50')
+        assert result['strat_a'].rolling_loss_7d == Decimal('50')
+        assert result['strat_a'].rolling_loss_30d == Decimal('50')
+
+    def test_loss_outside_24h_within_7d(self) -> None:
+        events = [_event('-50', 48)]
+        result = derive_rolling_losses(events, _NOW)
+        assert result['strat_a'].rolling_loss_24h == _ZERO
+        assert result['strat_a'].rolling_loss_7d == Decimal('50')
+        assert result['strat_a'].rolling_loss_30d == Decimal('50')
+
+    def test_loss_outside_7d_within_30d(self) -> None:
+        events = [_event('-50', 24 * 10)]
+        result = derive_rolling_losses(events, _NOW)
+        assert result['strat_a'].rolling_loss_24h == _ZERO
+        assert result['strat_a'].rolling_loss_7d == _ZERO
+        assert result['strat_a'].rolling_loss_30d == Decimal('50')
+
+    def test_loss_outside_30d_excluded(self) -> None:
+        events = [_event('-50', 24 * 31)]
+        result = derive_rolling_losses(events, _NOW)
+        assert result == {}
+
+
+class TestWindowBoundaries:
+    def test_exactly_at_24h_boundary_included(self) -> None:
+        events = [_event('-25', 24)]
+        result = derive_rolling_losses(events, _NOW)
+        assert result['strat_a'].rolling_loss_24h == Decimal('25')
+
+    def test_one_second_past_24h_excluded_from_24h(self) -> None:
+        event = StrategyEvent(
+            strategy_id='strat_a',
+            event_type='trade_outcome',
+            realized_pnl=Decimal('-25'),
+            timestamp=_NOW - timedelta(hours=24, seconds=1),
+        )
+        result = derive_rolling_losses([event], _NOW)
+        assert result['strat_a'].rolling_loss_24h == _ZERO
+        assert result['strat_a'].rolling_loss_7d == Decimal('25')
+
+
+class TestMultipleStrategies:
+    def test_losses_grouped_by_strategy(self) -> None:
+        events = [
+            _event('-10', 1, strategy_id='strat_a'),
+            _event('-20', 1, strategy_id='strat_b'),
+            _event('-30', 1, strategy_id='strat_a'),
+        ]
+        result = derive_rolling_losses(events, _NOW)
+        assert result['strat_a'].rolling_loss_24h == Decimal('40')
+        assert result['strat_b'].rolling_loss_24h == Decimal('20')
+
+
+class TestAccumulation:
+    def test_multiple_losses_summed(self) -> None:
+        events = [
+            _event('-10', 1),
+            _event('-20', 2),
+            _event('-30', 3),
+        ]
+        result = derive_rolling_losses(events, _NOW)
+        assert result['strat_a'].rolling_loss_24h == Decimal('60')
+
+    def test_mixed_pnl_only_losses_counted(self) -> None:
+        events = [
+            _event('-50', 1),
+            _event('100', 2),
+            _event('-25', 3),
+        ]
+        result = derive_rolling_losses(events, _NOW)
+        assert result['strat_a'].rolling_loss_24h == Decimal('75')
+
+
+class TestRollingLossesDataclass:
+    def test_defaults_to_zero(self) -> None:
+        rl = RollingLosses()
+        assert rl.rolling_loss_24h == _ZERO
+        assert rl.rolling_loss_7d == _ZERO
+        assert rl.rolling_loss_30d == _ZERO
+
+    def test_frozen(self) -> None:
+        rl = RollingLosses()
+        try:
+            rl.rolling_loss_24h = Decimal('1')  # type: ignore[misc]
+            raise AssertionError('Should have raised')
+        except AttributeError:
+            pass

--- a/tests/test_loss_derivation.py
+++ b/tests/test_loss_derivation.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 from nexus.infrastructure.loss_derivation import RollingLosses, derive_rolling_losses
 from nexus.infrastructure.strategy_event import StrategyEvent
 
-_NOW = datetime(2026, 3, 19, 12, 0, 0)
+_NOW = datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone.utc)
 _ZERO = Decimal(0)
 
 

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,14 +1,18 @@
-'''Verify StateStore checkpoint, append_mutation, and recover.'''
+'''Verify StateStore checkpoint, append_mutation, append_event, and recover.'''
 
 from __future__ import annotations
 
+from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
 
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.state_store import StateStore
+from nexus.infrastructure.strategy_event import StrategyEvent
 from nexus.infrastructure.wal import WriteAheadLog
+from nexus.infrastructure.wal_codec import deserialize_event
+from nexus.infrastructure.wal_entry import WALEntryType
 
 
 def _make_state(pool: str = '10000') -> InstanceState:
@@ -206,3 +210,60 @@ class TestCheckpointRecoverCycle:
         final = store3.recover()
         assert final is not None
         assert final.capital.capital_pool == Decimal('14000')
+
+
+def _make_event(strategy_id: str = 'strat_a', pnl: str = '-50.25') -> StrategyEvent:
+    return StrategyEvent(
+        strategy_id=strategy_id,
+        event_type='trade_outcome',
+        realized_pnl=Decimal(pnl),
+        timestamp=datetime(2026, 3, 19, 12, 0, 0),
+    )
+
+
+class TestAppendEvent:
+    def test_event_written_to_wal(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        store.append_event(_make_event())
+
+        wal = WriteAheadLog(tmp_path / 'state' / 'wal' / 'wal.bin')
+        entries = wal.read_all()
+        assert len(entries) == 1
+        assert entries[0].entry_type == WALEntryType.STRATEGY_EVENT
+
+    def test_event_payload_round_trips(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        original = _make_event(pnl='-123.456')
+        store.append_event(original)
+
+        wal = WriteAheadLog(tmp_path / 'state' / 'wal' / 'wal.bin')
+        entries = wal.read_all()
+        recovered = deserialize_event(entries[0].payload)
+        assert recovered.strategy_id == original.strategy_id
+        assert recovered.realized_pnl == original.realized_pnl
+
+    def test_event_sequence_increments(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        store.append_event(_make_event())
+        store.append_event(_make_event(pnl='100'))
+
+        wal = WriteAheadLog(tmp_path / 'state' / 'wal' / 'wal.bin')
+        entries = wal.read_all()
+        assert entries[0].sequence == 0
+        assert entries[1].sequence == 1
+
+    def test_mixed_mutations_and_events(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        store.append_mutation(_make_state('1000'))
+        store.append_event(_make_event())
+        store.append_mutation(_make_state('2000'))
+
+        wal = WriteAheadLog(tmp_path / 'state' / 'wal' / 'wal.bin')
+        entries = wal.read_all()
+        assert len(entries) == 3
+        assert entries[0].entry_type == WALEntryType.STATE_MUTATION
+        assert entries[1].entry_type == WALEntryType.STRATEGY_EVENT
+        assert entries[2].entry_type == WALEntryType.STATE_MUTATION
+        assert entries[0].sequence == 0
+        assert entries[1].sequence == 1
+        assert entries[2].sequence == 2

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -375,3 +375,33 @@ class TestRecoverWithEvents:
         assert recovered is not None
         assert recovered.risk.per_strategy['strat_a'].rolling_loss_24h == Decimal('10')
         assert recovered.risk.per_strategy['strat_b'].rolling_loss_24h == Decimal('20')
+
+    def test_checkpoint_truncates_pre_checkpoint_events(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        state = _make_state_with_risk()
+        store.append_mutation(state)
+
+        store.append_event(
+            StrategyEvent(
+                strategy_id='strat_a',
+                event_type='trade_outcome',
+                realized_pnl=Decimal('-100'),
+                timestamp=datetime.now(tz=timezone.utc),
+            )
+        )
+
+        store.checkpoint(state)
+
+        store.append_event(
+            StrategyEvent(
+                strategy_id='strat_a',
+                event_type='trade_outcome',
+                realized_pnl=Decimal('-25'),
+                timestamp=datetime.now(tz=timezone.utc),
+            )
+        )
+
+        store2 = StateStore(tmp_path / 'state')
+        recovered = store2.recover()
+        assert recovered is not None
+        assert recovered.risk.per_strategy['strat_a'].rolling_loss_24h == Decimal('25')

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.risk_state import RiskState, StrategyRiskState
 from nexus.infrastructure.state_store import StateStore
 from nexus.infrastructure.strategy_event import StrategyEvent
 from nexus.infrastructure.wal import WriteAheadLog
@@ -267,3 +268,110 @@ class TestAppendEvent:
         assert entries[0].sequence == 0
         assert entries[1].sequence == 1
         assert entries[2].sequence == 2
+
+
+def _make_state_with_risk(
+    pool: str = '10000',
+    strategy_id: str = 'strat_a',
+) -> InstanceState:
+    srs = StrategyRiskState(
+        strategy_id=strategy_id,
+        rolling_loss_24h=Decimal('999'),
+        rolling_loss_7d=Decimal('999'),
+        rolling_loss_30d=Decimal('999'),
+    )
+    return InstanceState(
+        capital=CapitalState(capital_pool=Decimal(pool)),
+        risk=RiskState(per_strategy={strategy_id: srs}),
+    )
+
+
+class TestRecoverWithEvents:
+    def test_no_events_preserves_snapshot_losses(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        state = _make_state_with_risk()
+        store.append_mutation(state)
+
+        store2 = StateStore(tmp_path / 'state')
+        recovered = store2.recover()
+        assert recovered is not None
+        srs = recovered.risk.per_strategy['strat_a']
+        assert srs.rolling_loss_24h == Decimal('999')
+        assert srs.rolling_loss_7d == Decimal('999')
+        assert srs.rolling_loss_30d == Decimal('999')
+
+    def test_events_overwrite_snapshot_losses(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        state = _make_state_with_risk()
+        store.append_mutation(state)
+
+        event = StrategyEvent(
+            strategy_id='strat_a',
+            event_type='trade_outcome',
+            realized_pnl=Decimal('-75'),
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        store.append_event(event)
+
+        store2 = StateStore(tmp_path / 'state')
+        recovered = store2.recover()
+        assert recovered is not None
+        srs = recovered.risk.per_strategy['strat_a']
+        assert srs.rolling_loss_24h == Decimal('75')
+        assert srs.rolling_loss_7d == Decimal('75')
+        assert srs.rolling_loss_30d == Decimal('75')
+
+    def test_events_for_unknown_strategy_ignored(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        store.append_mutation(_make_state_with_risk(strategy_id='strat_a'))
+
+        event = StrategyEvent(
+            strategy_id='strat_unknown',
+            event_type='trade_outcome',
+            realized_pnl=Decimal('-100'),
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        store.append_event(event)
+
+        store2 = StateStore(tmp_path / 'state')
+        recovered = store2.recover()
+        assert recovered is not None
+        assert 'strat_unknown' not in recovered.risk.per_strategy
+        assert recovered.risk.per_strategy['strat_a'].rolling_loss_24h == Decimal('999')
+
+    def test_multiple_strategies_recovered(self, tmp_path: Path) -> None:
+        srs_a = StrategyRiskState(
+            strategy_id='strat_a', rolling_loss_24h=Decimal('999')
+        )
+        srs_b = StrategyRiskState(
+            strategy_id='strat_b', rolling_loss_24h=Decimal('999')
+        )
+        state = InstanceState(
+            capital=CapitalState(capital_pool=Decimal('10000')),
+            risk=RiskState(per_strategy={'strat_a': srs_a, 'strat_b': srs_b}),
+        )
+        store = StateStore(tmp_path / 'state')
+        store.append_mutation(state)
+
+        store.append_event(
+            StrategyEvent(
+                strategy_id='strat_a',
+                event_type='trade_outcome',
+                realized_pnl=Decimal('-10'),
+                timestamp=datetime.now(tz=timezone.utc),
+            )
+        )
+        store.append_event(
+            StrategyEvent(
+                strategy_id='strat_b',
+                event_type='trade_outcome',
+                realized_pnl=Decimal('-20'),
+                timestamp=datetime.now(tz=timezone.utc),
+            )
+        )
+
+        store2 = StateStore(tmp_path / 'state')
+        recovered = store2.recover()
+        assert recovered is not None
+        assert recovered.risk.per_strategy['strat_a'].rolling_loss_24h == Decimal('10')
+        assert recovered.risk.per_strategy['strat_b'].rolling_loss_24h == Decimal('20')

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -218,7 +218,7 @@ def _make_event(strategy_id: str = 'strat_a', pnl: str = '-50.25') -> StrategyEv
         strategy_id=strategy_id,
         event_type='trade_outcome',
         realized_pnl=Decimal(pnl),
-        timestamp=datetime(2026, 3, 19, 12, 0, 0),
+        timestamp=datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone.utc),
     )
 
 

--- a/tests/test_strategy_event.py
+++ b/tests/test_strategy_event.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 from typing import Any
@@ -17,7 +17,7 @@ def _make_event(**overrides: Any) -> StrategyEvent:
         'strategy_id': 'strat_a',
         'event_type': 'trade_outcome',
         'realized_pnl': Decimal('-50.25'),
-        'timestamp': datetime(2026, 3, 19, 12, 0, 0),
+        'timestamp': datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone.utc),
     }
     defaults.update(overrides)
     return StrategyEvent(**defaults)
@@ -29,7 +29,7 @@ class TestValidConstruction:
         assert event.strategy_id == 'strat_a'
         assert event.event_type == 'trade_outcome'
         assert event.realized_pnl == Decimal('-50.25')
-        assert event.timestamp == datetime(2026, 3, 19, 12, 0, 0)
+        assert event.timestamp == datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone.utc)
 
     def test_positive_pnl(self) -> None:
         event = _make_event(realized_pnl=Decimal('100'))
@@ -72,3 +72,7 @@ class TestValidation:
     def test_nan_pnl_rejected(self) -> None:
         with pytest.raises(ValueError, match='realized_pnl'):
             _make_event(realized_pnl=Decimal('NaN'))
+
+    def test_naive_timestamp_rejected(self) -> None:
+        with pytest.raises(ValueError, match='timezone-aware'):
+            _make_event(timestamp=datetime(2026, 3, 19, 12, 0, 0))

--- a/tests/test_strategy_event.py
+++ b/tests/test_strategy_event.py
@@ -1,0 +1,73 @@
+'''Verify StrategyEvent construction and validation.'''
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+from typing import Any
+
+from nexus.infrastructure.strategy_event import StrategyEvent
+
+
+def _make_event(**overrides: Any) -> StrategyEvent:
+    defaults: dict[str, Any] = {
+        'strategy_id': 'strat_a',
+        'event_type': 'trade_outcome',
+        'realized_pnl': Decimal('-50.25'),
+        'timestamp': datetime(2026, 3, 19, 12, 0, 0),
+    }
+    defaults.update(overrides)
+    return StrategyEvent(**defaults)
+
+
+class TestValidConstruction:
+    def test_basic_construction(self) -> None:
+        event = _make_event()
+        assert event.strategy_id == 'strat_a'
+        assert event.event_type == 'trade_outcome'
+        assert event.realized_pnl == Decimal('-50.25')
+        assert event.timestamp == datetime(2026, 3, 19, 12, 0, 0)
+
+    def test_positive_pnl(self) -> None:
+        event = _make_event(realized_pnl=Decimal('100'))
+        assert event.realized_pnl == Decimal('100')
+
+    def test_zero_pnl(self) -> None:
+        event = _make_event(realized_pnl=Decimal('0'))
+        assert event.realized_pnl == Decimal('0')
+
+
+class TestImmutability:
+    def test_cannot_set_strategy_id(self) -> None:
+        event = _make_event()
+        with pytest.raises(AttributeError):
+            event.strategy_id = 'other'  # type: ignore[misc]
+
+    def test_cannot_set_realized_pnl(self) -> None:
+        event = _make_event()
+        with pytest.raises(AttributeError):
+            event.realized_pnl = Decimal('0')  # type: ignore[misc]
+
+
+class TestValidation:
+    def test_empty_strategy_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='strategy_id'):
+            _make_event(strategy_id='')
+
+    def test_whitespace_strategy_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='strategy_id'):
+            _make_event(strategy_id='   ')
+
+    def test_empty_event_type_rejected(self) -> None:
+        with pytest.raises(ValueError, match='event_type'):
+            _make_event(event_type='')
+
+    def test_infinite_pnl_rejected(self) -> None:
+        with pytest.raises(ValueError, match='realized_pnl'):
+            _make_event(realized_pnl=Decimal('Inf'))
+
+    def test_nan_pnl_rejected(self) -> None:
+        with pytest.raises(ValueError, match='realized_pnl'):
+            _make_event(realized_pnl=Decimal('NaN'))

--- a/tests/test_strategy_event.py
+++ b/tests/test_strategy_event.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import pytest
 from typing import Any
+
+import pytest
 
 from nexus.infrastructure.strategy_event import StrategyEvent
 

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -295,7 +295,7 @@ def _make_event() -> StrategyEvent:
         strategy_id='strat_a',
         event_type='trade_outcome',
         realized_pnl=Decimal('-50.25'),
-        timestamp=datetime(2026, 3, 19, 12, 0, 0),
+        timestamp=datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone.utc),
     )
 
 
@@ -314,7 +314,7 @@ class TestEventRoundTrip:
             strategy_id='strat_b',
             event_type='trade_outcome',
             realized_pnl=Decimal('123.456789012345678901234567890'),
-            timestamp=datetime(2026, 3, 19, 12, 0, 0),
+            timestamp=datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone.utc),
         )
         recovered = deserialize_event(serialize_event(event))
         assert recovered.realized_pnl == event.realized_pnl
@@ -324,7 +324,7 @@ class TestEventRoundTrip:
             strategy_id='strat_a',
             event_type='trade_outcome',
             realized_pnl=Decimal('-999.99'),
-            timestamp=datetime(2026, 3, 19, 12, 0, 0),
+            timestamp=datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone.utc),
         )
         recovered = deserialize_event(serialize_event(event))
         assert recovered.realized_pnl == Decimal('-999.99')
@@ -334,7 +334,7 @@ class TestEventRoundTrip:
             strategy_id='strat_a',
             event_type='trade_outcome',
             realized_pnl=Decimal('0'),
-            timestamp=datetime(2026, 3, 19, 12, 0, 0),
+            timestamp=datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone.utc),
         )
         recovered = deserialize_event(serialize_event(event))
         assert recovered.realized_pnl == Decimal('0')
@@ -346,17 +346,17 @@ class TestEventCodecVersion:
 
         data = serialize_event(_make_event())
         unpacked = msgpack.unpackb(data, raw=False)
-        assert unpacked['_v'] == '1'
+        assert unpacked['_v'] == 1
 
     def test_wrong_version_rejected(self) -> None:
         import msgpack
 
         d = {
-            '_v': '99',
+            '_v': 99,
             'strategy_id': 'strat_a',
             'event_type': 'trade_outcome',
             'realized_pnl': '0',
-            'timestamp': '2026-03-19T12:00:00',
+            'timestamp': '2026-03-19T12:00:00+00:00',
         }
         data = bytes(msgpack.packb(d))
 

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -1,4 +1,4 @@
-'''Verify WAL codec round-trip serialization for InstanceState.'''
+'''Verify WAL codec round-trip serialization for InstanceState and StrategyEvent.'''
 
 from __future__ import annotations
 
@@ -13,7 +13,13 @@ from nexus.core.domain.instance_state import InstanceState
 from nexus.core.domain.operational_mode import ModeState, StrategyModeState
 from nexus.core.domain.position import Position
 from nexus.core.domain.risk_state import RiskState, StrategyRiskState
-from nexus.infrastructure.wal_codec import deserialize_state, serialize_state
+from nexus.infrastructure.strategy_event import StrategyEvent
+from nexus.infrastructure.wal_codec import (
+    deserialize_event,
+    deserialize_state,
+    serialize_event,
+    serialize_state,
+)
 
 
 def _make_minimal_state() -> InstanceState:
@@ -282,3 +288,113 @@ class TestSerializationOutput:
         unpacked = msgpack.unpackb(result, raw=False)
         assert isinstance(unpacked, dict)
         assert unpacked['_v'] == 1
+
+
+def _make_event() -> StrategyEvent:
+    return StrategyEvent(
+        strategy_id='strat_a',
+        event_type='trade_outcome',
+        realized_pnl=Decimal('-50.25'),
+        timestamp=datetime(2026, 3, 19, 12, 0, 0),
+    )
+
+
+class TestEventRoundTrip:
+    def test_basic_round_trip(self) -> None:
+        event = _make_event()
+        data = serialize_event(event)
+        recovered = deserialize_event(data)
+        assert recovered.strategy_id == event.strategy_id
+        assert recovered.event_type == event.event_type
+        assert recovered.realized_pnl == event.realized_pnl
+        assert recovered.timestamp == event.timestamp
+
+    def test_decimal_precision_preserved(self) -> None:
+        event = StrategyEvent(
+            strategy_id='strat_b',
+            event_type='trade_outcome',
+            realized_pnl=Decimal('123.456789012345678901234567890'),
+            timestamp=datetime(2026, 3, 19, 12, 0, 0),
+        )
+        recovered = deserialize_event(serialize_event(event))
+        assert recovered.realized_pnl == event.realized_pnl
+
+    def test_negative_pnl_round_trip(self) -> None:
+        event = StrategyEvent(
+            strategy_id='strat_a',
+            event_type='trade_outcome',
+            realized_pnl=Decimal('-999.99'),
+            timestamp=datetime(2026, 3, 19, 12, 0, 0),
+        )
+        recovered = deserialize_event(serialize_event(event))
+        assert recovered.realized_pnl == Decimal('-999.99')
+
+    def test_zero_pnl_round_trip(self) -> None:
+        event = StrategyEvent(
+            strategy_id='strat_a',
+            event_type='trade_outcome',
+            realized_pnl=Decimal('0'),
+            timestamp=datetime(2026, 3, 19, 12, 0, 0),
+        )
+        recovered = deserialize_event(serialize_event(event))
+        assert recovered.realized_pnl == Decimal('0')
+
+
+class TestEventCodecVersion:
+    def test_version_embedded(self) -> None:
+        import msgpack
+
+        data = serialize_event(_make_event())
+        unpacked = msgpack.unpackb(data, raw=False)
+        assert unpacked['_v'] == '1'
+
+    def test_wrong_version_rejected(self) -> None:
+        import msgpack
+
+        d = {
+            '_v': '99',
+            'strategy_id': 'strat_a',
+            'event_type': 'trade_outcome',
+            'realized_pnl': '0',
+            'timestamp': '2026-03-19T12:00:00',
+        }
+        data = bytes(msgpack.packb(d))
+
+        with pytest.raises(ValueError, match='Unsupported event codec version'):
+            deserialize_event(data)
+
+
+class TestEventMalformedPayload:
+    def test_non_dict_rejected(self) -> None:
+        import msgpack
+
+        data = bytes(msgpack.packb([1, 2, 3]))
+
+        with pytest.raises(ValueError, match='Expected dict from event payload'):
+            deserialize_event(data)
+
+    def test_missing_field_rejected(self) -> None:
+        import msgpack
+
+        d = {'_v': '1', 'strategy_id': 'strat_a'}
+        data = bytes(msgpack.packb(d))
+
+        with pytest.raises(ValueError, match='Malformed event codec payload'):
+            deserialize_event(data)
+
+
+class TestEventSerializationOutput:
+    def test_output_is_bytes(self) -> None:
+        result = serialize_event(_make_event())
+        assert isinstance(result, bytes)
+
+    def test_output_is_non_empty(self) -> None:
+        result = serialize_event(_make_event())
+        assert len(result) > 0
+
+    def test_output_is_valid_msgpack(self) -> None:
+        import msgpack
+
+        result = serialize_event(_make_event())
+        unpacked = msgpack.unpackb(result, raw=False)
+        assert isinstance(unpacked, dict)

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -376,7 +376,37 @@ class TestEventMalformedPayload:
     def test_missing_field_rejected(self) -> None:
         import msgpack
 
-        d = {'_v': '1', 'strategy_id': 'strat_a'}
+        d = {'_v': 1, 'strategy_id': 'strat_a'}
+        data = bytes(msgpack.packb(d))
+
+        with pytest.raises(ValueError, match='Malformed event codec payload'):
+            deserialize_event(data)
+
+    def test_invalid_decimal_rejected(self) -> None:
+        import msgpack
+
+        d = {
+            '_v': 1,
+            'strategy_id': 'strat_a',
+            'event_type': 'trade_outcome',
+            'realized_pnl': 'not_a_number',
+            'timestamp': '2026-03-19T12:00:00+00:00',
+        }
+        data = bytes(msgpack.packb(d))
+
+        with pytest.raises(ValueError, match='Malformed event codec payload'):
+            deserialize_event(data)
+
+    def test_invalid_timestamp_rejected(self) -> None:
+        import msgpack
+
+        d = {
+            '_v': 1,
+            'strategy_id': 'strat_a',
+            'event_type': 'trade_outcome',
+            'realized_pnl': '100',
+            'timestamp': 'not-a-date',
+        }
         data = bytes(msgpack.packb(d))
 
         with pytest.raises(ValueError, match='Malformed event codec payload'):


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements Phase 1.3 (State recovery) from RFC-3001. Adds strategy event persistence and two-pass crash recovery that re-derives rolling loss counters from WAL events instead of relying on stale snapshot values.

**New files:**
- `strategy_event.py` — frozen `StrategyEvent` dataclass (strategy_id, event_type, realized_pnl, timestamp) with validation
- `loss_derivation.py` — pure `derive_rolling_losses()` function scanning events by 24h/7d/30d windows, summing negative realized P&L per strategy

**Changed files:**
- `wal_codec.py` — adds `serialize_event`/`deserialize_event` with versioned msgpack format, Decimal-as-string precision
- `state_store.py` — adds `append_event()` for STRATEGY_EVENT WAL entries; enhances `recover()` with two-pass: (1) snapshot + STATE_MUTATION replay, (2) STRATEGY_EVENT scan to re-derive and overwrite rolling loss counters

**Test coverage:** 44 new tests (182 total), covering event construction/validation, codec round-trip, loss derivation window boundaries, and recovery with checkpoint boundary handling.

**Version:** 0.4.0 → 0.5.0

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable