### PR TITLE
feat: 2.5 fee reconciliation (estimated vs actual)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.9.0 on 20th of March, 2026
+
+- Add fee reconciliation to `order_fill()` — actual vs estimated fees reconciled via `fee_reserve`
+- Extend `order_fill(order_id, fill_notional, actual_fee)` signature
+- Position receives actual cost (`fill_notional + actual_fee`), not estimated
+- Fail fill if `fee_reserve` insufficient for deficit
+- Add 7 tests for fee reconciliation (295 total)
+
 ## v0.8.0 on 20th of March, 2026
 
 - Add warning log on reservation TTL expiry with reservation_id, strategy_id, total, held duration

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -315,22 +315,22 @@ class CapitalController:
 
             return True
 
-    def order_fill(self, order_id: str, fill_notional: Decimal) -> bool:
+    def order_fill(
+        self, order_id: str, fill_notional: Decimal, actual_fee: Decimal
+    ) -> bool:
         '''Handle a fill (partial or full) on a working order.
 
         Moves capital from working_order_notional to position_notional.
-        The moved amount includes the fill plus its proportional share of
-        estimated fees. Partial fills update remaining_notional; full fills
-        remove the order.
+        Reconciles actual fees against estimated fees via fee_reserve.
 
         Args:
             order_id: ID of the filled order.
-            fill_notional: Quote capital filled (excluding fees). The
-                proportional fee component is computed and added.
+            fill_notional: Quote capital filled (excluding fees).
+            actual_fee: Actual fee charged by venue for this fill.
 
         Returns:
             True if successful, False if order not found, wrong state,
-            or fill_notional exceeds remaining.
+            fill_notional exceeds remaining, or fee_reserve insufficient.
         '''
 
         if not isinstance(fill_notional, Decimal) or not fill_notional.is_finite():
@@ -339,6 +339,14 @@ class CapitalController:
 
         if fill_notional <= _ZERO:
             msg = f'fill_notional must be positive: {fill_notional}'
+            raise ValueError(msg)
+
+        if not isinstance(actual_fee, Decimal) or not actual_fee.is_finite():
+            msg = f'actual_fee must be a finite Decimal: {actual_fee}'
+            raise ValueError(msg)
+
+        if actual_fee < _ZERO:
+            msg = f'actual_fee must be non-negative: {actual_fee}'
             raise ValueError(msg)
 
         with self._lock:
@@ -357,8 +365,7 @@ class CapitalController:
             new_remaining = order.remaining_notional - fill_notional
 
             if new_remaining == _ZERO:
-                fill_with_fees = pre_fill_remaining
-                self._orders.pop(order_id)
+                proportional_estimated = pre_fill_remaining - fill_notional
             else:
                 updated = TrackedOrder(
                     order_id=order.order_id,
@@ -370,11 +377,22 @@ class CapitalController:
                     state=OrderLifecycleState.WORKING,
                     created_at=order.created_at,
                 )
-                fill_with_fees = pre_fill_remaining - updated.remaining_total
+                proportional_estimated = pre_fill_remaining - fill_notional - updated.remaining_total
+
+            fee_delta = proportional_estimated - actual_fee
+
+            if fee_delta < _ZERO and self._state.fee_reserve < -fee_delta:
+                return False
+
+            if new_remaining == _ZERO:
+                self._orders.pop(order_id)
+            else:
                 self._orders[order_id] = updated
 
-            self._state.working_order_notional -= fill_with_fees
-            self._state.position_notional += fill_with_fees
+            released_from_working = fill_notional + proportional_estimated
+            self._state.working_order_notional -= released_from_working
+            self._state.position_notional += fill_notional + actual_fee
+            self._state.fee_reserve += fee_delta
 
             return True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.8.0"
+version = "0.9.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -491,6 +491,101 @@ class TestOrderFill:
         with pytest.raises(ValueError, match='positive'):
             ctrl.order_fill('ORD-001', Decimal('0'), Decimal('0'))
 
+    def test_order_fill_invalid_actual_fee(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        with pytest.raises(ValueError, match='non-negative'):
+            ctrl.order_fill('ORD-001', Decimal('100'), Decimal('-1'))
+
+
+class TestFeeReconciliation:
+    def test_fill_actual_equals_estimated(self) -> None:
+        ctrl = _make_controller()
+        ctrl._state.fee_reserve = Decimal('100')
+        result = _reserve(ctrl, notional='100', fees='10')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('10'))
+        assert filled is True
+        assert ctrl._state.fee_reserve == Decimal('100')
+        assert ctrl._state.position_notional == Decimal('110')
+
+    def test_fill_actual_less_than_estimated(self) -> None:
+        ctrl = _make_controller()
+        ctrl._state.fee_reserve = Decimal('100')
+        result = _reserve(ctrl, notional='100', fees='10')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('7'))
+        assert filled is True
+        assert ctrl._state.fee_reserve == Decimal('103')
+        assert ctrl._state.position_notional == Decimal('107')
+
+    def test_fill_actual_greater_than_estimated(self) -> None:
+        ctrl = _make_controller()
+        ctrl._state.fee_reserve = Decimal('100')
+        result = _reserve(ctrl, notional='100', fees='10')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('15'))
+        assert filled is True
+        assert ctrl._state.fee_reserve == Decimal('95')
+        assert ctrl._state.position_notional == Decimal('115')
+
+    def test_fill_deficit_exceeds_fee_reserve(self) -> None:
+        ctrl = _make_controller()
+        ctrl._state.fee_reserve = Decimal('3')
+        result = _reserve(ctrl, notional='100', fees='10')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('20'))
+        assert filled is False
+        assert ctrl._state.fee_reserve == Decimal('3')
+        assert ctrl._state.working_order_notional == Decimal('110')
+        assert ctrl._state.position_notional == _ZERO
+
+    def test_partial_fill_fee_reconciliation(self) -> None:
+        ctrl = _make_controller()
+        ctrl._state.fee_reserve = Decimal('100')
+        result = _reserve(ctrl, notional='100', fees='10')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        filled = ctrl.order_fill('ORD-001', Decimal('50'), Decimal('3'))
+        assert filled is True
+        assert ctrl._state.fee_reserve == Decimal('102')
+        assert ctrl._state.position_notional == Decimal('53')
+        assert ctrl._state.working_order_notional == Decimal('55')
+
+    def test_multiple_partial_fills_reconciliation(self) -> None:
+        ctrl = _make_controller()
+        ctrl._state.fee_reserve = Decimal('100')
+        result = _reserve(ctrl, notional='100', fees='10')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        ctrl.order_fill('ORD-001', Decimal('50'), Decimal('4'))
+        assert ctrl._state.fee_reserve == Decimal('101')
+
+        ctrl.order_fill('ORD-001', Decimal('50'), Decimal('6'))
+        assert ctrl._state.fee_reserve == Decimal('100')
+        assert ctrl._state.position_notional == Decimal('110')
+        assert ctrl._state.working_order_notional == _ZERO
+
 
 class TestOrderCancel:
     def test_order_cancel_success(self) -> None:

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -435,7 +435,7 @@ class TestOrderFill:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        filled = ctrl.order_fill('ORD-001', Decimal('100'))
+        filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('1'))
         assert filled is True
         assert ctrl._state.working_order_notional == _ZERO
         assert ctrl._state.position_notional == Decimal('101')
@@ -448,7 +448,7 @@ class TestOrderFill:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        filled = ctrl.order_fill('ORD-001', Decimal('400'))
+        filled = ctrl.order_fill('ORD-001', Decimal('400'), Decimal('4'))
         assert filled is True
         assert ctrl._state.working_order_notional == Decimal('606')
         assert ctrl._state.position_notional == Decimal('404')
@@ -462,14 +462,14 @@ class TestOrderFill:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        filled = ctrl.order_fill('ORD-001', Decimal('200'))
+        filled = ctrl.order_fill('ORD-001', Decimal('200'), Decimal('2'))
         assert filled is False
         assert ctrl._state.working_order_notional == Decimal('101')
         assert ctrl._state.position_notional == _ZERO
 
     def test_order_fill_not_found(self) -> None:
         ctrl = _make_controller()
-        filled = ctrl.order_fill('nonexistent', Decimal('100'))
+        filled = ctrl.order_fill('nonexistent', Decimal('100'), Decimal('1'))
         assert filled is False
 
     def test_order_fill_wrong_state(self) -> None:
@@ -478,7 +478,7 @@ class TestOrderFill:
         assert result.reservation is not None
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
 
-        filled = ctrl.order_fill('ORD-001', Decimal('100'))
+        filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('1'))
         assert filled is False
 
     def test_order_fill_invalid_notional(self) -> None:
@@ -489,7 +489,7 @@ class TestOrderFill:
         ctrl.order_ack('ORD-001')
 
         with pytest.raises(ValueError, match='positive'):
-            ctrl.order_fill('ORD-001', Decimal('0'))
+            ctrl.order_fill('ORD-001', Decimal('0'), Decimal('0'))
 
 
 class TestOrderCancel:
@@ -511,7 +511,7 @@ class TestOrderCancel:
         assert result.reservation is not None
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
-        ctrl.order_fill('ORD-001', Decimal('400'))
+        ctrl.order_fill('ORD-001', Decimal('400'), Decimal('4'))
 
         canceled = ctrl.order_cancel('ORD-001')
         assert canceled is True
@@ -550,7 +550,7 @@ class TestLifecycleHappyPath:
         assert ctrl._state.in_flight_order_notional == _ZERO
         assert ctrl._state.working_order_notional == Decimal('505')
 
-        ctrl.order_fill('ORD-001', Decimal('500'))
+        ctrl.order_fill('ORD-001', Decimal('500'), Decimal('5'))
         assert ctrl._state.working_order_notional == _ZERO
         assert ctrl._state.position_notional == Decimal('505')
         assert ctrl._state.available == initial_available - Decimal('505')
@@ -590,27 +590,27 @@ class TestLifecycleCancelPath:
 class TestNonTerminatingFeeRatio:
     def test_multi_fill_no_residual(self) -> None:
         ctrl = _make_controller()
-        result = _reserve(ctrl, notional='3', fees='1')
+        result = _reserve(ctrl, notional='100', fees='10')
         assert result.reservation is not None
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        ctrl.order_fill('ORD-001', Decimal('1'))
-        ctrl.order_fill('ORD-001', Decimal('1'))
-        ctrl.order_fill('ORD-001', Decimal('1'))
+        ctrl.order_fill('ORD-001', Decimal('25'), Decimal('2.5'))
+        ctrl.order_fill('ORD-001', Decimal('25'), Decimal('2.5'))
+        ctrl.order_fill('ORD-001', Decimal('50'), Decimal('5'))
 
         assert ctrl._state.working_order_notional == _ZERO
-        assert ctrl._state.position_notional == Decimal('4')
+        assert ctrl._state.position_notional == Decimal('110')
 
     def test_partial_fill_then_cancel_no_residual(self) -> None:
         ctrl = _make_controller()
         initial_available = ctrl._state.available
-        result = _reserve(ctrl, notional='3', fees='1')
+        result = _reserve(ctrl, notional='100', fees='10')
         assert result.reservation is not None
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        ctrl.order_fill('ORD-001', Decimal('1'))
+        ctrl.order_fill('ORD-001', Decimal('25'), Decimal('2.5'))
         ctrl.order_cancel('ORD-001')
 
         assert ctrl._state.working_order_notional == _ZERO
@@ -639,7 +639,7 @@ class TestLifecycleConcurrency:
                     sent = ctrl.send_order(res.reservation.reservation_id, f'ORD-{idx}')
                     if sent:
                         acked = ctrl.order_ack(f'ORD-{idx}')
-                        filled = ctrl.order_fill(f'ORD-{idx}', Decimal('500'))
+                        filled = ctrl.order_fill(f'ORD-{idx}', Decimal('500'), Decimal('5'))
                         if not acked or not filled:
                             msg = (
                                 f'Lifecycle failure ORD-{idx}: '


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Adds fee reconciliation to `order_fill()` — actual fees from venue are reconciled against estimated fees via `fee_reserve`. Extends signature to `order_fill(order_id, fill_notional, actual_fee)`. Position receives actual cost (`fill_notional + actual_fee`), not estimated. Fill fails if `fee_reserve` insufficient for deficit (actual > estimated). Adds 7 tests covering surplus, deficit, insufficient reserve, partial fills. Bumps to v0.9.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (295 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable