### PR TITLE
feat: Phase 2.3 — Capital lifecycle state machine (reservation → in_flight → working → position)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ build/
 
 .cursor/
 nexus-journals/
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.7.0 on 20th of March, 2026
+
+- Add [`tracked_order.py`](nexus/core/capital_controller/tracked_order.py) with `OrderLifecycleState` enum (IN_FLIGHT, WORKING) and frozen `TrackedOrder` dataclass
+- Add `CapitalController.send_order()` to convert reservation into in-flight order
+- Add `CapitalController.order_ack()` to transition in-flight → working
+- Add `CapitalController.order_reject()` to release in-flight order capital
+- Add `CapitalController.order_fill()` to handle partial/full fills with proportional fee allocation
+- Add `CapitalController.order_cancel()` to release working order remaining capital
+- Add 45 tests covering TrackedOrder validation, all lifecycle transitions, and concurrency (281 total)
+
 ## v0.6.0 on 19th of March, 2026
 
 - Add [`reservation.py`](nexus/core/capital_controller/reservation.py) with frozen `Reservation` dataclass (reservation_id, strategy_id, notional, estimated_fees, created_at, expires_at) and `ReservationResult` outcome type

--- a/nexus/core/capital_controller/__init__.py
+++ b/nexus/core/capital_controller/__init__.py
@@ -1,7 +1,7 @@
 '''Capital controller components for the Nexus Manager.
 
 Re-exports: CapitalController, Reservation, ReservationResult,
-OrderLifecycleState.
+OrderLifecycleState, TrackedOrder.
 '''
 
 from __future__ import annotations

--- a/nexus/core/capital_controller/__init__.py
+++ b/nexus/core/capital_controller/__init__.py
@@ -1,0 +1,22 @@
+'''Capital controller components for the Nexus Manager.
+
+Re-exports: CapitalController, Reservation, ReservationResult,
+OrderLifecycleState.
+'''
+
+from __future__ import annotations
+
+from nexus.core.capital_controller.capital_controller import CapitalController
+from nexus.core.capital_controller.reservation import Reservation, ReservationResult
+from nexus.core.capital_controller.tracked_order import (
+    OrderLifecycleState,
+    TrackedOrder,
+)
+
+__all__ = [
+    'CapitalController',
+    'OrderLifecycleState',
+    'Reservation',
+    'ReservationResult',
+    'TrackedOrder',
+]

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -298,3 +298,92 @@ class CapitalController:
             self._state.in_flight_order_notional -= order.total
 
             return True
+
+    def order_fill(self, order_id: str, fill_notional: Decimal) -> bool:
+        '''Handle a fill (partial or full) on a working order.
+
+        Moves capital from working_order_notional to position_notional.
+        Partial fills update remaining_notional; full fills remove the order.
+
+        Args:
+            order_id: ID of the filled order.
+            fill_notional: Quote capital filled (excluding fees).
+
+        Returns:
+            True if successful, False if order not found, wrong state,
+            or fill_notional exceeds remaining.
+        '''
+
+        if not isinstance(fill_notional, Decimal) or not fill_notional.is_finite():
+            msg = f'fill_notional must be a finite Decimal: {fill_notional}'
+            raise ValueError(msg)
+
+        if fill_notional <= _ZERO:
+            msg = f'fill_notional must be positive: {fill_notional}'
+            raise ValueError(msg)
+
+        with self._lock:
+            order = self._orders.get(order_id)
+
+            if order is None:
+                return False
+
+            if order.state != OrderLifecycleState.WORKING:
+                return False
+
+            if fill_notional > order.remaining_notional:
+                return False
+
+            fee_ratio = (
+                order.estimated_fees / order.notional
+                if order.notional > _ZERO
+                else _ZERO
+            )
+            fill_with_fees = fill_notional * (1 + fee_ratio)
+            new_remaining = order.remaining_notional - fill_notional
+
+            if new_remaining == _ZERO:
+                self._orders.pop(order_id)
+            else:
+                updated = TrackedOrder(
+                    order_id=order.order_id,
+                    reservation_id=order.reservation_id,
+                    strategy_id=order.strategy_id,
+                    notional=order.notional,
+                    estimated_fees=order.estimated_fees,
+                    remaining_notional=new_remaining,
+                    state=OrderLifecycleState.WORKING,
+                    created_at=order.created_at,
+                )
+                self._orders[order_id] = updated
+
+            self._state.working_order_notional -= fill_with_fees
+            self._state.position_notional += fill_with_fees
+
+            return True
+
+    def order_cancel(self, order_id: str) -> bool:
+        '''Handle cancellation of a working order.
+
+        Removes the order and releases remaining capital back to available.
+
+        Args:
+            order_id: ID of the canceled order.
+
+        Returns:
+            True if successful, False if order not found or not WORKING.
+        '''
+
+        with self._lock:
+            order = self._orders.get(order_id)
+
+            if order is None:
+                return False
+
+            if order.state != OrderLifecycleState.WORKING:
+                return False
+
+            self._orders.pop(order_id)
+            self._state.working_order_notional -= order.remaining_total
+
+            return True

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -15,6 +15,10 @@ from nexus.core.capital_controller.reservation import (
     Reservation,
     ReservationResult,
 )
+from nexus.core.capital_controller.tracked_order import (
+    OrderLifecycleState,
+    TrackedOrder,
+)
 from nexus.core.domain.capital_state import CapitalState
 
 __all__ = ['CapitalController']
@@ -37,6 +41,7 @@ class CapitalController:
         self._state = capital_state
         self._lock = threading.Lock()
         self._reservations: dict[str, Reservation] = {}
+        self._orders: dict[str, TrackedOrder] = {}
 
     def check_and_reserve(
         self,
@@ -183,4 +188,113 @@ class CapitalController:
                 return False
 
             self._state.reservation_notional -= reservation.total
+            return True
+
+    def send_order(self, reservation_id: str, order_id: str) -> bool:
+        '''Convert a reservation into an in-flight order.
+
+        Consumes the reservation and creates a TrackedOrder in IN_FLIGHT state.
+        Capital moves from reservation_notional to in_flight_order_notional.
+
+        Args:
+            reservation_id: ID of the reservation to consume.
+            order_id: Venue order ID for tracking.
+
+        Returns:
+            True if successful, False if reservation not found or expired.
+        '''
+
+        if not order_id or not order_id.strip():
+            msg = 'order_id must be a non-empty string'
+            raise ValueError(msg)
+
+        with self._lock:
+            self._purge_expired()
+
+            reservation = self._reservations.pop(reservation_id, None)
+
+            if reservation is None:
+                return False
+
+            now = datetime.now(tz=timezone.utc)
+            order = TrackedOrder(
+                order_id=order_id,
+                reservation_id=reservation_id,
+                strategy_id=reservation.strategy_id,
+                notional=reservation.notional,
+                estimated_fees=reservation.estimated_fees,
+                remaining_notional=reservation.notional,
+                state=OrderLifecycleState.IN_FLIGHT,
+                created_at=now,
+            )
+
+            self._orders[order_id] = order
+            self._state.reservation_notional -= reservation.total
+            self._state.in_flight_order_notional += reservation.total
+
+            return True
+
+    def order_ack(self, order_id: str) -> bool:
+        '''Acknowledge an in-flight order as working on venue.
+
+        Transitions the order from IN_FLIGHT to WORKING state.
+        Capital moves from in_flight_order_notional to working_order_notional.
+
+        Args:
+            order_id: ID of the order to acknowledge.
+
+        Returns:
+            True if successful, False if order not found or not IN_FLIGHT.
+        '''
+
+        with self._lock:
+            order = self._orders.get(order_id)
+
+            if order is None:
+                return False
+
+            if order.state != OrderLifecycleState.IN_FLIGHT:
+                return False
+
+            updated = TrackedOrder(
+                order_id=order.order_id,
+                reservation_id=order.reservation_id,
+                strategy_id=order.strategy_id,
+                notional=order.notional,
+                estimated_fees=order.estimated_fees,
+                remaining_notional=order.remaining_notional,
+                state=OrderLifecycleState.WORKING,
+                created_at=order.created_at,
+            )
+
+            self._orders[order_id] = updated
+            self._state.in_flight_order_notional -= order.total
+            self._state.working_order_notional += order.total
+
+            return True
+
+    def order_reject(self, order_id: str) -> bool:
+        '''Handle venue rejection of an in-flight order.
+
+        Removes the order and releases capital back to available.
+
+        Args:
+            order_id: ID of the rejected order.
+
+        Returns:
+            True if successful, False if order not found or not IN_FLIGHT.
+        '''
+
+        with self._lock:
+            order = self._orders.get(order_id)
+
+            if order is None:
+                return False
+
+            if order.state != OrderLifecycleState.IN_FLIGHT:
+                return False
+
+            self._orders.pop(order_id)
+            self._state.in_flight_order_notional -= order.total
+
             return True

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -348,16 +348,6 @@ class CapitalController:
                 fill_with_fees = pre_fill_remaining
                 self._orders.pop(order_id)
             else:
-                if order.notional == _ZERO:
-                    post_fill_remaining = order.estimated_fees
-                else:
-                    proportional_fee = (
-                        new_remaining * order.estimated_fees
-                    ) / order.notional
-                    post_fill_remaining = new_remaining + proportional_fee
-
-                fill_with_fees = pre_fill_remaining - post_fill_remaining
-
                 updated = TrackedOrder(
                     order_id=order.order_id,
                     reservation_id=order.reservation_id,
@@ -368,6 +358,7 @@ class CapitalController:
                     state=OrderLifecycleState.WORKING,
                     created_at=order.created_at,
                 )
+                fill_with_fees = pre_fill_remaining - updated.remaining_total
                 self._orders[order_id] = updated
 
             self._state.working_order_notional -= fill_with_fees

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -222,10 +222,6 @@ class CapitalController:
             if reservation is None:
                 return False
 
-            if reservation.is_expired(now):
-                self._state.reservation_notional -= reservation.total
-                return False
-
             order = TrackedOrder(
                 order_id=order_id,
                 reservation_id=reservation_id,

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -338,17 +338,23 @@ class CapitalController:
             if fill_notional > order.remaining_notional:
                 return False
 
-            fee_ratio = (
-                order.estimated_fees / order.notional
-                if order.notional > _ZERO
-                else _ZERO
-            )
-            fill_with_fees = fill_notional * (1 + fee_ratio)
+            pre_fill_remaining = order.remaining_total
             new_remaining = order.remaining_notional - fill_notional
 
             if new_remaining == _ZERO:
+                fill_with_fees = pre_fill_remaining
                 self._orders.pop(order_id)
             else:
+                if order.notional == _ZERO:
+                    post_fill_remaining = order.estimated_fees
+                else:
+                    proportional_fee = (
+                        new_remaining * order.estimated_fees
+                    ) / order.notional
+                    post_fill_remaining = new_remaining + proportional_fee
+
+                fill_with_fees = pre_fill_remaining - post_fill_remaining
+
                 updated = TrackedOrder(
                     order_id=order.order_id,
                     reservation_id=order.reservation_id,

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -307,11 +307,14 @@ class CapitalController:
         '''Handle a fill (partial or full) on a working order.
 
         Moves capital from working_order_notional to position_notional.
-        Partial fills update remaining_notional; full fills remove the order.
+        The moved amount includes the fill plus its proportional share of
+        estimated fees. Partial fills update remaining_notional; full fills
+        remove the order.
 
         Args:
             order_id: ID of the filled order.
-            fill_notional: Quote capital filled (excluding fees).
+            fill_notional: Quote capital filled (excluding fees). The
+                proportional fee component is computed and added.
 
         Returns:
             True if successful, False if order not found, wrong state,

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -163,8 +163,9 @@ class CapitalController:
 
             return ReservationResult(granted=True, reservation=reservation)
 
-    def _purge_expired(self) -> None:
-        now = datetime.now(tz=timezone.utc)
+    def _purge_expired(self, now: datetime | None = None) -> None:
+        if now is None:
+            now = datetime.now(tz=timezone.utc)
         expired = [rid for rid, r in self._reservations.items() if r.is_expired(now)]
 
         for rid in expired:
@@ -209,7 +210,8 @@ class CapitalController:
             raise ValueError(msg)
 
         with self._lock:
-            self._purge_expired()
+            now = datetime.now(tz=timezone.utc)
+            self._purge_expired(now)
 
             if order_id in self._orders:
                 msg = f'order_id already tracked: {order_id}'
@@ -220,7 +222,10 @@ class CapitalController:
             if reservation is None:
                 return False
 
-            now = datetime.now(tz=timezone.utc)
+            if reservation.is_expired(now):
+                self._state.reservation_notional -= reservation.total
+                return False
+
             order = TrackedOrder(
                 order_id=order_id,
                 reservation_id=reservation_id,

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -211,6 +211,10 @@ class CapitalController:
         with self._lock:
             self._purge_expired()
 
+            if order_id in self._orders:
+                msg = f'order_id already tracked: {order_id}'
+                raise ValueError(msg)
+
             reservation = self._reservations.pop(reservation_id, None)
 
             if reservation is None:

--- a/nexus/core/capital_controller/tracked_order.py
+++ b/nexus/core/capital_controller/tracked_order.py
@@ -125,6 +125,6 @@ class TrackedOrder:
 
         if self.notional == _ZERO:
             return _ZERO
-        
+
         fee_ratio = self.estimated_fees / self.notional
         return self.remaining_notional * (1 + fee_ratio)

--- a/nexus/core/capital_controller/tracked_order.py
+++ b/nexus/core/capital_controller/tracked_order.py
@@ -124,7 +124,7 @@ class TrackedOrder:
         '''Remaining quote capital including proportional fees.'''
 
         if self.notional == _ZERO:
-            return _ZERO
+            return self.estimated_fees
 
         fee_ratio = self.estimated_fees / self.notional
         return self.remaining_notional * (1 + fee_ratio)

--- a/nexus/core/capital_controller/tracked_order.py
+++ b/nexus/core/capital_controller/tracked_order.py
@@ -1,0 +1,130 @@
+'''Tracked order types for capital lifecycle state machine.
+
+An order moves through IN_FLIGHT → WORKING states while consuming
+capital from the corresponding CapitalState buckets.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+
+__all__ = ['OrderLifecycleState', 'TrackedOrder']
+
+_ZERO = Decimal(0)
+
+
+class OrderLifecycleState(Enum):
+    '''Order state in the capital lifecycle.
+
+    IN_FLIGHT means the order was sent but venue has not acknowledged.
+    WORKING means the venue acknowledged and the order is resting.
+    Terminal states (filled, rejected, canceled) remove the order
+    from tracking entirely.
+    '''
+
+    IN_FLIGHT = 'IN_FLIGHT'
+    WORKING = 'WORKING'
+
+
+@dataclass(frozen=True)
+class TrackedOrder:
+    '''An immutable record of an order in the capital lifecycle.
+
+    Args:
+        order_id: Venue order identifier.
+        reservation_id: Original reservation this order consumed.
+        strategy_id: Which strategy placed the order.
+        notional: Quote capital locked for this order.
+        estimated_fees: Quote capital locked for estimated fees.
+        remaining_notional: Quote capital not yet filled.
+        state: Current lifecycle state (IN_FLIGHT or WORKING).
+        created_at: When this order was sent.
+    '''
+
+    order_id: str
+    reservation_id: str
+    strategy_id: str
+    notional: Decimal
+    estimated_fees: Decimal
+    remaining_notional: Decimal
+    state: OrderLifecycleState
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if not isinstance(self.order_id, str) or not self.order_id.strip():
+            msg = 'TrackedOrder.order_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.reservation_id, str) or not self.reservation_id.strip():
+            msg = 'TrackedOrder.reservation_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.strategy_id, str) or not self.strategy_id.strip():
+            msg = 'TrackedOrder.strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if (
+            not isinstance(self.notional, Decimal)
+            or not self.notional.is_finite()
+            or self.notional < _ZERO
+        ):
+            msg = 'TrackedOrder.notional must be a finite non-negative Decimal'
+            raise ValueError(msg)
+
+        if (
+            not isinstance(self.estimated_fees, Decimal)
+            or not self.estimated_fees.is_finite()
+            or self.estimated_fees < _ZERO
+        ):
+            msg = 'TrackedOrder.estimated_fees must be a finite non-negative Decimal'
+            raise ValueError(msg)
+
+        if (
+            not isinstance(self.remaining_notional, Decimal)
+            or not self.remaining_notional.is_finite()
+            or self.remaining_notional < _ZERO
+        ):
+            msg = (
+                'TrackedOrder.remaining_notional must be a finite non-negative Decimal'
+            )
+            raise ValueError(msg)
+
+        if self.remaining_notional > self.notional:
+            msg = 'TrackedOrder.remaining_notional cannot exceed notional'
+            raise ValueError(msg)
+
+        if not isinstance(self.state, OrderLifecycleState):
+            msg = 'TrackedOrder.state must be an OrderLifecycleState'
+            raise ValueError(msg)
+
+        if not isinstance(self.created_at, datetime):
+            msg = 'TrackedOrder.created_at must be a datetime'
+            raise ValueError(msg)
+
+        if (
+            self.created_at.tzinfo is None
+            or self.created_at.tzinfo.utcoffset(self.created_at) is None
+        ):
+            msg = 'TrackedOrder.created_at must be timezone-aware'
+            raise ValueError(msg)
+
+    @property
+    def total(self) -> Decimal:
+        '''Total quote capital locked by this order.'''
+
+        return self.notional + self.estimated_fees
+
+    @property
+    def remaining_total(self) -> Decimal:
+        '''Remaining quote capital including proportional fees.'''
+
+        if self.notional == _ZERO:
+            return _ZERO
+        
+        fee_ratio = self.estimated_fees / self.notional
+        return self.remaining_notional * (1 + fee_ratio)

--- a/nexus/core/capital_controller/tracked_order.py
+++ b/nexus/core/capital_controller/tracked_order.py
@@ -126,5 +126,7 @@ class TrackedOrder:
         if self.notional == _ZERO:
             return self.estimated_fees
 
-        fee_ratio = self.estimated_fees / self.notional
-        return self.remaining_notional * (1 + fee_ratio)
+        proportional_fee = (
+            self.remaining_notional * self.estimated_fees
+        ) / self.notional
+        return self.remaining_notional + proportional_fee

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.6.0"
+version = "0.7.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -538,6 +538,37 @@ class TestLifecycleCancelPath:
         assert ctrl._state.available == initial_available
 
 
+class TestNonTerminatingFeeRatio:
+    def test_multi_fill_no_residual(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='3', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        ctrl.order_fill('ORD-001', Decimal('1'))
+        ctrl.order_fill('ORD-001', Decimal('1'))
+        ctrl.order_fill('ORD-001', Decimal('1'))
+
+        assert ctrl._state.working_order_notional == _ZERO
+        assert ctrl._state.position_notional == Decimal('4')
+
+    def test_partial_fill_then_cancel_no_residual(self) -> None:
+        ctrl = _make_controller()
+        initial_available = ctrl._state.available
+        result = _reserve(ctrl, notional='3', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        ctrl.order_fill('ORD-001', Decimal('1'))
+        ctrl.order_cancel('ORD-001')
+
+        assert ctrl._state.working_order_notional == _ZERO
+        position_plus_available = ctrl._state.position_notional + ctrl._state.available
+        assert position_plus_available == initial_available
+
+
 class TestLifecycleConcurrency:
     def test_no_double_counting_under_contention(self) -> None:
         ctrl = _make_controller()

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -308,6 +308,17 @@ class TestSendOrder:
         with pytest.raises(ValueError, match='order_id'):
             ctrl.send_order(result.reservation.reservation_id, '')
 
+    def test_send_order_duplicate_order_id_rejected(self) -> None:
+        ctrl = _make_controller()
+        res1 = _reserve(ctrl, notional='100', fees='1')
+        res2 = _reserve(ctrl, notional='100', fees='1')
+        assert res1.reservation is not None
+        assert res2.reservation is not None
+
+        ctrl.send_order(res1.reservation.reservation_id, 'ORD-DUP')
+        with pytest.raises(ValueError, match='already tracked'):
+            ctrl.send_order(res2.reservation.reservation_id, 'ORD-DUP')
+
 
 class TestOrderAck:
     def test_order_ack_success(self) -> None:
@@ -530,24 +541,28 @@ class TestLifecycleCancelPath:
 class TestLifecycleConcurrency:
     def test_no_double_counting_under_contention(self) -> None:
         ctrl = _make_controller()
-        results: list[bool] = []
+        successes: list[bool] = []
+        errors: list[Exception] = []
         barrier = threading.Barrier(10)
 
         def lifecycle_race(idx: int) -> None:
-            barrier.wait()
-            res = ctrl.check_and_reserve(
-                strategy_id='strat_a',
-                order_notional=Decimal('500'),
-                estimated_fees=Decimal('5'),
-                strategy_budget=_POOL,
-                strategy_deployed=_ZERO,
-            )
-            if res.granted and res.reservation:
-                sent = ctrl.send_order(res.reservation.reservation_id, f'ORD-{idx}')
-                if sent:
-                    ctrl.order_ack(f'ORD-{idx}')
-                    ctrl.order_fill(f'ORD-{idx}', Decimal('500'))
-                    results.append(True)
+            try:
+                barrier.wait()
+                res = ctrl.check_and_reserve(
+                    strategy_id='strat_a',
+                    order_notional=Decimal('500'),
+                    estimated_fees=Decimal('5'),
+                    strategy_budget=_POOL,
+                    strategy_deployed=_ZERO,
+                )
+                if res.granted and res.reservation:
+                    sent = ctrl.send_order(res.reservation.reservation_id, f'ORD-{idx}')
+                    if sent:
+                        ctrl.order_ack(f'ORD-{idx}')
+                        ctrl.order_fill(f'ORD-{idx}', Decimal('500'))
+                        successes.append(True)
+            except Exception as e:
+                errors.append(e)
 
         threads = [
             threading.Thread(target=lifecycle_race, args=(i,)) for i in range(10)
@@ -557,12 +572,13 @@ class TestLifecycleConcurrency:
         for t in threads:
             t.join()
 
-        total_position = ctrl._state.position_notional
-        assert total_position <= _POOL
-        total_buckets = (
+        assert not errors, f'Thread errors: {errors}'
+        assert len(successes) >= 1, 'At least one lifecycle must succeed'
+
+        total_committed = (
             ctrl._state.reservation_notional
             + ctrl._state.in_flight_order_notional
             + ctrl._state.working_order_notional
             + ctrl._state.position_notional
         )
-        assert total_buckets == total_position
+        assert ctrl._state.available + total_committed == _POOL

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -589,8 +589,14 @@ class TestLifecycleConcurrency:
                 if res.granted and res.reservation:
                     sent = ctrl.send_order(res.reservation.reservation_id, f'ORD-{idx}')
                     if sent:
-                        ctrl.order_ack(f'ORD-{idx}')
-                        ctrl.order_fill(f'ORD-{idx}', Decimal('500'))
+                        acked = ctrl.order_ack(f'ORD-{idx}')
+                        filled = ctrl.order_fill(f'ORD-{idx}', Decimal('500'))
+                        if not acked or not filled:
+                            msg = (
+                                f'Lifecycle failure ORD-{idx}: '
+                                f'acked={acked}, filled={filled}'
+                            )
+                            raise AssertionError(msg)
                         successes.append(True)
             except Exception as e:
                 errors.append(e)

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -1,9 +1,9 @@
-'''Verify CapitalController check-and-reserve and release under lock.'''
+'''Verify CapitalController check-and-reserve, release, and lifecycle transitions.'''
 
 from __future__ import annotations
 
 import threading
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -14,6 +14,7 @@ from nexus.core.capital_controller.capital_controller import (
     MAX_CAPITAL_UTILIZATION_PCT,
 )
 from nexus.core.capital_controller.reservation import Reservation, ReservationResult
+from nexus.core.capital_controller.tracked_order import OrderLifecycleState
 from nexus.core.domain.capital_state import CapitalState
 
 _POOL = Decimal('10000')
@@ -260,3 +261,308 @@ class TestInputValidation:
                 strategy_deployed=Decimal('0'),
                 ttl_seconds=0,
             )
+
+
+class TestSendOrder:
+    def test_send_order_success(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+
+        sent = ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        assert sent is True
+        assert ctrl._state.reservation_notional == _ZERO
+        assert ctrl._state.in_flight_order_notional == Decimal('101')
+        assert 'ORD-001' in ctrl._orders
+        assert ctrl._orders['ORD-001'].state == OrderLifecycleState.IN_FLIGHT
+
+    def test_send_order_reservation_not_found(self) -> None:
+        ctrl = _make_controller()
+        sent = ctrl.send_order('nonexistent', 'ORD-001')
+        assert sent is False
+        assert ctrl._state.in_flight_order_notional == _ZERO
+
+    def test_send_order_expired_reservation(self) -> None:
+        ctrl = _make_controller()
+        past = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        expired = Reservation(
+            reservation_id='expired_001',
+            strategy_id='strat_a',
+            notional=Decimal('100'),
+            estimated_fees=Decimal('1'),
+            created_at=past,
+            expires_at=past + timedelta(seconds=1),
+        )
+        ctrl._reservations['expired_001'] = expired
+        ctrl._state.reservation_notional = Decimal('101')
+
+        sent = ctrl.send_order('expired_001', 'ORD-001')
+        assert sent is False
+        assert ctrl._state.reservation_notional == _ZERO
+        assert ctrl._state.in_flight_order_notional == _ZERO
+
+    def test_send_order_empty_order_id_rejected(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl)
+        assert result.reservation is not None
+        with pytest.raises(ValueError, match='order_id'):
+            ctrl.send_order(result.reservation.reservation_id, '')
+
+
+class TestOrderAck:
+    def test_order_ack_success(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+
+        acked = ctrl.order_ack('ORD-001')
+        assert acked is True
+        assert ctrl._state.in_flight_order_notional == _ZERO
+        assert ctrl._state.working_order_notional == Decimal('101')
+        assert ctrl._orders['ORD-001'].state == OrderLifecycleState.WORKING
+
+    def test_order_ack_not_found(self) -> None:
+        ctrl = _make_controller()
+        acked = ctrl.order_ack('nonexistent')
+        assert acked is False
+
+    def test_order_ack_wrong_state(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        acked_again = ctrl.order_ack('ORD-001')
+        assert acked_again is False
+
+
+class TestOrderReject:
+    def test_order_reject_success(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        assert ctrl._state.in_flight_order_notional == Decimal('101')
+
+        rejected = ctrl.order_reject('ORD-001')
+        assert rejected is True
+        assert ctrl._state.in_flight_order_notional == _ZERO
+        assert 'ORD-001' not in ctrl._orders
+
+    def test_order_reject_not_found(self) -> None:
+        ctrl = _make_controller()
+        rejected = ctrl.order_reject('nonexistent')
+        assert rejected is False
+
+    def test_order_reject_wrong_state(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        rejected = ctrl.order_reject('ORD-001')
+        assert rejected is False
+
+
+class TestOrderFill:
+    def test_order_fill_full(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        filled = ctrl.order_fill('ORD-001', Decimal('100'))
+        assert filled is True
+        assert ctrl._state.working_order_notional == _ZERO
+        assert ctrl._state.position_notional == Decimal('101')
+        assert 'ORD-001' not in ctrl._orders
+
+    def test_order_fill_partial(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='1000', fees='10')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        filled = ctrl.order_fill('ORD-001', Decimal('400'))
+        assert filled is True
+        assert ctrl._state.working_order_notional == Decimal('606')
+        assert ctrl._state.position_notional == Decimal('404')
+        assert 'ORD-001' in ctrl._orders
+        assert ctrl._orders['ORD-001'].remaining_notional == Decimal('600')
+
+    def test_order_fill_overfill_rejected(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        filled = ctrl.order_fill('ORD-001', Decimal('200'))
+        assert filled is False
+        assert ctrl._state.working_order_notional == Decimal('101')
+        assert ctrl._state.position_notional == _ZERO
+
+    def test_order_fill_not_found(self) -> None:
+        ctrl = _make_controller()
+        filled = ctrl.order_fill('nonexistent', Decimal('100'))
+        assert filled is False
+
+    def test_order_fill_wrong_state(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+
+        filled = ctrl.order_fill('ORD-001', Decimal('100'))
+        assert filled is False
+
+    def test_order_fill_invalid_notional(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        with pytest.raises(ValueError, match='positive'):
+            ctrl.order_fill('ORD-001', Decimal('0'))
+
+
+class TestOrderCancel:
+    def test_order_cancel_success(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        canceled = ctrl.order_cancel('ORD-001')
+        assert canceled is True
+        assert ctrl._state.working_order_notional == _ZERO
+        assert 'ORD-001' not in ctrl._orders
+
+    def test_order_cancel_after_partial_fill(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='1000', fees='10')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+        ctrl.order_fill('ORD-001', Decimal('400'))
+
+        canceled = ctrl.order_cancel('ORD-001')
+        assert canceled is True
+        assert ctrl._state.working_order_notional == _ZERO
+        assert ctrl._state.position_notional == Decimal('404')
+
+    def test_order_cancel_not_found(self) -> None:
+        ctrl = _make_controller()
+        canceled = ctrl.order_cancel('nonexistent')
+        assert canceled is False
+
+    def test_order_cancel_wrong_state(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+
+        canceled = ctrl.order_cancel('ORD-001')
+        assert canceled is False
+
+
+class TestLifecycleHappyPath:
+    def test_reservation_to_position(self) -> None:
+        ctrl = _make_controller()
+        initial_available = ctrl._state.available
+
+        result = _reserve(ctrl, notional='500', fees='5')
+        assert result.reservation is not None
+        assert ctrl._state.reservation_notional == Decimal('505')
+
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        assert ctrl._state.reservation_notional == _ZERO
+        assert ctrl._state.in_flight_order_notional == Decimal('505')
+
+        ctrl.order_ack('ORD-001')
+        assert ctrl._state.in_flight_order_notional == _ZERO
+        assert ctrl._state.working_order_notional == Decimal('505')
+
+        ctrl.order_fill('ORD-001', Decimal('500'))
+        assert ctrl._state.working_order_notional == _ZERO
+        assert ctrl._state.position_notional == Decimal('505')
+        assert ctrl._state.available == initial_available - Decimal('505')
+
+
+class TestLifecycleRejectPath:
+    def test_reservation_to_reject(self) -> None:
+        ctrl = _make_controller()
+        initial_available = ctrl._state.available
+
+        result = _reserve(ctrl, notional='500', fees='5')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        assert ctrl._state.available == initial_available - Decimal('505')
+
+        ctrl.order_reject('ORD-001')
+        assert ctrl._state.in_flight_order_notional == _ZERO
+        assert ctrl._state.available == initial_available
+
+
+class TestLifecycleCancelPath:
+    def test_reservation_to_cancel(self) -> None:
+        ctrl = _make_controller()
+        initial_available = ctrl._state.available
+
+        result = _reserve(ctrl, notional='500', fees='5')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+        assert ctrl._state.available == initial_available - Decimal('505')
+
+        ctrl.order_cancel('ORD-001')
+        assert ctrl._state.working_order_notional == _ZERO
+        assert ctrl._state.available == initial_available
+
+
+class TestLifecycleConcurrency:
+    def test_no_double_counting_under_contention(self) -> None:
+        ctrl = _make_controller()
+        results: list[bool] = []
+        barrier = threading.Barrier(10)
+
+        def lifecycle_race(idx: int) -> None:
+            barrier.wait()
+            res = ctrl.check_and_reserve(
+                strategy_id='strat_a',
+                order_notional=Decimal('500'),
+                estimated_fees=Decimal('5'),
+                strategy_budget=_POOL,
+                strategy_deployed=_ZERO,
+            )
+            if res.granted and res.reservation:
+                sent = ctrl.send_order(res.reservation.reservation_id, f'ORD-{idx}')
+                if sent:
+                    ctrl.order_ack(f'ORD-{idx}')
+                    ctrl.order_fill(f'ORD-{idx}', Decimal('500'))
+                    results.append(True)
+
+        threads = [
+            threading.Thread(target=lifecycle_race, args=(i,)) for i in range(10)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        total_position = ctrl._state.position_notional
+        assert total_position <= _POOL
+        total_buckets = (
+            ctrl._state.reservation_notional
+            + ctrl._state.in_flight_order_notional
+            + ctrl._state.working_order_notional
+            + ctrl._state.position_notional
+        )
+        assert total_buckets == total_position

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -578,7 +578,7 @@ class TestLifecycleConcurrency:
 
         def lifecycle_race(idx: int) -> None:
             try:
-                barrier.wait()
+                barrier.wait(timeout=5)
                 res = ctrl.check_and_reserve(
                     strategy_id='strat_a',
                     order_notional=Decimal('500'),
@@ -607,7 +607,9 @@ class TestLifecycleConcurrency:
         for t in threads:
             t.start()
         for t in threads:
-            t.join()
+            t.join(timeout=10)
+        for t in threads:
+            assert not t.is_alive(), 'Thread did not finish within timeout'
 
         assert not errors, f'Thread errors: {errors}'
         assert len(successes) >= 1, 'At least one lifecycle must succeed'

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -198,8 +198,6 @@ class TestConcurrency:
 
 class TestExpiredPurge:
     def test_expired_reservations_purged_on_reserve(self) -> None:
-        from datetime import datetime, timezone
-
         past = datetime(2020, 1, 1, tzinfo=timezone.utc)
 
         ctrl = _make_controller()

--- a/tests/test_tracked_order.py
+++ b/tests/test_tracked_order.py
@@ -96,6 +96,14 @@ class TestRemainingTotalProperty:
         )
         assert order.remaining_total == Decimal('10')
 
+    def test_remaining_total_non_terminating_ratio(self) -> None:
+        order = _make_order(
+            notional=Decimal('3'),
+            estimated_fees=Decimal('1'),
+            remaining_notional=Decimal('3'),
+        )
+        assert order.remaining_total == order.total
+
 
 class TestImmutability:
     def test_frozen_dataclass(self) -> None:

--- a/tests/test_tracked_order.py
+++ b/tests/test_tracked_order.py
@@ -1,0 +1,150 @@
+'''Verify TrackedOrder dataclass construction, validation, and properties.'''
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from nexus.core.capital_controller.tracked_order import (
+    OrderLifecycleState,
+    TrackedOrder,
+)
+
+_NOW = datetime.now(tz=timezone.utc)
+_ZERO = Decimal(0)
+
+
+def _make_order(**overrides: Any) -> TrackedOrder:
+    defaults: dict[str, Any] = {
+        'order_id': 'ORD-001',
+        'reservation_id': 'RES-001',
+        'strategy_id': 'strat_a',
+        'notional': Decimal('1000'),
+        'estimated_fees': Decimal('10'),
+        'remaining_notional': Decimal('1000'),
+        'state': OrderLifecycleState.IN_FLIGHT,
+        'created_at': _NOW,
+    }
+    defaults.update(overrides)
+    return TrackedOrder(**defaults)
+
+
+class TestConstruction:
+    def test_valid_order(self) -> None:
+        order = _make_order()
+        assert order.order_id == 'ORD-001'
+        assert order.reservation_id == 'RES-001'
+        assert order.strategy_id == 'strat_a'
+        assert order.notional == Decimal('1000')
+        assert order.estimated_fees == Decimal('10')
+        assert order.remaining_notional == Decimal('1000')
+        assert order.state == OrderLifecycleState.IN_FLIGHT
+        assert order.created_at == _NOW
+
+    def test_working_state(self) -> None:
+        order = _make_order(state=OrderLifecycleState.WORKING)
+        assert order.state == OrderLifecycleState.WORKING
+
+
+class TestTotalProperty:
+    def test_total_includes_fees(self) -> None:
+        order = _make_order(notional=Decimal('1000'), estimated_fees=Decimal('10'))
+        assert order.total == Decimal('1010')
+
+    def test_total_zero_fees(self) -> None:
+        order = _make_order(
+            notional=Decimal('500'), estimated_fees=_ZERO, remaining_notional=Decimal('500')
+        )
+        assert order.total == Decimal('500')
+
+
+class TestRemainingTotalProperty:
+    def test_remaining_total_full(self) -> None:
+        order = _make_order(
+            notional=Decimal('1000'),
+            estimated_fees=Decimal('10'),
+            remaining_notional=Decimal('1000'),
+        )
+        assert order.remaining_total == Decimal('1010')
+
+    def test_remaining_total_partial(self) -> None:
+        order = _make_order(
+            notional=Decimal('1000'),
+            estimated_fees=Decimal('10'),
+            remaining_notional=Decimal('500'),
+        )
+        assert order.remaining_total == Decimal('505')
+
+    def test_remaining_total_zero_notional(self) -> None:
+        order = _make_order(
+            notional=_ZERO,
+            estimated_fees=_ZERO,
+            remaining_notional=_ZERO,
+        )
+        assert order.remaining_total == _ZERO
+
+
+class TestImmutability:
+    def test_frozen_dataclass(self) -> None:
+        order = _make_order()
+        with pytest.raises(AttributeError):
+            order.notional = Decimal('2000')  # type: ignore[misc]
+
+    def test_frozen_state(self) -> None:
+        order = _make_order()
+        with pytest.raises(AttributeError):
+            order.state = OrderLifecycleState.WORKING  # type: ignore[misc]
+
+
+class TestValidation:
+    def test_empty_order_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='order_id'):
+            _make_order(order_id='')
+
+    def test_whitespace_order_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='order_id'):
+            _make_order(order_id='   ')
+
+    def test_empty_reservation_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='reservation_id'):
+            _make_order(reservation_id='')
+
+    def test_empty_strategy_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='strategy_id'):
+            _make_order(strategy_id='')
+
+    def test_negative_notional_rejected(self) -> None:
+        with pytest.raises(ValueError, match='notional'):
+            _make_order(notional=Decimal('-1'))
+
+    def test_nan_notional_rejected(self) -> None:
+        with pytest.raises(ValueError, match='notional'):
+            _make_order(notional=Decimal('NaN'))
+
+    def test_negative_fees_rejected(self) -> None:
+        with pytest.raises(ValueError, match='estimated_fees'):
+            _make_order(estimated_fees=Decimal('-1'))
+
+    def test_nan_fees_rejected(self) -> None:
+        with pytest.raises(ValueError, match='estimated_fees'):
+            _make_order(estimated_fees=Decimal('NaN'))
+
+    def test_negative_remaining_rejected(self) -> None:
+        with pytest.raises(ValueError, match='remaining_notional'):
+            _make_order(remaining_notional=Decimal('-1'))
+
+    def test_remaining_exceeds_notional_rejected(self) -> None:
+        with pytest.raises(ValueError, match='remaining_notional cannot exceed'):
+            _make_order(notional=Decimal('100'), remaining_notional=Decimal('200'))
+
+    def test_invalid_state_rejected(self) -> None:
+        with pytest.raises(ValueError, match='state'):
+            _make_order(state='INVALID')
+
+    def test_naive_datetime_rejected(self) -> None:
+        naive = datetime(2024, 1, 1)
+        with pytest.raises(ValueError, match='timezone-aware'):
+            _make_order(created_at=naive)

--- a/tests/test_tracked_order.py
+++ b/tests/test_tracked_order.py
@@ -56,7 +56,9 @@ class TestTotalProperty:
 
     def test_total_zero_fees(self) -> None:
         order = _make_order(
-            notional=Decimal('500'), estimated_fees=_ZERO, remaining_notional=Decimal('500')
+            notional=Decimal('500'),
+            estimated_fees=_ZERO,
+            remaining_notional=Decimal('500'),
         )
         assert order.total == Decimal('500')
 
@@ -78,13 +80,21 @@ class TestRemainingTotalProperty:
         )
         assert order.remaining_total == Decimal('505')
 
-    def test_remaining_total_zero_notional(self) -> None:
+    def test_remaining_total_zero_notional_zero_fees(self) -> None:
         order = _make_order(
             notional=_ZERO,
             estimated_fees=_ZERO,
             remaining_notional=_ZERO,
         )
         assert order.remaining_total == _ZERO
+
+    def test_remaining_total_zero_notional_with_fees(self) -> None:
+        order = _make_order(
+            notional=_ZERO,
+            estimated_fees=Decimal('10'),
+            remaining_notional=_ZERO,
+        )
+        assert order.remaining_total == Decimal('10')
 
 
 class TestImmutability:


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements Phase 2.3 (Capital lifecycle state machine) from RFC-3001. Adds order tracking through the capital lifecycle with atomic state transitions under lock.

**New files:**
- `tracked_order.py` — `OrderLifecycleState` enum (IN_FLIGHT, WORKING) and frozen `TrackedOrder` dataclass with `total` and `remaining_total` properties

**Modified files:**
- `capital_controller.py` — adds 5 lifecycle transition methods and `_orders` tracking dict
- `__init__.py` — re-exports all capital_controller types

**Key design decisions:**
- All transitions under existing `threading.Lock` — single lock guards CapitalState + reservations + orders
- `TrackedOrder` is frozen (immutable) — state transitions create new instances
- `order_id` provided by caller (Praxis Connector) — CapitalController does not generate order IDs
- Partial fills track `remaining_notional` with proportional fee allocation
- Terminal states (filled, rejected, canceled) remove order from tracking entirely

**Lifecycle transitions:**
- `send_order()` — reservation → in_flight (consumes reservation)
- `order_ack()` — in_flight → working (venue acknowledged)
- `order_reject()` — in_flight → released (venue rejected)
- `order_fill()` — working → position (partial/full fills)
- `order_cancel()` — working → released (remaining capital returned)

**Test coverage:** 45 new tests (281 total), including lifecycle happy/reject/cancel paths and concurrency contention test.

**Version:** 0.6.0 → 0.7.0

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (281 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable