### PR TITLE
feat: Phase 2.2 — Atomic check-and-reserve under lock with strategy budget enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.6.0 on 19th of March, 2026
+
+- Add [`reservation.py`](nexus/core/capital_controller/reservation.py) with frozen `Reservation` dataclass (reservation_id, strategy_id, notional, estimated_fees, TTL) and `ReservationResult` outcome type
+- Add [`capital_controller.py`](nexus/core/capital_controller/capital_controller.py) with thread-safe `CapitalController` guarding `CapitalState` behind `threading.Lock`
+- Add `check_and_reserve()` with 4 ordered atomic checks: per-trade allocation, strategy budget, available capital, total utilization
+- Add `release_reservation()` returning locked capital to the available pool
+- Add constants `MAX_ALLOCATION_PER_TRADE_PCT` (0.15) and `MAX_CAPITAL_UTILIZATION_PCT` (0.80)
+- Add 39 tests covering reservation validation, all check failure paths, release lifecycle, and 10-thread concurrency contention
+
 ## v0.1.0 on 16th of March, 2026
 
 - Add CI pipeline mirroring Praxis: Ruff, Mypy strict, pytest, CodeQL workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0 on 19th of March, 2026
 
-- Add [`reservation.py`](nexus/core/capital_controller/reservation.py) with frozen `Reservation` dataclass (reservation_id, strategy_id, notional, estimated_fees, TTL) and `ReservationResult` outcome type
+- Add [`reservation.py`](nexus/core/capital_controller/reservation.py) with frozen `Reservation` dataclass (reservation_id, strategy_id, notional, estimated_fees, created_at, expires_at) and `ReservationResult` outcome type
 - Add [`capital_controller.py`](nexus/core/capital_controller/capital_controller.py) with thread-safe `CapitalController` guarding `CapitalState` behind `threading.Lock`
 - Add `check_and_reserve()` with 4 ordered atomic checks: per-trade allocation, strategy budget, available capital, total utilization
 - Add `release_reservation()` returning locked capital to the available pool

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -60,17 +60,33 @@ class CapitalController:
             ReservationResult with granted reservation or denial reason.
         '''
 
-        if order_notional < Decimal(0) or not order_notional.is_finite():
-            msg = f'Invalid order_notional: {order_notional}'
+        for name, val in (
+            ('order_notional', order_notional),
+            ('estimated_fees', estimated_fees),
+            ('strategy_budget', strategy_budget),
+            ('strategy_deployed', strategy_deployed),
+        ):
+            if not isinstance(val, Decimal) or not val.is_finite():
+                msg = f'Invalid {name}: {val}'
+                raise ValueError(msg)
+
+        if order_notional < Decimal(0):
+            msg = f'order_notional must be non-negative: {order_notional}'
             raise ValueError(msg)
 
-        if estimated_fees < Decimal(0) or not estimated_fees.is_finite():
-            msg = f'Invalid estimated_fees: {estimated_fees}'
+        if estimated_fees < Decimal(0):
+            msg = f'estimated_fees must be non-negative: {estimated_fees}'
+            raise ValueError(msg)
+
+        if ttl_seconds <= 0:
+            msg = f'ttl_seconds must be positive: {ttl_seconds}'
             raise ValueError(msg)
 
         total = order_notional + estimated_fees
 
         with self._lock:
+            self._purge_expired()
+
             allocation_pct = order_notional / self._state.capital_pool
 
             if allocation_pct > MAX_ALLOCATION_PER_TRADE_PCT:
@@ -82,11 +98,11 @@ class CapitalController:
                     ),
                 )
 
-            if strategy_deployed + order_notional > strategy_budget:
+            if strategy_deployed + total > strategy_budget:
                 return ReservationResult(
                     granted=False,
                     denial_reason=(
-                        f'Strategy deployed {strategy_deployed} + order {order_notional} '
+                        f'Strategy deployed {strategy_deployed} + order {total} '
                         f'exceeds budget {strategy_budget}'
                     ),
                 )
@@ -131,6 +147,14 @@ class CapitalController:
             self._state.reservation_notional += total
 
             return ReservationResult(granted=True, reservation=reservation)
+
+    def _purge_expired(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        expired = [rid for rid, r in self._reservations.items() if r.is_expired(now)]
+
+        for rid in expired:
+            reservation = self._reservations.pop(rid)
+            self._state.reservation_notional -= reservation.total
 
     def release_reservation(self, reservation_id: str) -> bool:
         '''Release a reservation and return its capital to the available pool.

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -23,8 +23,6 @@ MAX_ALLOCATION_PER_TRADE_PCT = Decimal('0.15')
 MAX_CAPITAL_UTILIZATION_PCT = Decimal('0.80')
 DEFAULT_TTL_SECONDS = 30
 
-_ZERO = Decimal(0)
-
 
 class CapitalController:
     '''Thread-safe capital reservation manager.
@@ -61,6 +59,14 @@ class CapitalController:
         Returns:
             ReservationResult with granted reservation or denial reason.
         '''
+
+        if order_notional < Decimal(0) or not order_notional.is_finite():
+            msg = f'Invalid order_notional: {order_notional}'
+            raise ValueError(msg)
+
+        if estimated_fees < Decimal(0) or not estimated_fees.is_finite():
+            msg = f'Invalid estimated_fees: {estimated_fees}'
+            raise ValueError(msg)
 
         total = order_notional + estimated_fees
 
@@ -100,7 +106,7 @@ class CapitalController:
                 + self._state.in_flight_order_notional
                 + self._state.reservation_notional
             )
-            utilization = (total_deployed + order_notional) / self._state.capital_pool
+            utilization = (total_deployed + total) / self._state.capital_pool
 
             if utilization > MAX_CAPITAL_UTILIZATION_PCT:
                 return ReservationResult(

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -23,6 +23,8 @@ MAX_ALLOCATION_PER_TRADE_PCT = Decimal('0.15')
 MAX_CAPITAL_UTILIZATION_PCT = Decimal('0.80')
 DEFAULT_TTL_SECONDS = 30
 
+_ZERO = Decimal(0)
+
 
 class CapitalController:
     '''Thread-safe capital reservation manager.
@@ -70,12 +72,20 @@ class CapitalController:
                 msg = f'Invalid {name}: {val}'
                 raise ValueError(msg)
 
-        if order_notional < Decimal(0):
+        if not strategy_id or not strategy_id.strip():
+            msg = 'strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if order_notional < _ZERO:
             msg = f'order_notional must be non-negative: {order_notional}'
             raise ValueError(msg)
 
-        if estimated_fees < Decimal(0):
+        if estimated_fees < _ZERO:
             msg = f'estimated_fees must be non-negative: {estimated_fees}'
+            raise ValueError(msg)
+
+        if strategy_deployed < _ZERO:
+            msg = f'strategy_deployed must be non-negative: {strategy_deployed}'
             raise ValueError(msg)
 
         if ttl_seconds <= 0:

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -1,0 +1,146 @@
+'''Atomic check-and-reserve capital controller.
+
+Guards CapitalState mutations behind a threading lock to prevent
+TOCTOU races when multiple strategies compete for the same pool.
+'''
+
+from __future__ import annotations
+
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from nexus.core.capital_controller.reservation import (
+    Reservation,
+    ReservationResult,
+)
+from nexus.core.domain.capital_state import CapitalState
+
+__all__ = ['CapitalController']
+
+MAX_ALLOCATION_PER_TRADE_PCT = Decimal('0.15')
+MAX_CAPITAL_UTILIZATION_PCT = Decimal('0.80')
+DEFAULT_TTL_SECONDS = 30
+
+_ZERO = Decimal(0)
+
+
+class CapitalController:
+    '''Thread-safe capital reservation manager.
+
+    Args:
+        capital_state: Mutable capital state to guard.
+    '''
+
+    def __init__(self, capital_state: CapitalState) -> None:
+        self._state = capital_state
+        self._lock = threading.Lock()
+        self._reservations: dict[str, Reservation] = {}
+
+    def check_and_reserve(
+        self,
+        strategy_id: str,
+        order_notional: Decimal,
+        estimated_fees: Decimal,
+        strategy_budget: Decimal,
+        strategy_deployed: Decimal,
+        *,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    ) -> ReservationResult:
+        '''Atomically validate capital checks and create a reservation.
+
+        Args:
+            strategy_id: Which strategy is requesting capital.
+            order_notional: Quote capital for the order.
+            estimated_fees: Estimated transaction fees.
+            strategy_budget: Budget ceiling for this strategy.
+            strategy_deployed: Capital already deployed by this strategy.
+            ttl_seconds: Seconds before reservation auto-expires.
+
+        Returns:
+            ReservationResult with granted reservation or denial reason.
+        '''
+
+        total = order_notional + estimated_fees
+
+        with self._lock:
+            allocation_pct = order_notional / self._state.capital_pool
+
+            if allocation_pct > MAX_ALLOCATION_PER_TRADE_PCT:
+                return ReservationResult(
+                    granted=False,
+                    denial_reason=(
+                        f'Per-trade allocation {allocation_pct:.4f} exceeds '
+                        f'limit {MAX_ALLOCATION_PER_TRADE_PCT}'
+                    ),
+                )
+
+            if strategy_deployed + order_notional > strategy_budget:
+                return ReservationResult(
+                    granted=False,
+                    denial_reason=(
+                        f'Strategy deployed {strategy_deployed} + order {order_notional} '
+                        f'exceeds budget {strategy_budget}'
+                    ),
+                )
+
+            if self._state.available < total:
+                return ReservationResult(
+                    granted=False,
+                    denial_reason=(
+                        f'Insufficient available capital {self._state.available} '
+                        f'for order {total}'
+                    ),
+                )
+
+            total_deployed = (
+                self._state.position_notional
+                + self._state.working_order_notional
+                + self._state.in_flight_order_notional
+                + self._state.reservation_notional
+            )
+            utilization = (total_deployed + order_notional) / self._state.capital_pool
+
+            if utilization > MAX_CAPITAL_UTILIZATION_PCT:
+                return ReservationResult(
+                    granted=False,
+                    denial_reason=(
+                        f'Total utilization {utilization:.4f} exceeds '
+                        f'limit {MAX_CAPITAL_UTILIZATION_PCT}'
+                    ),
+                )
+
+            now = datetime.now(tz=timezone.utc)
+            reservation = Reservation(
+                reservation_id=str(uuid.uuid4()),
+                strategy_id=strategy_id,
+                notional=order_notional,
+                estimated_fees=estimated_fees,
+                created_at=now,
+                expires_at=now + timedelta(seconds=ttl_seconds),
+            )
+
+            self._reservations[reservation.reservation_id] = reservation
+            self._state.reservation_notional += total
+
+            return ReservationResult(granted=True, reservation=reservation)
+
+    def release_reservation(self, reservation_id: str) -> bool:
+        '''Release a reservation and return its capital to the available pool.
+
+        Args:
+            reservation_id: ID of the reservation to release.
+
+        Returns:
+            True if the reservation was found and released.
+        '''
+
+        with self._lock:
+            reservation = self._reservations.pop(reservation_id, None)
+
+            if reservation is None:
+                return False
+
+            self._state.reservation_notional -= reservation.total
+            return True

--- a/nexus/core/capital_controller/reservation.py
+++ b/nexus/core/capital_controller/reservation.py
@@ -137,3 +137,7 @@ class ReservationResult:
         if not self.granted and self.denial_reason is None:
             msg = 'ReservationResult: granted=False requires a denial_reason'
             raise ValueError(msg)
+
+        if self.granted and self.denial_reason is not None:
+            msg = 'ReservationResult: granted=True must not have a denial_reason'
+            raise ValueError(msg)

--- a/nexus/core/capital_controller/reservation.py
+++ b/nexus/core/capital_controller/reservation.py
@@ -99,8 +99,12 @@ class Reservation:
         '''Check whether this reservation has passed its TTL.
 
         Args:
-            now: Current time to compare against expires_at.
+            now: Timezone-aware current time to compare against expires_at.
         '''
+
+        if now.tzinfo is None or now.tzinfo.utcoffset(now) is None:
+            msg = 'Reservation.is_expired requires timezone-aware datetime'
+            raise ValueError(msg)
 
         return now >= self.expires_at
 
@@ -118,3 +122,18 @@ class ReservationResult:
     granted: bool
     reservation: Reservation | None = None
     denial_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        '''Validate granted/reservation/denial_reason consistency.'''
+
+        if self.granted and self.reservation is None:
+            msg = 'ReservationResult: granted=True requires a reservation'
+            raise ValueError(msg)
+
+        if not self.granted and self.reservation is not None:
+            msg = 'ReservationResult: granted=False must not have a reservation'
+            raise ValueError(msg)
+
+        if not self.granted and self.denial_reason is None:
+            msg = 'ReservationResult: granted=False requires a denial_reason'
+            raise ValueError(msg)

--- a/nexus/core/capital_controller/reservation.py
+++ b/nexus/core/capital_controller/reservation.py
@@ -1,0 +1,120 @@
+'''Capital reservation records for TOCTOU race prevention.
+
+A Reservation locks quote capital between validation and order
+submission. ReservationResult carries the outcome of an atomic
+check-and-reserve attempt.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+__all__ = ['Reservation', 'ReservationResult']
+
+_ZERO = Decimal(0)
+
+
+@dataclass(frozen=True)
+class Reservation:
+    '''An immutable capital lock for a pending BUY order.
+
+    Args:
+        reservation_id: Unique identifier for this reservation.
+        strategy_id: Which strategy requested the reservation.
+        notional: Quote capital locked for the order.
+        estimated_fees: Quote capital locked for estimated transaction fees.
+        created_at: When this reservation was created.
+        expires_at: When this reservation auto-expires if unused.
+    '''
+
+    reservation_id: str
+    strategy_id: str
+    notional: Decimal
+    estimated_fees: Decimal
+    created_at: datetime
+    expires_at: datetime
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if not isinstance(self.reservation_id, str) or not self.reservation_id.strip():
+            msg = 'Reservation.reservation_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.strategy_id, str) or not self.strategy_id.strip():
+            msg = 'Reservation.strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if (
+            not isinstance(self.notional, Decimal)
+            or not self.notional.is_finite()
+            or self.notional < _ZERO
+        ):
+            msg = 'Reservation.notional must be a finite non-negative Decimal'
+            raise ValueError(msg)
+
+        if (
+            not isinstance(self.estimated_fees, Decimal)
+            or not self.estimated_fees.is_finite()
+            or self.estimated_fees < _ZERO
+        ):
+            msg = 'Reservation.estimated_fees must be a finite non-negative Decimal'
+            raise ValueError(msg)
+
+        if not isinstance(self.created_at, datetime):
+            msg = 'Reservation.created_at must be a datetime'
+            raise ValueError(msg)
+
+        if (
+            self.created_at.tzinfo is None
+            or self.created_at.tzinfo.utcoffset(self.created_at) is None
+        ):
+            msg = 'Reservation.created_at must be timezone-aware'
+            raise ValueError(msg)
+
+        if not isinstance(self.expires_at, datetime):
+            msg = 'Reservation.expires_at must be a datetime'
+            raise ValueError(msg)
+
+        if (
+            self.expires_at.tzinfo is None
+            or self.expires_at.tzinfo.utcoffset(self.expires_at) is None
+        ):
+            msg = 'Reservation.expires_at must be timezone-aware'
+            raise ValueError(msg)
+
+        if self.expires_at <= self.created_at:
+            msg = 'Reservation.expires_at must be after created_at'
+            raise ValueError(msg)
+
+    @property
+    def total(self) -> Decimal:
+        '''Total quote capital locked by this reservation.'''
+
+        return self.notional + self.estimated_fees
+
+    def is_expired(self, now: datetime) -> bool:
+        '''Check whether this reservation has passed its TTL.
+
+        Args:
+            now: Current time to compare against expires_at.
+        '''
+
+        return now >= self.expires_at
+
+
+@dataclass(frozen=True)
+class ReservationResult:
+    '''Outcome of an atomic check-and-reserve attempt.
+
+    Args:
+        granted: Whether the reservation was created.
+        reservation: The reservation if granted, None if denied.
+        denial_reason: Human-readable reason if denied, None if granted.
+    '''
+
+    granted: bool
+    reservation: Reservation | None = None
+    denial_reason: str | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.5.0"
+version = "0.6.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -1,0 +1,191 @@
+'''Verify CapitalController check-and-reserve and release under lock.'''
+
+from __future__ import annotations
+
+import threading
+from decimal import Decimal
+
+from nexus.core.capital_controller.capital_controller import (
+    CapitalController,
+    MAX_ALLOCATION_PER_TRADE_PCT,
+    MAX_CAPITAL_UTILIZATION_PCT,
+)
+from nexus.core.capital_controller.reservation import ReservationResult
+from nexus.core.domain.capital_state import CapitalState
+
+_POOL = Decimal('10000')
+_ZERO = Decimal(0)
+_BUDGET = Decimal('5000')
+
+
+def _make_controller(**overrides: Decimal) -> CapitalController:
+    cs = CapitalState(capital_pool=_POOL, **overrides)
+    return CapitalController(cs)
+
+
+def _reserve(
+    ctrl: CapitalController,
+    notional: str = '100',
+    fees: str = '1',
+    budget: str = '5000',
+    deployed: str = '0',
+) -> ReservationResult:
+    return ctrl.check_and_reserve(
+        strategy_id='strat_a',
+        order_notional=Decimal(notional),
+        estimated_fees=Decimal(fees),
+        strategy_budget=Decimal(budget),
+        strategy_deployed=Decimal(deployed),
+    )
+
+
+class TestSuccessfulReservation:
+    def test_granted_result(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl)
+        assert result.granted is True
+        assert result.reservation is not None
+        assert result.reservation.strategy_id == 'strat_a'
+        assert result.reservation.notional == Decimal('100')
+        assert result.reservation.estimated_fees == Decimal('1')
+
+    def test_reservation_notional_updated(self) -> None:
+        ctrl = _make_controller()
+        _reserve(ctrl, notional='200', fees='5')
+        assert ctrl._state.reservation_notional == Decimal('205')
+
+    def test_sequential_reservations_accumulate(self) -> None:
+        ctrl = _make_controller()
+        _reserve(ctrl, notional='100', fees='1')
+        _reserve(ctrl, notional='200', fees='2')
+        assert ctrl._state.reservation_notional == Decimal('303')
+
+
+class TestPerTradeAllocationCheck:
+    def test_exceeds_allocation_limit(self) -> None:
+        ctrl = _make_controller()
+        limit = _POOL * MAX_ALLOCATION_PER_TRADE_PCT
+        result = _reserve(ctrl, notional=str(limit + 1))
+        assert result.granted is False
+        assert result.denial_reason is not None
+        assert 'allocation' in result.denial_reason.lower()
+
+    def test_at_allocation_limit_passes(self) -> None:
+        ctrl = _make_controller()
+        limit = _POOL * MAX_ALLOCATION_PER_TRADE_PCT
+        result = _reserve(ctrl, notional=str(limit))
+        assert result.granted is True
+
+
+class TestStrategyBudgetCheck:
+    def test_exceeds_strategy_budget(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='500', deployed='4600', budget='5000')
+        assert result.granted is False
+        assert result.denial_reason is not None
+        assert 'budget' in result.denial_reason.lower()
+
+    def test_at_strategy_budget_passes(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='1000', deployed='4000', budget='5000')
+        assert result.granted is True
+
+    def test_exhausted_budget_denied(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', budget='0')
+        assert result.granted is False
+        assert result.denial_reason is not None
+        assert 'budget' in result.denial_reason.lower()
+
+    def test_negative_budget_denied(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', budget='-50')
+        assert result.granted is False
+        assert result.denial_reason is not None
+        assert 'budget' in result.denial_reason.lower()
+
+
+class TestAvailableCapitalCheck:
+    def test_insufficient_available(self) -> None:
+        ctrl = _make_controller(position_notional=Decimal('9950'))
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.granted is False
+        assert result.denial_reason is not None
+        assert 'insufficient' in result.denial_reason.lower()
+
+    def test_exactly_available_passes(self) -> None:
+        ctrl = _make_controller(position_notional=Decimal('7000'))
+        result = _reserve(ctrl, notional='999', fees='1', budget=str(_POOL))
+        assert result.granted is True
+
+
+class TestTotalUtilizationCheck:
+    def test_exceeds_utilization_limit(self) -> None:
+        deployed = _POOL * MAX_CAPITAL_UTILIZATION_PCT
+        ctrl = _make_controller(position_notional=deployed)
+        result = _reserve(ctrl, notional='1', fees='0', budget=str(_POOL))
+        assert result.granted is False
+        assert result.denial_reason is not None
+        assert 'utilization' in result.denial_reason.lower()
+
+    def test_at_utilization_limit_passes(self) -> None:
+        deployed = _POOL * MAX_CAPITAL_UTILIZATION_PCT - Decimal('100')
+        ctrl = _make_controller(position_notional=deployed)
+        result = _reserve(ctrl, notional='100', fees='0', budget=str(_POOL))
+        assert result.granted is True
+
+
+class TestReleaseReservation:
+    def test_release_returns_capital(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='500', fees='5')
+        assert ctrl._state.reservation_notional == Decimal('505')
+        assert result.reservation is not None
+
+        released = ctrl.release_reservation(result.reservation.reservation_id)
+        assert released is True
+        assert ctrl._state.reservation_notional == _ZERO
+
+    def test_release_unknown_id(self) -> None:
+        ctrl = _make_controller()
+        assert ctrl.release_reservation('nonexistent') is False
+
+    def test_double_release(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        rid = result.reservation.reservation_id
+
+        assert ctrl.release_reservation(rid) is True
+        assert ctrl.release_reservation(rid) is False
+
+
+class TestConcurrency:
+    def test_no_over_allocation_under_contention(self) -> None:
+        ctrl = _make_controller()
+        results: list[ReservationResult] = []
+        barrier = threading.Barrier(10)
+
+        def try_reserve() -> None:
+            barrier.wait()
+            r = ctrl.check_and_reserve(
+                strategy_id='strat_a',
+                order_notional=Decimal('1000'),
+                estimated_fees=Decimal('10'),
+                strategy_budget=_POOL,
+                strategy_deployed=_ZERO,
+            )
+            results.append(r)
+
+        threads = [threading.Thread(target=try_reserve) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        granted = [r for r in results if r.granted]
+        total_reserved = sum(
+            r.reservation.total for r in granted if r.reservation is not None
+        )
+        assert total_reserved <= _POOL
+        assert ctrl._state.reservation_notional == total_reserved

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import threading
+from datetime import timedelta
 from decimal import Decimal
+
+import pytest
 
 from nexus.core.capital_controller.capital_controller import (
     CapitalController,
     MAX_ALLOCATION_PER_TRADE_PCT,
     MAX_CAPITAL_UTILIZATION_PCT,
 )
-from nexus.core.capital_controller.reservation import ReservationResult
+from nexus.core.capital_controller.reservation import Reservation, ReservationResult
 from nexus.core.domain.capital_state import CapitalState
 
 _POOL = Decimal('10000')
@@ -86,7 +89,9 @@ class TestStrategyBudgetCheck:
 
     def test_at_strategy_budget_passes(self) -> None:
         ctrl = _make_controller()
-        result = _reserve(ctrl, notional='1000', deployed='4000', budget='5000')
+        result = _reserve(
+            ctrl, notional='999', fees='1', deployed='4000', budget='5000'
+        )
         assert result.granted is True
 
     def test_exhausted_budget_denied(self) -> None:
@@ -188,3 +193,61 @@ class TestConcurrency:
         )
         assert total_reserved <= _POOL
         assert ctrl._state.reservation_notional == total_reserved
+
+
+class TestExpiredPurge:
+    def test_expired_reservations_purged_on_reserve(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='500', fees='5', budget=str(_POOL))
+        assert result.granted is True
+        assert ctrl._state.reservation_notional == Decimal('505')
+
+        import time
+
+        ctrl2 = CapitalController(ctrl._state)
+        ctrl2._reservations = dict(ctrl._reservations)
+
+        for rid, r in ctrl2._reservations.items():
+            expired = Reservation(
+                reservation_id=r.reservation_id,
+                strategy_id=r.strategy_id,
+                notional=r.notional,
+                estimated_fees=r.estimated_fees,
+                created_at=r.created_at,
+                expires_at=r.created_at + timedelta(seconds=1),
+            )
+            ctrl2._reservations[rid] = expired
+
+        time.sleep(1.1)
+
+        _reserve(ctrl2, notional='100', fees='1', budget=str(_POOL))
+        assert ctrl2._state.reservation_notional == Decimal('101')
+
+
+class TestInputValidation:
+    def test_nan_notional_rejected(self) -> None:
+        ctrl = _make_controller()
+        with pytest.raises(ValueError, match='order_notional'):
+            _reserve(ctrl, notional='NaN')
+
+    def test_negative_notional_rejected(self) -> None:
+        ctrl = _make_controller()
+        with pytest.raises(ValueError, match='non-negative'):
+            _reserve(ctrl, notional='-1')
+
+    def test_nan_strategy_budget_rejected(self) -> None:
+        ctrl = _make_controller()
+        with pytest.raises(ValueError, match='strategy_budget'):
+            _reserve(ctrl, budget='NaN')
+
+    def test_zero_ttl_rejected(self) -> None:
+        ctrl = _make_controller()
+        with pytest.raises(ValueError, match='ttl_seconds'):
+            ctrl.check_and_reserve(
+                strategy_id='strat_a',
+                order_notional=Decimal('100'),
+                estimated_fees=Decimal('1'),
+                strategy_budget=Decimal('5000'),
+                strategy_deployed=Decimal('0'),
+                ttl_seconds=0,
+            )

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -15,7 +15,6 @@ from nexus.core.domain.capital_state import CapitalState
 
 _POOL = Decimal('10000')
 _ZERO = Decimal(0)
-_BUDGET = Decimal('5000')
 
 
 def _make_controller(**overrides: Decimal) -> CapitalController:

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -197,31 +197,24 @@ class TestConcurrency:
 
 class TestExpiredPurge:
     def test_expired_reservations_purged_on_reserve(self) -> None:
+        from datetime import datetime, timezone
+
+        past = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
         ctrl = _make_controller()
-        result = _reserve(ctrl, notional='500', fees='5', budget=str(_POOL))
-        assert result.granted is True
-        assert ctrl._state.reservation_notional == Decimal('505')
+        expired_res = Reservation(
+            reservation_id='expired_001',
+            strategy_id='strat_a',
+            notional=Decimal('500'),
+            estimated_fees=Decimal('5'),
+            created_at=past,
+            expires_at=past + timedelta(seconds=1),
+        )
+        ctrl._reservations['expired_001'] = expired_res
+        ctrl._state.reservation_notional = Decimal('505')
 
-        import time
-
-        ctrl2 = CapitalController(ctrl._state)
-        ctrl2._reservations = dict(ctrl._reservations)
-
-        for rid, r in ctrl2._reservations.items():
-            expired = Reservation(
-                reservation_id=r.reservation_id,
-                strategy_id=r.strategy_id,
-                notional=r.notional,
-                estimated_fees=r.estimated_fees,
-                created_at=r.created_at,
-                expires_at=r.created_at + timedelta(seconds=1),
-            )
-            ctrl2._reservations[rid] = expired
-
-        time.sleep(1.1)
-
-        _reserve(ctrl2, notional='100', fees='1', budget=str(_POOL))
-        assert ctrl2._state.reservation_notional == Decimal('101')
+        _reserve(ctrl, notional='100', fees='1', budget=str(_POOL))
+        assert ctrl._state.reservation_notional == Decimal('101')
 
 
 class TestInputValidation:
@@ -239,6 +232,22 @@ class TestInputValidation:
         ctrl = _make_controller()
         with pytest.raises(ValueError, match='strategy_budget'):
             _reserve(ctrl, budget='NaN')
+
+    def test_empty_strategy_id_rejected(self) -> None:
+        ctrl = _make_controller()
+        with pytest.raises(ValueError, match='strategy_id'):
+            ctrl.check_and_reserve(
+                strategy_id='',
+                order_notional=Decimal('100'),
+                estimated_fees=Decimal('1'),
+                strategy_budget=Decimal('5000'),
+                strategy_deployed=Decimal('0'),
+            )
+
+    def test_negative_deployed_rejected(self) -> None:
+        ctrl = _make_controller()
+        with pytest.raises(ValueError, match='strategy_deployed'):
+            _reserve(ctrl, deployed='-1')
 
     def test_zero_ttl_rejected(self) -> None:
         ctrl = _make_controller()

--- a/tests/test_reservation.py
+++ b/tests/test_reservation.py
@@ -151,6 +151,11 @@ class TestReservationResult:
         with pytest.raises(ValueError, match='granted=False requires'):
             ReservationResult(granted=False)
 
+    def test_granted_with_denial_reason_rejected(self) -> None:
+        r = _make_reservation()
+        with pytest.raises(ValueError, match='granted=True must not'):
+            ReservationResult(granted=True, reservation=r, denial_reason='oops')
+
 
 class TestIsExpiredValidation:
     def test_naive_now_rejected(self) -> None:

--- a/tests/test_reservation.py
+++ b/tests/test_reservation.py
@@ -1,0 +1,139 @@
+'''Verify Reservation and ReservationResult construction and validation.'''
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from nexus.core.capital_controller.reservation import Reservation, ReservationResult
+
+_NOW = datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone.utc)
+_LATER = _NOW + timedelta(seconds=30)
+
+
+def _make_reservation(**overrides: Any) -> Reservation:
+    defaults: dict[str, Any] = {
+        'reservation_id': 'res_001',
+        'strategy_id': 'strat_a',
+        'notional': Decimal('500'),
+        'estimated_fees': Decimal('1.50'),
+        'created_at': _NOW,
+        'expires_at': _LATER,
+    }
+    defaults.update(overrides)
+    return Reservation(**defaults)
+
+
+class TestValidConstruction:
+    def test_fields_stored(self) -> None:
+        r = _make_reservation()
+        assert r.reservation_id == 'res_001'
+        assert r.strategy_id == 'strat_a'
+        assert r.notional == Decimal('500')
+        assert r.estimated_fees == Decimal('1.50')
+        assert r.created_at == _NOW
+        assert r.expires_at == _LATER
+
+    def test_zero_notional_accepted(self) -> None:
+        r = _make_reservation(notional=Decimal('0'))
+        assert r.notional == Decimal('0')
+
+    def test_zero_fees_accepted(self) -> None:
+        r = _make_reservation(estimated_fees=Decimal('0'))
+        assert r.estimated_fees == Decimal('0')
+
+
+class TestTotal:
+    def test_total_sums_notional_and_fees(self) -> None:
+        r = _make_reservation(notional=Decimal('100'), estimated_fees=Decimal('2'))
+        assert r.total == Decimal('102')
+
+    def test_total_zero_fees(self) -> None:
+        r = _make_reservation(notional=Decimal('100'), estimated_fees=Decimal('0'))
+        assert r.total == Decimal('100')
+
+
+class TestExpiry:
+    def test_not_expired_before_ttl(self) -> None:
+        r = _make_reservation()
+        assert r.is_expired(_NOW + timedelta(seconds=10)) is False
+
+    def test_expired_at_exact_ttl(self) -> None:
+        r = _make_reservation()
+        assert r.is_expired(_LATER) is True
+
+    def test_expired_after_ttl(self) -> None:
+        r = _make_reservation()
+        assert r.is_expired(_LATER + timedelta(seconds=1)) is True
+
+
+class TestImmutability:
+    def test_cannot_set_notional(self) -> None:
+        r = _make_reservation()
+        with pytest.raises(AttributeError):
+            r.notional = Decimal('0')  # type: ignore[misc]
+
+    def test_cannot_set_strategy_id(self) -> None:
+        r = _make_reservation()
+        with pytest.raises(AttributeError):
+            r.strategy_id = 'other'  # type: ignore[misc]
+
+
+class TestValidation:
+    def test_empty_reservation_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='reservation_id'):
+            _make_reservation(reservation_id='')
+
+    def test_empty_strategy_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='strategy_id'):
+            _make_reservation(strategy_id='')
+
+    def test_negative_notional_rejected(self) -> None:
+        with pytest.raises(ValueError, match='notional'):
+            _make_reservation(notional=Decimal('-1'))
+
+    def test_negative_fees_rejected(self) -> None:
+        with pytest.raises(ValueError, match='estimated_fees'):
+            _make_reservation(estimated_fees=Decimal('-1'))
+
+    def test_nan_notional_rejected(self) -> None:
+        with pytest.raises(ValueError, match='notional'):
+            _make_reservation(notional=Decimal('NaN'))
+
+    def test_inf_fees_rejected(self) -> None:
+        with pytest.raises(ValueError, match='estimated_fees'):
+            _make_reservation(estimated_fees=Decimal('Inf'))
+
+    def test_naive_created_at_rejected(self) -> None:
+        with pytest.raises(ValueError, match='timezone-aware'):
+            _make_reservation(created_at=datetime(2026, 3, 19, 12, 0, 0))
+
+    def test_naive_expires_at_rejected(self) -> None:
+        with pytest.raises(ValueError, match='timezone-aware'):
+            _make_reservation(expires_at=datetime(2026, 3, 19, 12, 0, 30))
+
+    def test_expires_at_before_created_at_rejected(self) -> None:
+        with pytest.raises(ValueError, match='expires_at must be after'):
+            _make_reservation(expires_at=_NOW - timedelta(seconds=1))
+
+    def test_expires_at_equal_created_at_rejected(self) -> None:
+        with pytest.raises(ValueError, match='expires_at must be after'):
+            _make_reservation(expires_at=_NOW)
+
+
+class TestReservationResult:
+    def test_granted_result(self) -> None:
+        r = _make_reservation()
+        result = ReservationResult(granted=True, reservation=r)
+        assert result.granted is True
+        assert result.reservation is r
+        assert result.denial_reason is None
+
+    def test_denied_result(self) -> None:
+        result = ReservationResult(granted=False, denial_reason='insufficient capital')
+        assert result.granted is False
+        assert result.reservation is None
+        assert result.denial_reason == 'insufficient capital'

--- a/tests/test_reservation.py
+++ b/tests/test_reservation.py
@@ -137,3 +137,23 @@ class TestReservationResult:
         assert result.granted is False
         assert result.reservation is None
         assert result.denial_reason == 'insufficient capital'
+
+    def test_granted_without_reservation_rejected(self) -> None:
+        with pytest.raises(ValueError, match='granted=True requires'):
+            ReservationResult(granted=True)
+
+    def test_denied_with_reservation_rejected(self) -> None:
+        r = _make_reservation()
+        with pytest.raises(ValueError, match='granted=False must not'):
+            ReservationResult(granted=False, reservation=r, denial_reason='x')
+
+    def test_denied_without_reason_rejected(self) -> None:
+        with pytest.raises(ValueError, match='granted=False requires'):
+            ReservationResult(granted=False)
+
+
+class TestIsExpiredValidation:
+    def test_naive_now_rejected(self) -> None:
+        r = _make_reservation()
+        with pytest.raises(ValueError, match='timezone-aware'):
+            r.is_expired(datetime(2026, 3, 19, 12, 0, 30))


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements Phase 2.2 (Atomic check-and-reserve) from RFC-3001. Adds thread-safe capital reservation system that prevents TOCTOU races when multiple strategies compete for the same capital pool.

**New files:**
- `reservation.py` — frozen `Reservation` dataclass (reservation_id, strategy_id, notional, estimated_fees, TTL) with `total` property, `is_expired()` check, and `ReservationResult` outcome type
- `capital_controller.py` — `CapitalController` guarding `CapitalState` behind `threading.Lock` with 4 ordered atomic checks: per-trade allocation (15%), strategy budget, available capital, total utilization (80%)

**Key design decisions:**
- Controller accepts `strategy_budget` and `strategy_deployed` as inputs — does not own per-strategy tracking (deferred to Phase 2.6)
- Denial returns structured `ReservationResult` with reason string, not exceptions
- Reservation ID via `uuid4` — collision-proof, no coordination needed

**Test coverage:** 39 new tests (224 total), including 10-thread concurrency contention test verifying no over-allocation under race conditions.

**Version:** 0.5.0 → 0.6.0

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (224 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable