### PR TITLE
feat: 2.5 drawdown computation — instance-level HWM and diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.9.0 on 21st of March, 2026
+
+- Add instance-level drawdown state fields to `RiskState`: starting capital, cumulative realized/unrealized P&L, equity/HWMs, current drawdowns, and max drawdown metrics
+- Add deterministic recompute and update triggers for drawdown metrics via `recompute_drawdown_metrics`, `update_cumulative_realized_pnl`, and `update_unrealized_pnl`
+- Extend WAL risk-state codec to persist and recover all drawdown metrics with backward-compatible defaults for older payloads
+- Expose drawdown views for validator and diagnostics consumers via `to_risk_check_metrics()` and `to_drawdown_diagnostics()`
+- Add comprehensive drawdown tests for formula correctness, monotonic HWM/max drawdown behavior, and codec round-trip coverage (304 total)
+
 ## v0.8.0 on 20th of March, 2026
 
 - Add warning log on reservation TTL expiry with reservation_id, strategy_id, total, held duration

--- a/nexus/core/domain/__init__.py
+++ b/nexus/core/domain/__init__.py
@@ -11,16 +11,23 @@ from nexus.core.domain.enums import BreachLevel, OperationalMode, OrderSide
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.domain.operational_mode import ModeState, StrategyModeState
 from nexus.core.domain.position import Position
-from nexus.core.domain.risk_state import RiskState, StrategyRiskState
+from nexus.core.domain.risk_state import (
+    DrawdownDiagnostics,
+    RiskCheckMetrics,
+    RiskState,
+    StrategyRiskState,
+)
 
 __all__ = [
     'BreachLevel',
     'CapitalState',
+    'DrawdownDiagnostics',
     'InstanceState',
     'ModeState',
     'OperationalMode',
     'OrderSide',
     'Position',
+    'RiskCheckMetrics',
     'RiskState',
     'StrategyModeState',
     'StrategyRiskState',

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -91,12 +91,15 @@ class RiskState:
     (not a sum of per-strategy HWMs — they peak at different times).
 
     Args:
-        high_water_mark: Lifetime peak total equity.
+        high_water_mark: Legacy alias of equity_hwm retained for backward
+            compatibility with persisted state.
         starting_capital: Initial allocated capital for this instance.
         cumulative_realized_pnl: Cumulative realized P&L at instance scope.
         unrealized_pnl: Current mark-to-market unrealized P&L.
         equity: Current equity (realized equity + unrealized P&L).
-        equity_hwm: Lifetime peak of equity.
+        equity_hwm: Authoritative lifetime peak of equity used for drawdown
+            recomputation. recompute_drawdown_metrics normalizes
+            high_water_mark to this value.
         realized_equity_hwm: Lifetime peak of realized equity.
         total_drawdown: Current drawdown from equity_hwm.
         total_drawdown_pct: Current drawdown as fraction of equity_hwm.

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -188,11 +188,18 @@ class RiskState:
 
         realized_equity = self.starting_capital + self.cumulative_realized_pnl
         equity = realized_equity + self.unrealized_pnl
+        equity_hwm_seed = max(self.starting_capital, realized_equity, _ZERO)
 
         self.equity = equity
-        self.equity_hwm = max(self.equity_hwm, self.high_water_mark, equity)
+        self.equity_hwm = max(
+            self.equity_hwm, self.high_water_mark, equity_hwm_seed, equity
+        )
         self.high_water_mark = self.equity_hwm
-        self.realized_equity_hwm = max(self.realized_equity_hwm, realized_equity)
+        self.realized_equity_hwm = max(
+            self.realized_equity_hwm,
+            self.starting_capital,
+            realized_equity,
+        )
 
         self.total_drawdown = max(_ZERO, self.equity_hwm - equity)
         if self.equity_hwm == _ZERO:

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -43,7 +43,7 @@ class StrategyRiskState:
             raise ValueError(msg)
 
         if not self.high_water_mark.is_finite() or self.high_water_mark < _ZERO:
-            msg = 'StrategyRiskState.high_water_mark must be a finite non-negative value'
+            msg = 'StrategyRiskState.high_water_mark must be finite and non-negative'
             raise ValueError(msg)
 
         for field_name in ('rolling_loss_24h', 'rolling_loss_7d', 'rolling_loss_30d'):
@@ -67,10 +67,28 @@ class RiskState:
 
     Args:
         high_water_mark: Lifetime peak total equity.
+        starting_capital: Initial allocated capital for this instance.
+        cumulative_realized_pnl: Cumulative realized P&L at instance scope.
+        unrealized_pnl: Current mark-to-market unrealized P&L.
+        equity: Current equity (realized equity + unrealized P&L).
+        equity_hwm: Lifetime peak of equity.
+        realized_equity_hwm: Lifetime peak of realized equity.
+        total_drawdown: Current drawdown from equity_hwm.
+        realized_drawdown: Current drawdown from realized_equity_hwm.
+        unrealized_drawdown: Current unrealized-only drawdown component.
         per_strategy: Per-strategy risk state keyed by strategy_id.
     '''
 
     high_water_mark: Decimal = _ZERO
+    starting_capital: Decimal = _ZERO
+    cumulative_realized_pnl: Decimal = _ZERO
+    unrealized_pnl: Decimal = _ZERO
+    equity: Decimal = _ZERO
+    equity_hwm: Decimal = _ZERO
+    realized_equity_hwm: Decimal = _ZERO
+    total_drawdown: Decimal = _ZERO
+    realized_drawdown: Decimal = _ZERO
+    unrealized_drawdown: Decimal = _ZERO
     per_strategy: dict[str, StrategyRiskState] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -79,6 +97,25 @@ class RiskState:
         if not self.high_water_mark.is_finite() or self.high_water_mark < _ZERO:
             msg = 'RiskState.high_water_mark must be a finite non-negative value'
             raise ValueError(msg)
+
+        for field_name in (
+            'starting_capital',
+            'equity_hwm',
+            'realized_equity_hwm',
+            'total_drawdown',
+            'realized_drawdown',
+            'unrealized_drawdown',
+        ):
+            val = getattr(self, field_name)
+            if not val.is_finite() or val < _ZERO:
+                msg = f'RiskState.{field_name} must be a finite non-negative value'
+                raise ValueError(msg)
+
+        for field_name in ('cumulative_realized_pnl', 'unrealized_pnl', 'equity'):
+            val = getattr(self, field_name)
+            if not val.is_finite():
+                msg = f'RiskState.{field_name} must be finite'
+                raise ValueError(msg)
 
         for key, state in self.per_strategy.items():
             if not isinstance(state, StrategyRiskState):

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -179,3 +179,23 @@ class RiskState:
 
         self.max_drawdown = max(self.max_drawdown, self.total_drawdown)
         self.max_drawdown_pct = max(self.max_drawdown_pct, self.total_drawdown_pct)
+
+    def update_cumulative_realized_pnl(self, cumulative_realized_pnl: Decimal) -> None:
+        '''Set cumulative realized P&L and recompute drawdown metrics.'''
+
+        if not cumulative_realized_pnl.is_finite():
+            msg = 'cumulative_realized_pnl must be finite'
+            raise ValueError(msg)
+
+        self.cumulative_realized_pnl = cumulative_realized_pnl
+        self.recompute_drawdown_metrics()
+
+    def update_unrealized_pnl(self, unrealized_pnl: Decimal) -> None:
+        '''Set unrealized P&L and recompute drawdown metrics.'''
+
+        if not unrealized_pnl.is_finite():
+            msg = 'unrealized_pnl must be finite'
+            raise ValueError(msg)
+
+        self.unrealized_pnl = unrealized_pnl
+        self.recompute_drawdown_metrics()

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -190,7 +190,7 @@ class RiskState:
         equity = realized_equity + self.unrealized_pnl
 
         self.equity = equity
-        self.equity_hwm = max(self.equity_hwm, equity)
+        self.equity_hwm = max(self.equity_hwm, self.high_water_mark, equity)
         self.high_water_mark = self.equity_hwm
         self.realized_equity_hwm = max(self.realized_equity_hwm, realized_equity)
 

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -74,8 +74,11 @@ class RiskState:
         equity_hwm: Lifetime peak of equity.
         realized_equity_hwm: Lifetime peak of realized equity.
         total_drawdown: Current drawdown from equity_hwm.
+        total_drawdown_pct: Current drawdown as fraction of equity_hwm.
         realized_drawdown: Current drawdown from realized_equity_hwm.
         unrealized_drawdown: Current unrealized-only drawdown component.
+        max_drawdown: Lifetime worst total drawdown.
+        max_drawdown_pct: Lifetime worst drawdown fraction.
         per_strategy: Per-strategy risk state keyed by strategy_id.
     '''
 
@@ -87,8 +90,11 @@ class RiskState:
     equity_hwm: Decimal = _ZERO
     realized_equity_hwm: Decimal = _ZERO
     total_drawdown: Decimal = _ZERO
+    total_drawdown_pct: Decimal = _ZERO
     realized_drawdown: Decimal = _ZERO
     unrealized_drawdown: Decimal = _ZERO
+    max_drawdown: Decimal = _ZERO
+    max_drawdown_pct: Decimal = _ZERO
     per_strategy: dict[str, StrategyRiskState] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -103,8 +109,11 @@ class RiskState:
             'equity_hwm',
             'realized_equity_hwm',
             'total_drawdown',
+            'total_drawdown_pct',
             'realized_drawdown',
             'unrealized_drawdown',
+            'max_drawdown',
+            'max_drawdown_pct',
         ):
             val = getattr(self, field_name)
             if not val.is_finite() or val < _ZERO:
@@ -148,3 +157,25 @@ class RiskState:
         '''Sum of per-strategy cumulative realized P&L.'''
 
         return sum((s.strategy_realized_pnl for s in self.per_strategy.values()), _ZERO)
+
+    def recompute_drawdown_metrics(self) -> None:
+        '''Recompute equity, HWMs, and drawdown diagnostics deterministically.'''
+
+        realized_equity = self.starting_capital + self.cumulative_realized_pnl
+        equity = realized_equity + self.unrealized_pnl
+
+        self.equity = equity
+        self.equity_hwm = max(self.equity_hwm, equity)
+        self.high_water_mark = self.equity_hwm
+        self.realized_equity_hwm = max(self.realized_equity_hwm, realized_equity)
+
+        self.total_drawdown = max(_ZERO, self.equity_hwm - equity)
+        if self.equity_hwm == _ZERO:
+            self.total_drawdown_pct = _ZERO
+        else:
+            self.total_drawdown_pct = self.total_drawdown / self.equity_hwm
+        self.realized_drawdown = max(_ZERO, self.realized_equity_hwm - realized_equity)
+        self.unrealized_drawdown = max(_ZERO, -self.unrealized_pnl)
+
+        self.max_drawdown = max(self.max_drawdown, self.total_drawdown)
+        self.max_drawdown_pct = max(self.max_drawdown_pct, self.total_drawdown_pct)

--- a/nexus/core/domain/risk_state.py
+++ b/nexus/core/domain/risk_state.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from decimal import Decimal
 
-__all__ = ['RiskState', 'StrategyRiskState']
+__all__ = ['DrawdownDiagnostics', 'RiskCheckMetrics', 'RiskState', 'StrategyRiskState']
 
 _ZERO = Decimal(0)
 
@@ -55,6 +55,31 @@ class StrategyRiskState:
         if not self.strategy_realized_pnl.is_finite():
             msg = 'StrategyRiskState.strategy_realized_pnl must be finite'
             raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class RiskCheckMetrics:
+    '''Drawdown metrics exposed to risk-limit checks.'''
+
+    total_drawdown: Decimal
+    total_drawdown_pct: Decimal
+    max_drawdown: Decimal
+    max_drawdown_pct: Decimal
+
+
+@dataclass(frozen=True)
+class DrawdownDiagnostics:
+    '''Drawdown telemetry exposed for diagnostics surfaces.'''
+
+    equity: Decimal
+    equity_hwm: Decimal
+    realized_equity_hwm: Decimal
+    total_drawdown: Decimal
+    total_drawdown_pct: Decimal
+    realized_drawdown: Decimal
+    unrealized_drawdown: Decimal
+    max_drawdown: Decimal
+    max_drawdown_pct: Decimal
 
 
 @dataclass
@@ -199,3 +224,28 @@ class RiskState:
 
         self.unrealized_pnl = unrealized_pnl
         self.recompute_drawdown_metrics()
+
+    def to_risk_check_metrics(self) -> RiskCheckMetrics:
+        '''Return drawdown values needed for validator-style checks.'''
+
+        return RiskCheckMetrics(
+            total_drawdown=self.total_drawdown,
+            total_drawdown_pct=self.total_drawdown_pct,
+            max_drawdown=self.max_drawdown,
+            max_drawdown_pct=self.max_drawdown_pct,
+        )
+
+    def to_drawdown_diagnostics(self) -> DrawdownDiagnostics:
+        '''Return full drawdown telemetry for diagnostics consumers.'''
+
+        return DrawdownDiagnostics(
+            equity=self.equity,
+            equity_hwm=self.equity_hwm,
+            realized_equity_hwm=self.realized_equity_hwm,
+            total_drawdown=self.total_drawdown,
+            total_drawdown_pct=self.total_drawdown_pct,
+            realized_drawdown=self.realized_drawdown,
+            unrealized_drawdown=self.unrealized_drawdown,
+            max_drawdown=self.max_drawdown,
+            max_drawdown_pct=self.max_drawdown_pct,
+        )

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -85,7 +85,7 @@ def deserialize_state(data: bytes) -> InstanceState:
                 for k, v in d['strategy_modes'].items()
             },
         )
-    except (KeyError, TypeError, AttributeError) as exc:
+    except (KeyError, TypeError, AttributeError, ValueError, InvalidOperation) as exc:
         msg = f'Malformed WAL codec payload: {exc}'
         raise ValueError(msg) from exc
 

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import Any, cast
 
 import msgpack
 
@@ -52,7 +52,7 @@ def serialize_state(state: InstanceState) -> bytes:
             k: _encode_strategy_mode_state(v) for k, v in state.strategy_modes.items()
         },
     }
-    return bytes(msgpack.packb(d))
+    return cast(bytes, msgpack.packb(d))
 
 
 def deserialize_state(data: bytes) -> InstanceState:
@@ -182,6 +182,15 @@ def _encode_risk_state(rs: RiskState) -> dict[str, Any]:
 
     return {
         'high_water_mark': str(rs.high_water_mark),
+        'starting_capital': str(rs.starting_capital),
+        'cumulative_realized_pnl': str(rs.cumulative_realized_pnl),
+        'unrealized_pnl': str(rs.unrealized_pnl),
+        'equity': str(rs.equity),
+        'equity_hwm': str(rs.equity_hwm),
+        'realized_equity_hwm': str(rs.realized_equity_hwm),
+        'total_drawdown': str(rs.total_drawdown),
+        'realized_drawdown': str(rs.realized_drawdown),
+        'unrealized_drawdown': str(rs.unrealized_drawdown),
         'per_strategy': {
             k: _encode_strategy_risk_state(v) for k, v in rs.per_strategy.items()
         },
@@ -198,8 +207,22 @@ def _decode_risk_state(d: dict[str, Any]) -> RiskState:
         Reconstructed risk state with per-strategy entries.
     '''
 
+    legacy_hwm = Decimal(d.get('high_water_mark', d.get('equity_hwm', '0')))
+    equity_hwm = Decimal(d.get('equity_hwm', str(legacy_hwm)))
+    high_water_mark = Decimal(d.get('high_water_mark', str(equity_hwm)))
+    starting_capital = Decimal(d.get('starting_capital', str(legacy_hwm)))
+
     return RiskState(
-        high_water_mark=Decimal(d['high_water_mark']),
+        high_water_mark=high_water_mark,
+        starting_capital=starting_capital,
+        cumulative_realized_pnl=Decimal(d.get('cumulative_realized_pnl', '0')),
+        unrealized_pnl=Decimal(d.get('unrealized_pnl', '0')),
+        equity=Decimal(d.get('equity', str(starting_capital))),
+        equity_hwm=equity_hwm,
+        realized_equity_hwm=Decimal(d.get('realized_equity_hwm', str(equity_hwm))),
+        total_drawdown=Decimal(d.get('total_drawdown', '0')),
+        realized_drawdown=Decimal(d.get('realized_drawdown', '0')),
+        unrealized_drawdown=Decimal(d.get('unrealized_drawdown', '0')),
         per_strategy={
             k: _decode_strategy_risk_state(v) for k, v in d['per_strategy'].items()
         },
@@ -333,7 +356,7 @@ def serialize_event(event: StrategyEvent) -> bytes:
         'realized_pnl': str(event.realized_pnl),
         'timestamp': event.timestamp.isoformat(),
     }
-    return bytes(msgpack.packb(d))
+    return cast(bytes, msgpack.packb(d))
 
 
 def deserialize_event(data: bytes) -> StrategyEvent:

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -189,8 +189,11 @@ def _encode_risk_state(rs: RiskState) -> dict[str, Any]:
         'equity_hwm': str(rs.equity_hwm),
         'realized_equity_hwm': str(rs.realized_equity_hwm),
         'total_drawdown': str(rs.total_drawdown),
+        'total_drawdown_pct': str(rs.total_drawdown_pct),
         'realized_drawdown': str(rs.realized_drawdown),
         'unrealized_drawdown': str(rs.unrealized_drawdown),
+        'max_drawdown': str(rs.max_drawdown),
+        'max_drawdown_pct': str(rs.max_drawdown_pct),
         'per_strategy': {
             k: _encode_strategy_risk_state(v) for k, v in rs.per_strategy.items()
         },
@@ -221,8 +224,11 @@ def _decode_risk_state(d: dict[str, Any]) -> RiskState:
         equity_hwm=equity_hwm,
         realized_equity_hwm=Decimal(d.get('realized_equity_hwm', str(equity_hwm))),
         total_drawdown=Decimal(d.get('total_drawdown', '0')),
+        total_drawdown_pct=Decimal(d.get('total_drawdown_pct', '0')),
         realized_drawdown=Decimal(d.get('realized_drawdown', '0')),
         unrealized_drawdown=Decimal(d.get('unrealized_drawdown', '0')),
+        max_drawdown=Decimal(d.get('max_drawdown', '0')),
+        max_drawdown_pct=Decimal(d.get('max_drawdown_pct', '0')),
         per_strategy={
             k: _decode_strategy_risk_state(v) for k, v in d['per_strategy'].items()
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.8.0"
+version = "0.9.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_risk_state.py
+++ b/tests/test_risk_state.py
@@ -30,6 +30,15 @@ def test_risk_state_empty() -> None:
 
     rs = RiskState()
     assert rs.high_water_mark == Decimal(0)
+    assert rs.starting_capital == Decimal(0)
+    assert rs.cumulative_realized_pnl == Decimal(0)
+    assert rs.unrealized_pnl == Decimal(0)
+    assert rs.equity == Decimal(0)
+    assert rs.equity_hwm == Decimal(0)
+    assert rs.realized_equity_hwm == Decimal(0)
+    assert rs.total_drawdown == Decimal(0)
+    assert rs.realized_drawdown == Decimal(0)
+    assert rs.unrealized_drawdown == Decimal(0)
     assert rs.rolling_loss_24h == Decimal(0)
     assert rs.rolling_loss_7d == Decimal(0)
     assert rs.rolling_loss_30d == Decimal(0)
@@ -125,8 +134,9 @@ def test_negative_rolling_loss_rejected() -> None:
 def test_infinity_strategy_pnl_rejected() -> None:
     '''Verify Infinity strategy_realized_pnl raises ValueError.'''
 
+    inf_value = Decimal('Infinity')
     with pytest.raises(ValueError, match='strategy_realized_pnl'):
-        StrategyRiskState(strategy_id='momentum', strategy_realized_pnl=Decimal('Infinity'))
+        StrategyRiskState(strategy_id='momentum', strategy_realized_pnl=inf_value)
 
 
 def test_nan_instance_hwm_rejected() -> None:
@@ -141,3 +151,24 @@ def test_negative_instance_hwm_rejected() -> None:
 
     with pytest.raises(ValueError, match='high_water_mark'):
         RiskState(high_water_mark=Decimal('-1'))
+
+
+def test_negative_starting_capital_rejected() -> None:
+    '''Verify negative starting_capital in RiskState raises ValueError.'''
+
+    with pytest.raises(ValueError, match='starting_capital'):
+        RiskState(starting_capital=Decimal('-1'))
+
+
+def test_nan_equity_rejected() -> None:
+    '''Verify NaN equity in RiskState raises ValueError.'''
+
+    with pytest.raises(ValueError, match='equity'):
+        RiskState(equity=Decimal('NaN'))
+
+
+def test_negative_total_drawdown_rejected() -> None:
+    '''Verify negative total_drawdown in RiskState raises ValueError.'''
+
+    with pytest.raises(ValueError, match='total_drawdown'):
+        RiskState(total_drawdown=Decimal('-1'))

--- a/tests/test_risk_state.py
+++ b/tests/test_risk_state.py
@@ -455,3 +455,25 @@ def test_recompute_preserves_legacy_high_water_mark_when_equity_hwm_unset() -> N
     assert rs.equity_hwm == Decimal('1000')
     assert rs.high_water_mark == Decimal('1000')
     assert rs.total_drawdown == Decimal('500')
+
+
+def test_recompute_seeds_hwm_floor_for_deep_initial_loss() -> None:
+    '''Verify first recompute seeds HWM from starting capital under deep loss.'''
+
+    rs = RiskState(
+        high_water_mark=Decimal('0'),
+        starting_capital=Decimal('1000'),
+        cumulative_realized_pnl=Decimal('0'),
+        unrealized_pnl=Decimal('-1200'),
+        equity_hwm=Decimal('0'),
+        realized_equity_hwm=Decimal('0'),
+    )
+
+    rs.recompute_drawdown_metrics()
+
+    assert rs.equity == Decimal('-200')
+    assert rs.equity_hwm == Decimal('1000')
+    assert rs.high_water_mark == Decimal('1000')
+    assert rs.realized_equity_hwm == Decimal('1000')
+    assert rs.total_drawdown == Decimal('1200')
+    assert rs.total_drawdown_pct == Decimal('1.2')

--- a/tests/test_risk_state.py
+++ b/tests/test_risk_state.py
@@ -435,3 +435,23 @@ def test_equity_hwm_and_max_drawdown_are_monotonic_over_sequence() -> None:
         prior_realized_hwm = rs.realized_equity_hwm
         prior_max_drawdown = rs.max_drawdown
         prior_max_drawdown_pct = rs.max_drawdown_pct
+
+
+def test_recompute_preserves_legacy_high_water_mark_when_equity_hwm_unset() -> None:
+    '''Verify recompute keeps existing high_water_mark as HWM floor.'''
+
+    rs = RiskState(
+        high_water_mark=Decimal('1000'),
+        starting_capital=Decimal('500'),
+        cumulative_realized_pnl=Decimal('0'),
+        unrealized_pnl=Decimal('0'),
+        equity_hwm=Decimal('0'),
+        realized_equity_hwm=Decimal('0'),
+    )
+
+    rs.recompute_drawdown_metrics()
+
+    assert rs.equity == Decimal('500')
+    assert rs.equity_hwm == Decimal('1000')
+    assert rs.high_water_mark == Decimal('1000')
+    assert rs.total_drawdown == Decimal('500')

--- a/tests/test_risk_state.py
+++ b/tests/test_risk_state.py
@@ -282,3 +282,39 @@ def test_recompute_drawdown_metrics_preserves_lifetime_max_drawdown() -> None:
     assert rs.total_drawdown == Decimal('0')
     assert rs.max_drawdown == Decimal('300')
     assert rs.max_drawdown_pct == Decimal('0.3')
+
+
+def test_update_cumulative_realized_pnl_triggers_recompute() -> None:
+    '''Verify updating cumulative realized PnL recomputes drawdown metrics.'''
+
+    rs = RiskState(
+        starting_capital=Decimal('1000'),
+        equity_hwm=Decimal('1100'),
+        realized_equity_hwm=Decimal('1100'),
+    )
+
+    rs.update_cumulative_realized_pnl(Decimal('-50'))
+
+    assert rs.cumulative_realized_pnl == Decimal('-50')
+    assert rs.equity == Decimal('950')
+    assert rs.total_drawdown == Decimal('150')
+    assert rs.total_drawdown_pct == Decimal('0.1363636363636363636363636364')
+
+
+def test_update_unrealized_pnl_triggers_recompute() -> None:
+    '''Verify updating unrealized PnL recomputes drawdown metrics.'''
+
+    rs = RiskState(
+        starting_capital=Decimal('1000'),
+        cumulative_realized_pnl=Decimal('0'),
+        equity_hwm=Decimal('1000'),
+        realized_equity_hwm=Decimal('1000'),
+    )
+
+    rs.update_unrealized_pnl(Decimal('-200'))
+
+    assert rs.unrealized_pnl == Decimal('-200')
+    assert rs.equity == Decimal('800')
+    assert rs.total_drawdown == Decimal('200')
+    assert rs.total_drawdown_pct == Decimal('0.2')
+    assert rs.unrealized_drawdown == Decimal('200')

--- a/tests/test_risk_state.py
+++ b/tests/test_risk_state.py
@@ -6,7 +6,12 @@ from decimal import Decimal
 
 import pytest
 
-from nexus.core.domain.risk_state import RiskState, StrategyRiskState
+from nexus.core.domain.risk_state import (
+    DrawdownDiagnostics,
+    RiskCheckMetrics,
+    RiskState,
+    StrategyRiskState,
+)
 
 
 def test_strategy_risk_state_creation() -> None:
@@ -318,3 +323,51 @@ def test_update_unrealized_pnl_triggers_recompute() -> None:
     assert rs.total_drawdown == Decimal('200')
     assert rs.total_drawdown_pct == Decimal('0.2')
     assert rs.unrealized_drawdown == Decimal('200')
+
+
+def test_to_risk_check_metrics_exposes_validator_fields() -> None:
+    '''Verify validator-facing drawdown metrics are exposed in one typed view.'''
+
+    rs = RiskState(
+        total_drawdown=Decimal('100'),
+        total_drawdown_pct=Decimal('0.1'),
+        max_drawdown=Decimal('250'),
+        max_drawdown_pct=Decimal('0.2'),
+    )
+
+    metrics = rs.to_risk_check_metrics()
+
+    assert isinstance(metrics, RiskCheckMetrics)
+    assert metrics.total_drawdown == Decimal('100')
+    assert metrics.total_drawdown_pct == Decimal('0.1')
+    assert metrics.max_drawdown == Decimal('250')
+    assert metrics.max_drawdown_pct == Decimal('0.2')
+
+
+def test_to_drawdown_diagnostics_exposes_telemetry_fields() -> None:
+    '''Verify diagnostics-facing drawdown telemetry fields are exposed together.'''
+
+    rs = RiskState(
+        equity=Decimal('900'),
+        equity_hwm=Decimal('1000'),
+        realized_equity_hwm=Decimal('980'),
+        total_drawdown=Decimal('100'),
+        total_drawdown_pct=Decimal('0.1'),
+        realized_drawdown=Decimal('80'),
+        unrealized_drawdown=Decimal('20'),
+        max_drawdown=Decimal('150'),
+        max_drawdown_pct=Decimal('0.15'),
+    )
+
+    diagnostics = rs.to_drawdown_diagnostics()
+
+    assert isinstance(diagnostics, DrawdownDiagnostics)
+    assert diagnostics.equity == Decimal('900')
+    assert diagnostics.equity_hwm == Decimal('1000')
+    assert diagnostics.realized_equity_hwm == Decimal('980')
+    assert diagnostics.total_drawdown == Decimal('100')
+    assert diagnostics.total_drawdown_pct == Decimal('0.1')
+    assert diagnostics.realized_drawdown == Decimal('80')
+    assert diagnostics.unrealized_drawdown == Decimal('20')
+    assert diagnostics.max_drawdown == Decimal('150')
+    assert diagnostics.max_drawdown_pct == Decimal('0.15')

--- a/tests/test_risk_state.py
+++ b/tests/test_risk_state.py
@@ -37,8 +37,11 @@ def test_risk_state_empty() -> None:
     assert rs.equity_hwm == Decimal(0)
     assert rs.realized_equity_hwm == Decimal(0)
     assert rs.total_drawdown == Decimal(0)
+    assert rs.total_drawdown_pct == Decimal(0)
     assert rs.realized_drawdown == Decimal(0)
     assert rs.unrealized_drawdown == Decimal(0)
+    assert rs.max_drawdown == Decimal(0)
+    assert rs.max_drawdown_pct == Decimal(0)
     assert rs.rolling_loss_24h == Decimal(0)
     assert rs.rolling_loss_7d == Decimal(0)
     assert rs.rolling_loss_30d == Decimal(0)
@@ -172,3 +175,110 @@ def test_negative_total_drawdown_rejected() -> None:
 
     with pytest.raises(ValueError, match='total_drawdown'):
         RiskState(total_drawdown=Decimal('-1'))
+
+
+def test_negative_total_drawdown_pct_rejected() -> None:
+    '''Verify negative total_drawdown_pct in RiskState raises ValueError.'''
+
+    with pytest.raises(ValueError, match='total_drawdown_pct'):
+        RiskState(total_drawdown_pct=Decimal('-0.01'))
+
+
+def test_negative_max_drawdown_rejected() -> None:
+    '''Verify negative max_drawdown in RiskState raises ValueError.'''
+
+    with pytest.raises(ValueError, match='max_drawdown'):
+        RiskState(max_drawdown=Decimal('-1'))
+
+
+def test_recompute_drawdown_metrics_updates_peaks_and_resets_drawdowns() -> None:
+    '''Verify recompute updates HWMs and resets drawdowns at new peaks.'''
+
+    rs = RiskState(
+        starting_capital=Decimal('1000'),
+        cumulative_realized_pnl=Decimal('120'),
+        unrealized_pnl=Decimal('30'),
+        equity_hwm=Decimal('1100'),
+        realized_equity_hwm=Decimal('1100'),
+    )
+
+    rs.recompute_drawdown_metrics()
+
+    assert rs.equity == Decimal('1150')
+    assert rs.equity_hwm == Decimal('1150')
+    assert rs.high_water_mark == Decimal('1150')
+    assert rs.realized_equity_hwm == Decimal('1120')
+    assert rs.total_drawdown == Decimal('0')
+    assert rs.total_drawdown_pct == Decimal('0')
+    assert rs.realized_drawdown == Decimal('0')
+    assert rs.unrealized_drawdown == Decimal('0')
+    assert rs.max_drawdown == Decimal('0')
+    assert rs.max_drawdown_pct == Decimal('0')
+
+
+def test_recompute_drawdown_metrics_tracks_losses_without_new_peak() -> None:
+    '''Verify recompute grows drawdowns under worse PnL without updating HWMs.'''
+
+    rs = RiskState(
+        starting_capital=Decimal('1000'),
+        cumulative_realized_pnl=Decimal('50'),
+        unrealized_pnl=Decimal('-80'),
+        equity_hwm=Decimal('1200'),
+        realized_equity_hwm=Decimal('1100'),
+    )
+
+    rs.recompute_drawdown_metrics()
+
+    assert rs.equity == Decimal('970')
+    assert rs.equity_hwm == Decimal('1200')
+    assert rs.high_water_mark == Decimal('1200')
+    assert rs.total_drawdown == Decimal('230')
+    assert rs.total_drawdown_pct == Decimal('0.1916666666666666666666666667')
+    assert rs.realized_drawdown == Decimal('50')
+    assert rs.unrealized_drawdown == Decimal('80')
+    assert rs.max_drawdown == Decimal('230')
+    assert rs.max_drawdown_pct == Decimal('0.1916666666666666666666666667')
+
+
+def test_recompute_drawdown_metrics_sets_unrealized_drawdown_zero_when_flat() -> None:
+    '''Verify unrealized drawdown is zero when unrealized_pnl is zero.'''
+
+    rs = RiskState(
+        starting_capital=Decimal('1000'),
+        cumulative_realized_pnl=Decimal('10'),
+        unrealized_pnl=Decimal('0'),
+        equity_hwm=Decimal('1010'),
+        realized_equity_hwm=Decimal('1010'),
+    )
+
+    rs.recompute_drawdown_metrics()
+
+    assert rs.equity == Decimal('1010')
+    assert rs.total_drawdown == Decimal('0')
+    assert rs.total_drawdown_pct == Decimal('0')
+    assert rs.realized_drawdown == Decimal('0')
+    assert rs.unrealized_drawdown == Decimal('0')
+    assert rs.max_drawdown == Decimal('0')
+    assert rs.max_drawdown_pct == Decimal('0')
+
+
+def test_recompute_drawdown_metrics_preserves_lifetime_max_drawdown() -> None:
+    '''Verify max drawdown metrics remain at lifetime worst after recovery.'''
+
+    rs = RiskState(
+        starting_capital=Decimal('1000'),
+        cumulative_realized_pnl=Decimal('0'),
+        unrealized_pnl=Decimal('-300'),
+        equity_hwm=Decimal('1000'),
+        realized_equity_hwm=Decimal('1000'),
+    )
+
+    rs.recompute_drawdown_metrics()
+    assert rs.max_drawdown == Decimal('300')
+    assert rs.max_drawdown_pct == Decimal('0.3')
+
+    rs.unrealized_pnl = Decimal('50')
+    rs.recompute_drawdown_metrics()
+    assert rs.total_drawdown == Decimal('0')
+    assert rs.max_drawdown == Decimal('300')
+    assert rs.max_drawdown_pct == Decimal('0.3')

--- a/tests/test_risk_state.py
+++ b/tests/test_risk_state.py
@@ -371,3 +371,67 @@ def test_to_drawdown_diagnostics_exposes_telemetry_fields() -> None:
     assert diagnostics.unrealized_drawdown == Decimal('20')
     assert diagnostics.max_drawdown == Decimal('150')
     assert diagnostics.max_drawdown_pct == Decimal('0.15')
+
+
+def test_drawdown_formula_correctness_across_pnl_updates() -> None:
+    '''Verify recompute formulas hold over a multi-step PnL sequence.'''
+
+    rs = RiskState(starting_capital=Decimal('1000'))
+
+    steps = [
+        (Decimal('0'), Decimal('0')),
+        (Decimal('50'), Decimal('25')),
+        (Decimal('20'), Decimal('-100')),
+        (Decimal('-10'), Decimal('-250')),
+        (Decimal('80'), Decimal('10')),
+    ]
+
+    for cumulative_realized_pnl, unrealized_pnl in steps:
+        rs.update_cumulative_realized_pnl(cumulative_realized_pnl)
+        rs.update_unrealized_pnl(unrealized_pnl)
+
+        realized_equity = rs.starting_capital + rs.cumulative_realized_pnl
+        equity = realized_equity + rs.unrealized_pnl
+
+        assert rs.equity == equity
+        assert rs.total_drawdown == max(Decimal('0'), rs.equity_hwm - equity)
+        assert rs.realized_drawdown == max(
+            Decimal('0'), rs.realized_equity_hwm - realized_equity
+        )
+        assert rs.unrealized_drawdown == max(Decimal('0'), -rs.unrealized_pnl)
+        if rs.equity_hwm == Decimal('0'):
+            assert rs.total_drawdown_pct == Decimal('0')
+        else:
+            assert rs.total_drawdown_pct == rs.total_drawdown / rs.equity_hwm
+
+
+def test_equity_hwm_and_max_drawdown_are_monotonic_over_sequence() -> None:
+    '''Verify HWM and max drawdown metrics never decrease over updates.'''
+
+    rs = RiskState(starting_capital=Decimal('1000'))
+    prior_equity_hwm = rs.equity_hwm
+    prior_realized_hwm = rs.realized_equity_hwm
+    prior_max_drawdown = rs.max_drawdown
+    prior_max_drawdown_pct = rs.max_drawdown_pct
+
+    sequence = [
+        (Decimal('0'), Decimal('0')),
+        (Decimal('100'), Decimal('0')),
+        (Decimal('100'), Decimal('-50')),
+        (Decimal('200'), Decimal('25')),
+        (Decimal('-20'), Decimal('-300')),
+    ]
+
+    for cumulative_realized_pnl, unrealized_pnl in sequence:
+        rs.update_cumulative_realized_pnl(cumulative_realized_pnl)
+        rs.update_unrealized_pnl(unrealized_pnl)
+
+        assert rs.equity_hwm >= prior_equity_hwm
+        assert rs.realized_equity_hwm >= prior_realized_hwm
+        assert rs.max_drawdown >= prior_max_drawdown
+        assert rs.max_drawdown_pct >= prior_max_drawdown_pct
+
+        prior_equity_hwm = rs.equity_hwm
+        prior_realized_hwm = rs.realized_equity_hwm
+        prior_max_drawdown = rs.max_drawdown
+        prior_max_drawdown_pct = rs.max_drawdown_pct

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import cast
 
 import pytest
 
@@ -42,6 +43,15 @@ def _make_full_state() -> InstanceState:
         ),
         risk=RiskState(
             high_water_mark=Decimal('110000'),
+            starting_capital=Decimal('100000'),
+            cumulative_realized_pnl=Decimal('450.25'),
+            unrealized_pnl=Decimal('-125.75'),
+            equity=Decimal('100324.50'),
+            equity_hwm=Decimal('111000'),
+            realized_equity_hwm=Decimal('108000'),
+            total_drawdown=Decimal('10675.50'),
+            realized_drawdown=Decimal('7550.25'),
+            unrealized_drawdown=Decimal('125.75'),
             per_strategy={
                 'momentum': StrategyRiskState(
                     strategy_id='momentum',
@@ -137,6 +147,18 @@ class TestRoundTrip:
         restored = deserialize_state(serialize_state(original))
 
         assert restored.risk.high_water_mark == original.risk.high_water_mark
+        assert restored.risk.starting_capital == original.risk.starting_capital
+        assert (
+            restored.risk.cumulative_realized_pnl
+            == original.risk.cumulative_realized_pnl
+        )
+        assert restored.risk.unrealized_pnl == original.risk.unrealized_pnl
+        assert restored.risk.equity == original.risk.equity
+        assert restored.risk.equity_hwm == original.risk.equity_hwm
+        assert restored.risk.realized_equity_hwm == original.risk.realized_equity_hwm
+        assert restored.risk.total_drawdown == original.risk.total_drawdown
+        assert restored.risk.realized_drawdown == original.risk.realized_drawdown
+        assert restored.risk.unrealized_drawdown == original.risk.unrealized_drawdown
         assert 'momentum' in restored.risk.per_strategy
 
         orig_srs = original.risk.per_strategy['momentum']
@@ -233,7 +255,7 @@ class TestCodecVersioning:
 
         import msgpack
 
-        bad_data = msgpack.packb({'_v': 999})
+        bad_data = cast(bytes, msgpack.packb({'_v': 999}))
         with pytest.raises(ValueError, match='Unsupported WAL codec version'):
             deserialize_state(bad_data)
 
@@ -242,9 +264,49 @@ class TestCodecVersioning:
 
         import msgpack
 
-        bad_data = msgpack.packb({'capital': {}})
+        bad_data = cast(bytes, msgpack.packb({'capital': {}}))
         with pytest.raises(ValueError, match='Unsupported WAL codec version'):
             deserialize_state(bad_data)
+
+
+class TestRiskDecodeDefaults:
+    '''Verify risk decode defaults for missing fields.'''
+
+    def test_missing_risk_fields_seed_from_high_water_mark(self) -> None:
+        '''Verify missing risk fields default from high_water_mark.'''
+
+        import msgpack
+
+        payload = {
+            '_v': 1,
+            'capital': {
+                'capital_pool': '100000',
+                'position_notional': '0',
+                'working_order_notional': '0',
+                'in_flight_order_notional': '0',
+                'fee_reserve': '0',
+                'reservation_notional': '0',
+            },
+            'risk': {
+                'high_water_mark': '110000',
+                'per_strategy': {},
+            },
+            'positions': {},
+            'mode': {
+                'mode': 'ACTIVE',
+                'trigger': 'init',
+                'transitioned_at': '2026-03-20T00:00:00',
+            },
+            'strategy_modes': {},
+        }
+
+        restored = deserialize_state(cast(bytes, msgpack.packb(payload)))
+
+        assert restored.risk.high_water_mark == Decimal('110000')
+        assert restored.risk.starting_capital == Decimal('110000')
+        assert restored.risk.equity == Decimal('110000')
+        assert restored.risk.equity_hwm == Decimal('110000')
+        assert restored.risk.realized_equity_hwm == Decimal('110000')
 
 
 class TestMalformedPayload:
@@ -255,7 +317,7 @@ class TestMalformedPayload:
 
         import msgpack
 
-        bad_data = bytes(msgpack.packb([1, 2, 3]))
+        bad_data = cast(bytes, msgpack.packb([1, 2, 3]))
 
         with pytest.raises(ValueError, match='Expected dict from WAL payload'):
             deserialize_state(bad_data)
@@ -358,7 +420,7 @@ class TestEventCodecVersion:
             'realized_pnl': '0',
             'timestamp': '2026-03-19T12:00:00+00:00',
         }
-        data = bytes(msgpack.packb(d))
+        data = cast(bytes, msgpack.packb(d))
 
         with pytest.raises(ValueError, match='Unsupported event codec version'):
             deserialize_event(data)
@@ -368,7 +430,7 @@ class TestEventMalformedPayload:
     def test_non_dict_rejected(self) -> None:
         import msgpack
 
-        data = bytes(msgpack.packb([1, 2, 3]))
+        data = cast(bytes, msgpack.packb([1, 2, 3]))
 
         with pytest.raises(ValueError, match='Expected dict from event payload'):
             deserialize_event(data)
@@ -377,7 +439,7 @@ class TestEventMalformedPayload:
         import msgpack
 
         d = {'_v': 1, 'strategy_id': 'strat_a'}
-        data = bytes(msgpack.packb(d))
+        data = cast(bytes, msgpack.packb(d))
 
         with pytest.raises(ValueError, match='Malformed event codec payload'):
             deserialize_event(data)
@@ -392,7 +454,7 @@ class TestEventMalformedPayload:
             'realized_pnl': 'not_a_number',
             'timestamp': '2026-03-19T12:00:00+00:00',
         }
-        data = bytes(msgpack.packb(d))
+        data = cast(bytes, msgpack.packb(d))
 
         with pytest.raises(ValueError, match='Malformed event codec payload'):
             deserialize_event(data)
@@ -407,7 +469,7 @@ class TestEventMalformedPayload:
             'realized_pnl': '100',
             'timestamp': 'not-a-date',
         }
-        data = bytes(msgpack.packb(d))
+        data = cast(bytes, msgpack.packb(d))
 
         with pytest.raises(ValueError, match='Malformed event codec payload'):
             deserialize_event(data)

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -50,8 +50,11 @@ def _make_full_state() -> InstanceState:
             equity_hwm=Decimal('111000'),
             realized_equity_hwm=Decimal('108000'),
             total_drawdown=Decimal('10675.50'),
+            total_drawdown_pct=Decimal('0.09617567567567567567567567568'),
             realized_drawdown=Decimal('7550.25'),
             unrealized_drawdown=Decimal('125.75'),
+            max_drawdown=Decimal('20000'),
+            max_drawdown_pct=Decimal('0.18'),
             per_strategy={
                 'momentum': StrategyRiskState(
                     strategy_id='momentum',
@@ -157,8 +160,11 @@ class TestRoundTrip:
         assert restored.risk.equity_hwm == original.risk.equity_hwm
         assert restored.risk.realized_equity_hwm == original.risk.realized_equity_hwm
         assert restored.risk.total_drawdown == original.risk.total_drawdown
+        assert restored.risk.total_drawdown_pct == original.risk.total_drawdown_pct
         assert restored.risk.realized_drawdown == original.risk.realized_drawdown
         assert restored.risk.unrealized_drawdown == original.risk.unrealized_drawdown
+        assert restored.risk.max_drawdown == original.risk.max_drawdown
+        assert restored.risk.max_drawdown_pct == original.risk.max_drawdown_pct
         assert 'momentum' in restored.risk.per_strategy
 
         orig_srs = original.risk.per_strategy['momentum']
@@ -307,6 +313,9 @@ class TestRiskDecodeDefaults:
         assert restored.risk.equity == Decimal('110000')
         assert restored.risk.equity_hwm == Decimal('110000')
         assert restored.risk.realized_equity_hwm == Decimal('110000')
+        assert restored.risk.total_drawdown_pct == Decimal('0')
+        assert restored.risk.max_drawdown == Decimal('0')
+        assert restored.risk.max_drawdown_pct == Decimal('0')
 
 
 class TestMalformedPayload:

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -331,6 +331,39 @@ class TestMalformedPayload:
         with pytest.raises(ValueError, match='Expected dict from WAL payload'):
             deserialize_state(bad_data)
 
+    def test_invalid_decimal_in_risk_payload_raises(self) -> None:
+        '''Verify malformed Decimal risk field raises normalized ValueError.'''
+
+        import msgpack
+
+        payload = {
+            '_v': 1,
+            'capital': {
+                'capital_pool': '100000',
+                'position_notional': '0',
+                'working_order_notional': '0',
+                'in_flight_order_notional': '0',
+                'fee_reserve': '0',
+                'reservation_notional': '0',
+            },
+            'risk': {
+                'high_water_mark': 'not_a_number',
+                'per_strategy': {},
+            },
+            'positions': {},
+            'mode': {
+                'mode': 'ACTIVE',
+                'trigger': 'init',
+                'transitioned_at': '2026-03-20T00:00:00',
+            },
+            'strategy_modes': {},
+        }
+
+        data = cast(bytes, msgpack.packb(payload))
+
+        with pytest.raises(ValueError, match='Malformed WAL codec payload'):
+            deserialize_state(data)
+
 
 class TestSerializationOutput:
     '''Verify serialization produces expected binary format.'''


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements journal item 2.5 end-to-end for instance-level drawdown computation and exposure. Adds risk-state drawdown fields (`starting_capital`, cumulative realized/unrealized P&L, equity/HWMs, total/realized/unrealized drawdown, percent and max drawdown), deterministic recompute/update methods, and backward-compatible WAL persistence defaults. Exposes validator/diagnostic metric views via typed accessors. Adds comprehensive tests for formula correctness, monotonic HWM/max-drawdown behavior, and WAL compatibility/round-trips. Updates release metadata in `CHANGELOG.md` and bumps `pyproject.toml` version to `0.9.0`.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (304 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable