### PR TITLE
feat: 2.4 reservation TTL expiry logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.8.0 on 20th of March, 2026
+
+- Add warning log on reservation TTL expiry with reservation_id, strategy_id, total, held duration
+- Add 2 tests for expiry logging (78 total)
+
 ## v0.7.0 on 20th of March, 2026
 
 - Add [`tracked_order.py`](nexus/core/capital_controller/tracked_order.py) with `OrderLifecycleState` enum (IN_FLIGHT, WORKING) and frozen `TrackedOrder` dataclass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.8.0 on 20th of March, 2026
 
 - Add warning log on reservation TTL expiry with reservation_id, strategy_id, total, held duration
-- Add 2 tests for expiry logging (78 total)
+- Add 2 tests for expiry logging (288 total)
 
 ## v0.7.0 on 20th of March, 2026
 

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -6,6 +6,7 @@ TOCTOU races when multiple strategies compete for the same pool.
 
 from __future__ import annotations
 
+import logging
 import threading
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -22,6 +23,8 @@ from nexus.core.capital_controller.tracked_order import (
 from nexus.core.domain.capital_state import CapitalState
 
 __all__ = ['CapitalController']
+
+_logger = logging.getLogger(__name__)
 
 MAX_ALLOCATION_PER_TRADE_PCT = Decimal('0.15')
 MAX_CAPITAL_UTILIZATION_PCT = Decimal('0.80')
@@ -171,6 +174,14 @@ class CapitalController:
         for rid in expired:
             reservation = self._reservations.pop(rid)
             self._state.reservation_notional -= reservation.total
+            held_seconds = (now - reservation.created_at).total_seconds()
+            _logger.warning(
+                'Reservation expired: id=%s strategy=%s total=%s held=%.1fs',
+                reservation.reservation_id,
+                reservation.strategy_id,
+                reservation.total,
+                held_seconds,
+            )
 
     def release_reservation(self, reservation_id: str) -> bool:
         '''Release a reservation and return its capital to the available pool.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.7.0"
+version = "0.8.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -215,6 +215,56 @@ class TestExpiredPurge:
         _reserve(ctrl, notional='100', fees='1', budget=str(_POOL))
         assert ctrl._state.reservation_notional == Decimal('101')
 
+    def test_expired_reservation_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        past = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+        ctrl = _make_controller()
+        expired_res = Reservation(
+            reservation_id='expired_002',
+            strategy_id='strat_b',
+            notional=Decimal('200'),
+            estimated_fees=Decimal('2'),
+            created_at=past,
+            expires_at=past + timedelta(seconds=30),
+        )
+        ctrl._reservations['expired_002'] = expired_res
+        ctrl._state.reservation_notional = Decimal('202')
+
+        with caplog.at_level('WARNING'):
+            _reserve(ctrl)
+
+        assert 'Reservation expired' in caplog.text
+        assert 'expired_002' in caplog.text
+        assert 'strat_b' in caplog.text
+        assert '202' in caplog.text
+
+    def test_multiple_expired_reservations_log_each(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        past = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+        ctrl = _make_controller()
+        for i in range(3):
+            res = Reservation(
+                reservation_id=f'expired_{i}',
+                strategy_id=f'strat_{i}',
+                notional=Decimal('100'),
+                estimated_fees=Decimal('1'),
+                created_at=past,
+                expires_at=past + timedelta(seconds=30),
+            )
+            ctrl._reservations[f'expired_{i}'] = res
+        ctrl._state.reservation_notional = Decimal('303')
+
+        with caplog.at_level('WARNING'):
+            _reserve(ctrl)
+
+        assert caplog.text.count('Reservation expired') == 3
+        for i in range(3):
+            assert f'expired_{i}' in caplog.text
+
 
 class TestInputValidation:
     def test_nan_notional_rejected(self) -> None:

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -238,7 +238,8 @@ class TestExpiredPurge:
         assert 'Reservation expired' in caplog.text
         assert 'expired_002' in caplog.text
         assert 'strat_b' in caplog.text
-        assert '202' in caplog.text
+        assert 'total=202' in caplog.text
+        assert 'held=' in caplog.text
 
     def test_multiple_expired_reservations_log_each(
         self, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Adds warning log when reservations expire in `_purge_expired()`. Log includes reservation_id, strategy_id, total, and held duration. Implements RFC §Alert on expiry requirement for Phase 2.4. Adds 2 tests for expiry logging using pytest `caplog` fixture. Bumps to v0.8.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (288 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable