### PR TITLE
feat: 2.6 per-strategy capital tracking and allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.10.0 on 21st of March, 2026
+
+- Add `CapitalState.per_strategy_deployed` with finite non-negative validation for per-strategy deployment accounting
+- Add `InstanceConfig.capital_pct` with allocation validation (`(0,100]` per strategy, total `<= 100`)
+- Add `CapitalController.compute_strategy_budget()` to derive budget from `capital_pool` and `capital_pct`, with optional realized P&L auto-compounding
+- Refactor `check_and_reserve()` to enforce strategy budget from controller-owned deployed state instead of caller-provided `strategy_deployed`
+- Add lifecycle deployed accounting updates across reservation expiry/release and order reject/cancel paths
+- Extend WAL/state recovery to persist and restore `per_strategy_deployed` with backward-compatible defaults for older payloads
+- Add comprehensive per-strategy isolation and accounting invariant tests (326 total)
+
 ## v0.9.0 on 21st of March, 2026
 
 - Add instance-level drawdown state fields to `RiskState`: starting capital, cumulative realized/unrealized P&L, equity/HWMs, current drawdowns, and max drawdown metrics

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -197,6 +197,11 @@ class CapitalController:
             msg = f'capital_pct must be in (0, 100]: {capital_pct}'
             raise ValueError(msg)
 
+        base_budget = self._state.capital_pool * (capital_pct / _ONE_HUNDRED)
+
+        if not auto_compound:
+            return base_budget
+
         if (
             not isinstance(strategy_realized_pnl, Decimal)
             or not strategy_realized_pnl.is_finite()
@@ -206,11 +211,6 @@ class CapitalController:
                 f'{strategy_realized_pnl}'
             )
             raise ValueError(msg)
-
-        base_budget = self._state.capital_pool * (capital_pct / _ONE_HUNDRED)
-
-        if not auto_compound:
-            return base_budget
 
         return base_budget + strategy_realized_pnl
 
@@ -466,7 +466,18 @@ class CapitalController:
         current = self._state.per_strategy_deployed.get(strategy_id, _ZERO)
         updated = current + delta
 
-        if updated <= _ZERO:
+        if updated < _ZERO:
+            _logger.warning(
+                'Per-strategy deployed underflow: strategy=%s current=%s delta=%s updated=%s',
+                strategy_id,
+                current,
+                delta,
+                updated,
+            )
+            self._state.per_strategy_deployed.pop(strategy_id, None)
+            return
+
+        if updated == _ZERO:
             self._state.per_strategy_deployed.pop(strategy_id, None)
             return
 

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -222,6 +222,10 @@ class CapitalController:
         for rid in expired:
             reservation = self._reservations.pop(rid)
             self._state.reservation_notional -= reservation.total
+            self._adjust_strategy_deployed(
+                reservation.strategy_id,
+                -reservation.total,
+            )
             held_seconds = (now - reservation.created_at).total_seconds()
             _logger.warning(
                 'Reservation expired: id=%s strategy=%s total=%s held=%.1fs',
@@ -248,6 +252,10 @@ class CapitalController:
                 return False
 
             self._state.reservation_notional -= reservation.total
+            self._adjust_strategy_deployed(
+                reservation.strategy_id,
+                -reservation.total,
+            )
             return True
 
     def send_order(self, reservation_id: str, order_id: str) -> bool:
@@ -360,6 +368,7 @@ class CapitalController:
 
             self._orders.pop(order_id)
             self._state.in_flight_order_notional -= order.total
+            self._adjust_strategy_deployed(order.strategy_id, -order.total)
 
             return True
 
@@ -449,5 +458,16 @@ class CapitalController:
 
             self._orders.pop(order_id)
             self._state.working_order_notional -= order.remaining_total
+            self._adjust_strategy_deployed(order.strategy_id, -order.remaining_total)
 
             return True
+
+    def _adjust_strategy_deployed(self, strategy_id: str, delta: Decimal) -> None:
+        current = self._state.per_strategy_deployed.get(strategy_id, _ZERO)
+        updated = current + delta
+
+        if updated <= _ZERO:
+            self._state.per_strategy_deployed.pop(strategy_id, None)
+            return
+
+        self._state.per_strategy_deployed[strategy_id] = updated

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -31,6 +31,7 @@ MAX_CAPITAL_UTILIZATION_PCT = Decimal('0.80')
 DEFAULT_TTL_SECONDS = 30
 
 _ZERO = Decimal(0)
+_ONE_HUNDRED = Decimal('100')
 
 
 class CapitalController:
@@ -165,6 +166,56 @@ class CapitalController:
             self._state.reservation_notional += total
 
             return ReservationResult(granted=True, reservation=reservation)
+
+    def compute_strategy_budget(
+        self,
+        strategy_id: str,
+        capital_pct: Decimal,
+        *,
+        auto_compound: bool = False,
+        strategy_realized_pnl: Decimal = _ZERO,
+    ) -> Decimal:
+        '''Compute strategy budget from capital pool and allocation percentage.
+
+        Args:
+            strategy_id: Strategy identifier for validation and diagnostics.
+            capital_pct: Strategy allocation percentage in (0, 100].
+            auto_compound: Whether to include realized PnL adjustment.
+            strategy_realized_pnl: Realized PnL adjustment applied when
+                auto_compound is enabled.
+
+        Returns:
+            Computed strategy budget in quote capital units.
+        '''
+
+        if not strategy_id or not strategy_id.strip():
+            msg = 'strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(capital_pct, Decimal) or not capital_pct.is_finite():
+            msg = f'capital_pct must be a finite Decimal: {capital_pct}'
+            raise ValueError(msg)
+
+        if capital_pct <= _ZERO or capital_pct > _ONE_HUNDRED:
+            msg = f'capital_pct must be in (0, 100]: {capital_pct}'
+            raise ValueError(msg)
+
+        if (
+            not isinstance(strategy_realized_pnl, Decimal)
+            or not strategy_realized_pnl.is_finite()
+        ):
+            msg = (
+                'strategy_realized_pnl must be a finite Decimal: '
+                f'{strategy_realized_pnl}'
+            )
+            raise ValueError(msg)
+
+        base_budget = self._state.capital_pool * (capital_pct / _ONE_HUNDRED)
+
+        if not auto_compound:
+            return base_budget
+
+        return base_budget + strategy_realized_pnl
 
     def _purge_expired(self, now: datetime | None = None) -> None:
         if now is None:

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -53,7 +53,6 @@ class CapitalController:
         order_notional: Decimal,
         estimated_fees: Decimal,
         strategy_budget: Decimal,
-        strategy_deployed: Decimal,
         *,
         ttl_seconds: int = DEFAULT_TTL_SECONDS,
     ) -> ReservationResult:
@@ -64,7 +63,6 @@ class CapitalController:
             order_notional: Quote capital for the order.
             estimated_fees: Estimated transaction fees.
             strategy_budget: Budget ceiling for this strategy.
-            strategy_deployed: Capital already deployed by this strategy.
             ttl_seconds: Seconds before reservation auto-expires.
 
         Returns:
@@ -75,7 +73,6 @@ class CapitalController:
             ('order_notional', order_notional),
             ('estimated_fees', estimated_fees),
             ('strategy_budget', strategy_budget),
-            ('strategy_deployed', strategy_deployed),
         ):
             if not isinstance(val, Decimal) or not val.is_finite():
                 msg = f'Invalid {name}: {val}'
@@ -93,10 +90,6 @@ class CapitalController:
             msg = f'estimated_fees must be non-negative: {estimated_fees}'
             raise ValueError(msg)
 
-        if strategy_deployed < _ZERO:
-            msg = f'strategy_deployed must be non-negative: {strategy_deployed}'
-            raise ValueError(msg)
-
         if ttl_seconds <= 0:
             msg = f'ttl_seconds must be positive: {ttl_seconds}'
             raise ValueError(msg)
@@ -105,6 +98,9 @@ class CapitalController:
 
         with self._lock:
             self._purge_expired()
+            strategy_deployed = self._state.per_strategy_deployed.get(
+                strategy_id, _ZERO
+            )
 
             allocation_pct = order_notional / self._state.capital_pool
 
@@ -164,6 +160,7 @@ class CapitalController:
 
             self._reservations[reservation.reservation_id] = reservation
             self._state.reservation_notional += total
+            self._state.per_strategy_deployed[strategy_id] = strategy_deployed + total
 
             return ReservationResult(granted=True, reservation=reservation)
 

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -184,7 +184,7 @@ class CapitalController:
 
             self._reservations[reservation.reservation_id] = reservation
             self._state.reservation_notional += total
-            self._state.per_strategy_deployed[strategy_id] = strategy_deployed + total
+            self._adjust_strategy_deployed(strategy_id, total)
 
             return ReservationResult(granted=True, reservation=reservation)
 

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -101,6 +101,21 @@ class CapitalController:
             strategy_deployed = self._state.per_strategy_deployed.get(
                 strategy_id, _ZERO
             )
+            total_deployed = (
+                self._state.position_notional
+                + self._state.working_order_notional
+                + self._state.in_flight_order_notional
+                + self._state.reservation_notional
+            )
+
+            if not self._state.per_strategy_deployed and total_deployed > _ZERO:
+                return ReservationResult(
+                    granted=False,
+                    denial_reason=(
+                        'Per-strategy deployed attribution is unknown for non-flat '
+                        'state; reconcile strategy deployment before new reservations'
+                    ),
+                )
 
             allocation_pct = order_notional / self._state.capital_pool
 
@@ -131,12 +146,6 @@ class CapitalController:
                     ),
                 )
 
-            total_deployed = (
-                self._state.position_notional
-                + self._state.working_order_notional
-                + self._state.in_flight_order_notional
-                + self._state.reservation_notional
-            )
             utilization = (total_deployed + total) / self._state.capital_pool
 
             if utilization > MAX_CAPITAL_UTILIZATION_PCT:

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -108,14 +108,27 @@ class CapitalController:
                 + self._state.reservation_notional
             )
 
-            if not self._state.per_strategy_deployed and total_deployed > _ZERO:
-                return ReservationResult(
-                    granted=False,
-                    denial_reason=(
+            per_strategy_deployed = self._state.per_strategy_deployed
+            if total_deployed > _ZERO:
+                denial_reason: str | None = None
+                if not per_strategy_deployed:
+                    denial_reason = (
                         'Per-strategy deployed attribution is unknown for non-flat '
                         'state; reconcile strategy deployment before new reservations'
-                    ),
-                )
+                    )
+                else:
+                    attributed_deployed = sum(per_strategy_deployed.values(), _ZERO)
+                    if attributed_deployed != total_deployed:
+                        denial_reason = (
+                            'Per-strategy deployed attribution mismatch for non-flat '
+                            'state; reconcile strategy deployment before new reservations'
+                        )
+
+                if denial_reason is not None:
+                    return ReservationResult(
+                        granted=False,
+                        denial_reason=denial_reason,
+                    )
 
             allocation_pct = order_notional / self._state.capital_pool
 

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -82,6 +82,8 @@ class CapitalController:
             msg = 'strategy_id must be a non-empty string'
             raise ValueError(msg)
 
+        strategy_id = strategy_id.strip()
+
         if order_notional < _ZERO:
             msg = f'order_notional must be non-negative: {order_notional}'
             raise ValueError(msg)
@@ -210,6 +212,8 @@ class CapitalController:
         if not strategy_id or not strategy_id.strip():
             msg = 'strategy_id must be a non-empty string'
             raise ValueError(msg)
+
+        strategy_id = strategy_id.strip()
 
         if not isinstance(capital_pct, Decimal) or not capital_pct.is_finite():
             msg = f'capital_pct must be a finite Decimal: {capital_pct}'

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -111,20 +111,27 @@ class CapitalController:
             )
 
             per_strategy_deployed = self._state.per_strategy_deployed
-            if total_deployed > _ZERO:
-                denial_reason: str | None = None
+            denial_reason: str | None = None
+            if total_deployed > _ZERO or per_strategy_deployed:
                 if not per_strategy_deployed:
-                    denial_reason = (
-                        'Per-strategy deployed attribution is unknown for non-flat '
-                        'state; reconcile strategy deployment before new reservations'
-                    )
+                    if total_deployed > _ZERO:
+                        denial_reason = (
+                            'Per-strategy deployed attribution is unknown for non-flat '
+                            'state; reconcile strategy deployment before new reservations'
+                        )
                 else:
                     attributed_deployed = sum(per_strategy_deployed.values(), _ZERO)
                     if attributed_deployed != total_deployed:
-                        denial_reason = (
-                            'Per-strategy deployed attribution mismatch for non-flat '
-                            'state; reconcile strategy deployment before new reservations'
-                        )
+                        if total_deployed > _ZERO:
+                            denial_reason = (
+                                'Per-strategy deployed attribution mismatch for non-flat '
+                                'state; reconcile strategy deployment before new reservations'
+                            )
+                        else:
+                            denial_reason = (
+                                'Per-strategy deployed attribution mismatch for flat state; '
+                                'reconcile strategy deployment before new reservations'
+                            )
 
                 if denial_reason is not None:
                     return ReservationResult(

--- a/nexus/core/domain/capital_state.py
+++ b/nexus/core/domain/capital_state.py
@@ -74,6 +74,12 @@ class CapitalState:
                     'or trailing whitespace'
                 )
                 raise ValueError(msg)
+            if not isinstance(deployed, Decimal):
+                msg = (
+                    'CapitalState.per_strategy_deployed values must be finite '
+                    'non-negative Decimal values'
+                )
+                raise ValueError(msg)
             if not deployed.is_finite() or deployed < _ZERO:
                 msg = (
                     'CapitalState.per_strategy_deployed values must be finite '

--- a/nexus/core/domain/capital_state.py
+++ b/nexus/core/domain/capital_state.py
@@ -68,6 +68,12 @@ class CapitalState:
                     'CapitalState.per_strategy_deployed keys must be non-empty strings'
                 )
                 raise ValueError(msg)
+            if strategy_key != strategy_id:
+                msg = (
+                    'CapitalState.per_strategy_deployed keys must not contain leading '
+                    'or trailing whitespace'
+                )
+                raise ValueError(msg)
             if not deployed.is_finite() or deployed < _ZERO:
                 msg = (
                     'CapitalState.per_strategy_deployed values must be finite '

--- a/nexus/core/domain/capital_state.py
+++ b/nexus/core/domain/capital_state.py
@@ -55,8 +55,15 @@ class CapitalState:
                 msg = f'CapitalState.{field_name} must be a finite non-negative value'
                 raise ValueError(msg)
 
-        for strategy_id, deployed in self.per_strategy_deployed.items():
-            if not strategy_id or not strategy_id.strip():
+        for strategy_key, deployed in self.per_strategy_deployed.items():
+            if not isinstance(strategy_key, str):
+                msg = (
+                    'CapitalState.per_strategy_deployed keys must be non-empty strings'
+                )
+                raise ValueError(msg)
+
+            strategy_id = strategy_key.strip()
+            if not strategy_id:
                 msg = (
                     'CapitalState.per_strategy_deployed keys must be non-empty strings'
                 )

--- a/nexus/core/domain/capital_state.py
+++ b/nexus/core/domain/capital_state.py
@@ -6,7 +6,7 @@ instance. The ``available`` property is derived — never stored directly.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 
 __all__ = ['CapitalState']
@@ -25,6 +25,7 @@ class CapitalState:
         in_flight_order_notional: Sum of BUY orders sent but not acked.
         fee_reserve: Reserved for transaction costs.
         reservation_notional: Sum of active TOCTOU locks (BUY-side).
+        per_strategy_deployed: Deployed capital by strategy_id.
     '''
 
     capital_pool: Decimal
@@ -33,6 +34,7 @@ class CapitalState:
     in_flight_order_notional: Decimal = _ZERO
     fee_reserve: Decimal = _ZERO
     reservation_notional: Decimal = _ZERO
+    per_strategy_deployed: dict[str, Decimal] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         '''Validate invariants at construction time.'''
@@ -51,6 +53,19 @@ class CapitalState:
             val = getattr(self, field_name)
             if not val.is_finite() or val < _ZERO:
                 msg = f'CapitalState.{field_name} must be a finite non-negative value'
+                raise ValueError(msg)
+
+        for strategy_id, deployed in self.per_strategy_deployed.items():
+            if not strategy_id or not strategy_id.strip():
+                msg = (
+                    'CapitalState.per_strategy_deployed keys must be non-empty strings'
+                )
+                raise ValueError(msg)
+            if not deployed.is_finite() or deployed < _ZERO:
+                msg = (
+                    'CapitalState.per_strategy_deployed values must be finite '
+                    'non-negative Decimal values'
+                )
                 raise ValueError(msg)
 
     @property

--- a/nexus/core/domain/capital_state.py
+++ b/nexus/core/domain/capital_state.py
@@ -6,6 +6,7 @@ instance. The ``available`` property is derived — never stored directly.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from decimal import Decimal
 
@@ -55,6 +56,11 @@ class CapitalState:
                 msg = f'CapitalState.{field_name} must be a finite non-negative value'
                 raise ValueError(msg)
 
+        if not isinstance(self.per_strategy_deployed, Mapping):
+            msg = 'CapitalState.per_strategy_deployed must be a mapping of strategy_id to Decimal'
+            raise ValueError(msg)
+
+        normalized_per_strategy_deployed: dict[str, Decimal] = {}
         for strategy_key, deployed in self.per_strategy_deployed.items():
             if not isinstance(strategy_key, str):
                 msg = (
@@ -86,6 +92,10 @@ class CapitalState:
                     'non-negative Decimal values'
                 )
                 raise ValueError(msg)
+
+            normalized_per_strategy_deployed[strategy_id] = deployed
+
+        self.per_strategy_deployed = normalized_per_strategy_deployed
 
     @property
     def available(self) -> Decimal:

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -91,13 +91,15 @@ def deserialize_state(data: bytes) -> InstanceState:
 
 
 def _encode_capital_state(cs: CapitalState) -> dict[str, Any]:
-    '''Encode CapitalState to string-valued dict for msgpack.
+    '''Encode CapitalState to nested dict for msgpack.
 
     Args:
         cs: Capital state to encode.
 
     Returns:
-        String-keyed dict with Decimal values as strings.
+        String-keyed dict with top-level Decimal values as strings and
+        ``per_strategy_deployed`` as a nested mapping of
+        ``strategy_id -> deployed Decimal`` encoded as strings.
     '''
 
     return {
@@ -115,10 +117,11 @@ def _encode_capital_state(cs: CapitalState) -> dict[str, Any]:
 
 
 def _decode_capital_state(d: dict[str, Any]) -> CapitalState:
-    '''Decode string-valued dict to CapitalState.
+    '''Decode nested capital-state dict to CapitalState.
 
     Args:
-        d: Encoded capital state dict.
+        d: Encoded capital state dict with stringified Decimal fields and
+            optional nested ``per_strategy_deployed`` mapping.
 
     Returns:
         Reconstructed capital state.

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -90,7 +90,7 @@ def deserialize_state(data: bytes) -> InstanceState:
         raise ValueError(msg) from exc
 
 
-def _encode_capital_state(cs: CapitalState) -> dict[str, str]:
+def _encode_capital_state(cs: CapitalState) -> dict[str, Any]:
     '''Encode CapitalState to string-valued dict for msgpack.
 
     Args:
@@ -107,10 +107,14 @@ def _encode_capital_state(cs: CapitalState) -> dict[str, str]:
         'in_flight_order_notional': str(cs.in_flight_order_notional),
         'fee_reserve': str(cs.fee_reserve),
         'reservation_notional': str(cs.reservation_notional),
+        'per_strategy_deployed': {
+            strategy_id: str(deployed)
+            for strategy_id, deployed in cs.per_strategy_deployed.items()
+        },
     }
 
 
-def _decode_capital_state(d: dict[str, str]) -> CapitalState:
+def _decode_capital_state(d: dict[str, Any]) -> CapitalState:
     '''Decode string-valued dict to CapitalState.
 
     Args:
@@ -127,6 +131,10 @@ def _decode_capital_state(d: dict[str, str]) -> CapitalState:
         in_flight_order_notional=Decimal(d['in_flight_order_notional']),
         fee_reserve=Decimal(d['fee_reserve']),
         reservation_notional=Decimal(d['reservation_notional']),
+        per_strategy_deployed={
+            strategy_id: Decimal(deployed)
+            for strategy_id, deployed in d.get('per_strategy_deployed', {}).items()
+        },
     )
 
 

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -63,6 +63,12 @@ class InstanceConfig:
             if not strategy_id:
                 msg = 'InstanceConfig.capital_pct keys must be non-empty strings'
                 raise ValueError(msg)
+            if strategy_id in normalized_capital_pct:
+                msg = (
+                    'InstanceConfig.capital_pct contains duplicate keys after '
+                    'normalization'
+                )
+                raise ValueError(msg)
             if not isinstance(pct, Decimal) or not pct.is_finite():
                 msg = 'InstanceConfig.capital_pct values must be finite Decimals'
                 raise ValueError(msg)

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -54,8 +54,13 @@ class InstanceConfig:
 
         normalized_capital_pct: dict[str, Decimal] = {}
         total_pct = _ZERO
-        for strategy_id, pct in self.capital_pct.items():
-            if not strategy_id or not strategy_id.strip():
+        for raw_strategy_id, pct in self.capital_pct.items():
+            if not isinstance(raw_strategy_id, str):
+                msg = 'InstanceConfig.capital_pct keys must be non-empty strings'
+                raise ValueError(msg)
+
+            strategy_id = raw_strategy_id.strip()
+            if not strategy_id:
                 msg = 'InstanceConfig.capital_pct keys must be non-empty strings'
                 raise ValueError(msg)
             if not isinstance(pct, Decimal) or not pct.is_finite():

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -7,8 +7,10 @@ are added as their respective phases land.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from decimal import Decimal
+from types import MappingProxyType
 
 __all__ = ['InstanceConfig']
 
@@ -33,7 +35,7 @@ class InstanceConfig:
     account_id: str
     venue: str
     allocated_capital: Decimal
-    capital_pct: dict[str, Decimal] = field(default_factory=dict)
+    capital_pct: Mapping[str, Decimal] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         '''Validate configuration invariants.'''
@@ -50,6 +52,7 @@ class InstanceConfig:
             msg = 'InstanceConfig.allocated_capital must be a finite positive value'
             raise ValueError(msg)
 
+        normalized_capital_pct: dict[str, Decimal] = {}
         total_pct = _ZERO
         for strategy_id, pct in self.capital_pct.items():
             if not strategy_id or not strategy_id.strip():
@@ -62,7 +65,14 @@ class InstanceConfig:
                 msg = 'InstanceConfig.capital_pct values must be in (0, 100]'
                 raise ValueError(msg)
             total_pct += pct
+            normalized_capital_pct[strategy_id] = pct
 
         if total_pct > _ONE_HUNDRED:
             msg = 'InstanceConfig.capital_pct total must be <= 100'
             raise ValueError(msg)
+
+        object.__setattr__(
+            self,
+            'capital_pct',
+            MappingProxyType(normalized_capital_pct),
+        )

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -7,10 +7,13 @@ are added as their respective phases land.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 
 __all__ = ['InstanceConfig']
+
+_ZERO = Decimal('0')
+_ONE_HUNDRED = Decimal('100')
 
 
 @dataclass(frozen=True)
@@ -23,11 +26,14 @@ class InstanceConfig:
         allocated_capital: Hard ceiling on capital this instance can use,
             denominated in quote asset. The manifest's ``capital_pool``
             must not exceed this value.
+        capital_pct: Strategy capital-allocation percentages keyed by
+            strategy_id.
     '''
 
     account_id: str
     venue: str
     allocated_capital: Decimal
+    capital_pct: dict[str, Decimal] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         '''Validate configuration invariants.'''
@@ -42,4 +48,21 @@ class InstanceConfig:
 
         if not self.allocated_capital.is_finite() or self.allocated_capital <= 0:
             msg = 'InstanceConfig.allocated_capital must be a finite positive value'
+            raise ValueError(msg)
+
+        total_pct = _ZERO
+        for strategy_id, pct in self.capital_pct.items():
+            if not strategy_id or not strategy_id.strip():
+                msg = 'InstanceConfig.capital_pct keys must be non-empty strings'
+                raise ValueError(msg)
+            if not isinstance(pct, Decimal) or not pct.is_finite():
+                msg = 'InstanceConfig.capital_pct values must be finite Decimals'
+                raise ValueError(msg)
+            if pct <= _ZERO or pct > _ONE_HUNDRED:
+                msg = 'InstanceConfig.capital_pct values must be in (0, 100]'
+                raise ValueError(msg)
+            total_pct += pct
+
+        if total_pct > _ONE_HUNDRED:
+            msg = 'InstanceConfig.capital_pct total must be <= 100'
             raise ValueError(msg)

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -52,6 +52,12 @@ class InstanceConfig:
             msg = 'InstanceConfig.allocated_capital must be a finite positive value'
             raise ValueError(msg)
 
+        if not isinstance(self.capital_pct, Mapping):
+            msg = (
+                'InstanceConfig.capital_pct must be a mapping of strategy_id to Decimal'
+            )
+            raise ValueError(msg)
+
         normalized_capital_pct: dict[str, Decimal] = {}
         total_pct = _ZERO
         for raw_strategy_id, pct in self.capital_pct.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.9.0"
+version = "0.10.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -93,6 +93,16 @@ class TestStrategyBudgetCheck:
         assert result.denial_reason is not None
         assert 'unknown' in result.denial_reason.lower()
 
+    def test_per_strategy_deployment_mismatch_in_non_flat_state_denied(self) -> None:
+        ctrl = _make_controller(
+            position_notional=Decimal('1000'),
+            per_strategy_deployed={'strat_a': Decimal('900')},
+        )
+        result = _reserve(ctrl, notional='100', fees='1', budget='5000')
+        assert result.granted is False
+        assert result.denial_reason is not None
+        assert 'mismatch' in result.denial_reason.lower()
+
     def test_exceeds_strategy_budget(self) -> None:
         ctrl = _make_controller(
             per_strategy_deployed={'strat_a': Decimal('4600')},

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -193,11 +193,13 @@ class TestReleaseReservation:
         ctrl = _make_controller()
         result = _reserve(ctrl, notional='500', fees='5')
         assert ctrl._state.reservation_notional == Decimal('505')
+        assert ctrl._state.per_strategy_deployed['strat_a'] == Decimal('505')
         assert result.reservation is not None
 
         released = ctrl.release_reservation(result.reservation.reservation_id)
         assert released is True
         assert ctrl._state.reservation_notional == _ZERO
+        assert 'strat_a' not in ctrl._state.per_strategy_deployed
 
     def test_release_unknown_id(self) -> None:
         ctrl = _make_controller()
@@ -258,9 +260,11 @@ class TestExpiredPurge:
         )
         ctrl._reservations['expired_001'] = expired_res
         ctrl._state.reservation_notional = Decimal('505')
+        ctrl._state.per_strategy_deployed['strat_a'] = Decimal('505')
 
         _reserve(ctrl, notional='100', fees='1', budget=str(_POOL))
         assert ctrl._state.reservation_notional == Decimal('101')
+        assert ctrl._state.per_strategy_deployed['strat_a'] == Decimal('101')
 
     def test_expired_reservation_logs_warning(
         self, caplog: pytest.LogCaptureFixture
@@ -443,12 +447,14 @@ class TestOrderReject:
         ctrl = _make_controller()
         result = _reserve(ctrl, notional='100', fees='1')
         assert result.reservation is not None
+        assert ctrl._state.per_strategy_deployed['strat_a'] == Decimal('101')
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         assert ctrl._state.in_flight_order_notional == Decimal('101')
 
         rejected = ctrl.order_reject('ORD-001')
         assert rejected is True
         assert ctrl._state.in_flight_order_notional == _ZERO
+        assert 'strat_a' not in ctrl._state.per_strategy_deployed
         assert 'ORD-001' not in ctrl._orders
 
     def test_order_reject_not_found(self) -> None:
@@ -537,12 +543,14 @@ class TestOrderCancel:
         ctrl = _make_controller()
         result = _reserve(ctrl, notional='100', fees='1')
         assert result.reservation is not None
+        assert ctrl._state.per_strategy_deployed['strat_a'] == Decimal('101')
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
         canceled = ctrl.order_cancel('ORD-001')
         assert canceled is True
         assert ctrl._state.working_order_notional == _ZERO
+        assert 'strat_a' not in ctrl._state.per_strategy_deployed
         assert 'ORD-001' not in ctrl._orders
 
     def test_order_cancel_after_partial_fill(self) -> None:
@@ -593,6 +601,7 @@ class TestLifecycleHappyPath:
         ctrl.order_fill('ORD-001', Decimal('500'))
         assert ctrl._state.working_order_notional == _ZERO
         assert ctrl._state.position_notional == Decimal('505')
+        assert ctrl._state.per_strategy_deployed['strat_a'] == Decimal('505')
         assert ctrl._state.available == initial_available - Decimal('505')
 
 

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -158,6 +158,16 @@ class TestComputeStrategyBudget:
                 strategy_realized_pnl=Decimal('NaN'),
             )
 
+    def test_non_compound_ignores_strategy_realized_pnl_validation(self) -> None:
+        ctrl = _make_controller()
+        budget = ctrl.compute_strategy_budget(
+            'strat_a',
+            Decimal('25'),
+            auto_compound=False,
+            strategy_realized_pnl=Decimal('NaN'),
+        )
+        assert budget == Decimal('2500')
+
 
 class TestAvailableCapitalCheck:
     def test_insufficient_available(self) -> None:
@@ -785,3 +795,15 @@ class TestPerStrategyDeployedInvariants:
 
         assert per_strategy_total == committed
         assert ctrl._state.per_strategy_deployed == {'strat_a': Decimal('151.5')}
+
+    def test_underflow_logs_warning_and_removes_strategy(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        ctrl = _make_controller(per_strategy_deployed={'strat_a': Decimal('1')})
+
+        with caplog.at_level('WARNING'):
+            ctrl._adjust_strategy_deployed('strat_a', Decimal('-2'))
+
+        assert 'Per-strategy deployed underflow' in caplog.text
+        assert 'strat_a' not in ctrl._state.per_strategy_deployed

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -29,12 +29,13 @@ def _make_controller(**overrides: Any) -> CapitalController:
 
 def _reserve(
     ctrl: CapitalController,
+    strategy_id: str = 'strat_a',
     notional: str = '100',
     fees: str = '1',
     budget: str = '5000',
 ) -> ReservationResult:
     return ctrl.check_and_reserve(
-        strategy_id='strat_a',
+        strategy_id=strategy_id,
         order_notional=Decimal(notional),
         estimated_fees=Decimal(fees),
         strategy_budget=Decimal(budget),
@@ -718,3 +719,69 @@ class TestLifecycleConcurrency:
             + ctrl._state.position_notional
         )
         assert ctrl._state.available + total_committed == _POOL
+
+
+class TestPerStrategyIsolation:
+    def test_budget_check_isolated_per_strategy(self) -> None:
+        ctrl = _make_controller(
+            per_strategy_deployed={
+                'strat_a': Decimal('4900'),
+                'strat_b': Decimal('0'),
+            },
+        )
+
+        denied = _reserve(
+            ctrl,
+            strategy_id='strat_a',
+            notional='200',
+            fees='1',
+            budget='5000',
+        )
+        allowed = _reserve(
+            ctrl,
+            strategy_id='strat_b',
+            notional='200',
+            fees='1',
+            budget='5000',
+        )
+
+        assert denied.granted is False
+        assert allowed.granted is True
+
+    def test_deployed_map_updates_by_strategy_id(self) -> None:
+        ctrl = _make_controller()
+
+        _reserve(ctrl, strategy_id='strat_a', notional='100', fees='1')
+        _reserve(ctrl, strategy_id='strat_b', notional='200', fees='2')
+
+        assert ctrl._state.per_strategy_deployed['strat_a'] == Decimal('101')
+        assert ctrl._state.per_strategy_deployed['strat_b'] == Decimal('202')
+
+
+class TestPerStrategyDeployedInvariants:
+    def test_sum_per_strategy_deployed_equals_committed_capital(self) -> None:
+        ctrl = _make_controller()
+
+        res_a = _reserve(ctrl, strategy_id='strat_a', notional='300', fees='3')
+        res_b = _reserve(ctrl, strategy_id='strat_b', notional='200', fees='2')
+        assert res_a.reservation is not None
+        assert res_b.reservation is not None
+
+        ctrl.send_order(res_a.reservation.reservation_id, 'ORD-A')
+        ctrl.order_ack('ORD-A')
+        ctrl.order_fill('ORD-A', Decimal('150'))
+        ctrl.order_cancel('ORD-A')
+
+        ctrl.send_order(res_b.reservation.reservation_id, 'ORD-B')
+        ctrl.order_reject('ORD-B')
+
+        committed = (
+            ctrl._state.reservation_notional
+            + ctrl._state.in_flight_order_notional
+            + ctrl._state.working_order_notional
+            + ctrl._state.position_notional
+        )
+        per_strategy_total = sum(ctrl._state.per_strategy_deployed.values(), _ZERO)
+
+        assert per_strategy_total == committed
+        assert ctrl._state.per_strategy_deployed == {'strat_a': Decimal('151.5')}

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -86,6 +86,13 @@ class TestPerTradeAllocationCheck:
 
 
 class TestStrategyBudgetCheck:
+    def test_unknown_per_strategy_deployment_in_non_flat_state_denied(self) -> None:
+        ctrl = _make_controller(position_notional=Decimal('1000'))
+        result = _reserve(ctrl, notional='100', fees='1', budget='5000')
+        assert result.granted is False
+        assert result.denial_reason is not None
+        assert 'unknown' in result.denial_reason.lower()
+
     def test_exceeds_strategy_budget(self) -> None:
         ctrl = _make_controller(
             per_strategy_deployed={'strat_a': Decimal('4600')},
@@ -171,14 +178,20 @@ class TestComputeStrategyBudget:
 
 class TestAvailableCapitalCheck:
     def test_insufficient_available(self) -> None:
-        ctrl = _make_controller(position_notional=Decimal('9950'))
-        result = _reserve(ctrl, notional='100', fees='1')
+        ctrl = _make_controller(
+            position_notional=Decimal('9950'),
+            per_strategy_deployed={'strat_a': Decimal('9950')},
+        )
+        result = _reserve(ctrl, notional='100', fees='1', budget='20000')
         assert result.granted is False
         assert result.denial_reason is not None
         assert 'insufficient' in result.denial_reason.lower()
 
     def test_exactly_available_passes(self) -> None:
-        ctrl = _make_controller(position_notional=Decimal('7000'))
+        ctrl = _make_controller(
+            position_notional=Decimal('7000'),
+            per_strategy_deployed={'strat_a': Decimal('7000')},
+        )
         result = _reserve(ctrl, notional='999', fees='1', budget=str(_POOL))
         assert result.granted is True
 
@@ -186,7 +199,10 @@ class TestAvailableCapitalCheck:
 class TestTotalUtilizationCheck:
     def test_exceeds_utilization_limit(self) -> None:
         deployed = _POOL * MAX_CAPITAL_UTILIZATION_PCT
-        ctrl = _make_controller(position_notional=deployed)
+        ctrl = _make_controller(
+            position_notional=deployed,
+            per_strategy_deployed={'strat_a': deployed},
+        )
         result = _reserve(ctrl, notional='1', fees='0', budget=str(_POOL))
         assert result.granted is False
         assert result.denial_reason is not None
@@ -194,7 +210,10 @@ class TestTotalUtilizationCheck:
 
     def test_at_utilization_limit_passes(self) -> None:
         deployed = _POOL * MAX_CAPITAL_UTILIZATION_PCT - Decimal('100')
-        ctrl = _make_controller(position_notional=deployed)
+        ctrl = _make_controller(
+            position_notional=deployed,
+            per_strategy_deployed={'strat_a': deployed},
+        )
         result = _reserve(ctrl, notional='100', fees='0', budget=str(_POOL))
         assert result.granted is True
 

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from typing import Any
 
 import pytest
 
@@ -21,7 +22,7 @@ _POOL = Decimal('10000')
 _ZERO = Decimal(0)
 
 
-def _make_controller(**overrides: Decimal) -> CapitalController:
+def _make_controller(**overrides: Any) -> CapitalController:
     cs = CapitalState(capital_pool=_POOL, **overrides)
     return CapitalController(cs)
 
@@ -108,6 +109,48 @@ class TestStrategyBudgetCheck:
         assert result.granted is False
         assert result.denial_reason is not None
         assert 'budget' in result.denial_reason.lower()
+
+
+class TestComputeStrategyBudget:
+    def test_base_budget_from_capital_pct(self) -> None:
+        ctrl = _make_controller()
+        budget = ctrl.compute_strategy_budget('strat_a', Decimal('25'))
+        assert budget == Decimal('2500')
+
+    def test_auto_compound_adds_realized_pnl(self) -> None:
+        ctrl = _make_controller()
+        budget = ctrl.compute_strategy_budget(
+            'strat_a',
+            Decimal('25'),
+            auto_compound=True,
+            strategy_realized_pnl=Decimal('150'),
+        )
+        assert budget == Decimal('2650')
+
+    def test_auto_compound_applies_negative_realized_pnl(self) -> None:
+        ctrl = _make_controller()
+        budget = ctrl.compute_strategy_budget(
+            'strat_a',
+            Decimal('25'),
+            auto_compound=True,
+            strategy_realized_pnl=Decimal('-300'),
+        )
+        assert budget == Decimal('2200')
+
+    def test_invalid_capital_pct_rejected(self) -> None:
+        ctrl = _make_controller()
+        with pytest.raises(ValueError, match='capital_pct'):
+            ctrl.compute_strategy_budget('strat_a', Decimal('0'))
+
+    def test_invalid_strategy_realized_pnl_rejected(self) -> None:
+        ctrl = _make_controller()
+        with pytest.raises(ValueError, match='strategy_realized_pnl'):
+            ctrl.compute_strategy_budget(
+                'strat_a',
+                Decimal('25'),
+                auto_compound=True,
+                strategy_realized_pnl=Decimal('NaN'),
+            )
 
 
 class TestAvailableCapitalCheck:

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -103,8 +103,19 @@ class TestStrategyBudgetCheck:
         assert result.denial_reason is not None
         assert 'mismatch' in result.denial_reason.lower()
 
+    def test_per_strategy_deployment_mismatch_in_flat_state_denied(self) -> None:
+        ctrl = _make_controller(
+            per_strategy_deployed={'strat_a': Decimal('1')},
+        )
+        result = _reserve(ctrl, notional='100', fees='1', budget='5000')
+        assert result.granted is False
+        assert result.denial_reason is not None
+        assert 'mismatch' in result.denial_reason.lower()
+        assert 'flat state' in result.denial_reason.lower()
+
     def test_exceeds_strategy_budget(self) -> None:
         ctrl = _make_controller(
+            position_notional=Decimal('4600'),
             per_strategy_deployed={'strat_a': Decimal('4600')},
         )
         result = _reserve(ctrl, notional='500', budget='5000')
@@ -114,6 +125,7 @@ class TestStrategyBudgetCheck:
 
     def test_at_strategy_budget_passes(self) -> None:
         ctrl = _make_controller(
+            position_notional=Decimal('4000'),
             per_strategy_deployed={'strat_a': Decimal('4000')},
         )
         result = _reserve(ctrl, notional='999', fees='1', budget='5000')
@@ -128,6 +140,7 @@ class TestStrategyBudgetCheck:
 
     def test_budget_check_uses_normalized_strategy_id(self) -> None:
         ctrl = _make_controller(
+            position_notional=Decimal('4900'),
             per_strategy_deployed={'strat_a': Decimal('4900')},
         )
         result = _reserve(
@@ -793,6 +806,7 @@ class TestLifecycleConcurrency:
 class TestPerStrategyIsolation:
     def test_budget_check_isolated_per_strategy(self) -> None:
         ctrl = _make_controller(
+            position_notional=Decimal('4900'),
             per_strategy_deployed={
                 'strat_a': Decimal('4900'),
                 'strat_b': Decimal('0'),

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -32,14 +32,12 @@ def _reserve(
     notional: str = '100',
     fees: str = '1',
     budget: str = '5000',
-    deployed: str = '0',
 ) -> ReservationResult:
     return ctrl.check_and_reserve(
         strategy_id='strat_a',
         order_notional=Decimal(notional),
         estimated_fees=Decimal(fees),
         strategy_budget=Decimal(budget),
-        strategy_deployed=Decimal(deployed),
     )
 
 
@@ -64,6 +62,11 @@ class TestSuccessfulReservation:
         _reserve(ctrl, notional='200', fees='2')
         assert ctrl._state.reservation_notional == Decimal('303')
 
+    def test_strategy_deployed_updates_on_success(self) -> None:
+        ctrl = _make_controller()
+        _reserve(ctrl, notional='100', fees='1')
+        assert ctrl._state.per_strategy_deployed['strat_a'] == Decimal('101')
+
 
 class TestPerTradeAllocationCheck:
     def test_exceeds_allocation_limit(self) -> None:
@@ -83,17 +86,19 @@ class TestPerTradeAllocationCheck:
 
 class TestStrategyBudgetCheck:
     def test_exceeds_strategy_budget(self) -> None:
-        ctrl = _make_controller()
-        result = _reserve(ctrl, notional='500', deployed='4600', budget='5000')
+        ctrl = _make_controller(
+            per_strategy_deployed={'strat_a': Decimal('4600')},
+        )
+        result = _reserve(ctrl, notional='500', budget='5000')
         assert result.granted is False
         assert result.denial_reason is not None
         assert 'budget' in result.denial_reason.lower()
 
     def test_at_strategy_budget_passes(self) -> None:
-        ctrl = _make_controller()
-        result = _reserve(
-            ctrl, notional='999', fees='1', deployed='4000', budget='5000'
+        ctrl = _make_controller(
+            per_strategy_deployed={'strat_a': Decimal('4000')},
         )
+        result = _reserve(ctrl, notional='999', fees='1', budget='5000')
         assert result.granted is True
 
     def test_exhausted_budget_denied(self) -> None:
@@ -221,7 +226,6 @@ class TestConcurrency:
                 order_notional=Decimal('1000'),
                 estimated_fees=Decimal('10'),
                 strategy_budget=_POOL,
-                strategy_deployed=_ZERO,
             )
             results.append(r)
 
@@ -334,13 +338,7 @@ class TestInputValidation:
                 order_notional=Decimal('100'),
                 estimated_fees=Decimal('1'),
                 strategy_budget=Decimal('5000'),
-                strategy_deployed=Decimal('0'),
             )
-
-    def test_negative_deployed_rejected(self) -> None:
-        ctrl = _make_controller()
-        with pytest.raises(ValueError, match='strategy_deployed'):
-            _reserve(ctrl, deployed='-1')
 
     def test_zero_ttl_rejected(self) -> None:
         ctrl = _make_controller()
@@ -350,7 +348,6 @@ class TestInputValidation:
                 order_notional=Decimal('100'),
                 estimated_fees=Decimal('1'),
                 strategy_budget=Decimal('5000'),
-                strategy_deployed=Decimal('0'),
                 ttl_seconds=0,
             )
 
@@ -676,7 +673,6 @@ class TestLifecycleConcurrency:
                     order_notional=Decimal('500'),
                     estimated_fees=Decimal('5'),
                     strategy_budget=_POOL,
-                    strategy_deployed=_ZERO,
                 )
                 if res.granted and res.reservation:
                     sent = ctrl.send_order(res.reservation.reservation_id, f'ORD-{idx}')

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -126,6 +126,36 @@ class TestStrategyBudgetCheck:
         assert result.denial_reason is not None
         assert 'budget' in result.denial_reason.lower()
 
+    def test_budget_check_uses_normalized_strategy_id(self) -> None:
+        ctrl = _make_controller(
+            per_strategy_deployed={'strat_a': Decimal('4900')},
+        )
+        result = _reserve(
+            ctrl,
+            strategy_id=' strat_a ',
+            notional='200',
+            fees='1',
+            budget='5000',
+        )
+
+        assert result.granted is False
+        assert result.denial_reason is not None
+        assert 'budget' in result.denial_reason.lower()
+
+    def test_successful_reservation_stores_normalized_strategy_id(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(
+            ctrl,
+            strategy_id=' strat_a ',
+            notional='100',
+            fees='1',
+            budget='5000',
+        )
+
+        assert result.granted is True
+        assert 'strat_a' in ctrl._state.per_strategy_deployed
+        assert ' strat_a ' not in ctrl._state.per_strategy_deployed
+
     def test_negative_budget_denied(self) -> None:
         ctrl = _make_controller()
         result = _reserve(ctrl, notional='100', budget='-50')

--- a/tests/test_capital_state.py
+++ b/tests/test_capital_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import cast
 
 import pytest
 
@@ -133,6 +134,19 @@ def test_empty_strategy_key_rejected() -> None:
         CapitalState(
             capital_pool=Decimal('10000'),
             per_strategy_deployed={'': Decimal('1')},
+        )
+
+
+def test_non_string_strategy_key_rejected() -> None:
+    '''Verify non-string key in per_strategy_deployed raises ValueError.'''
+
+    with pytest.raises(ValueError, match='per_strategy_deployed keys'):
+        CapitalState(
+            capital_pool=Decimal('10000'),
+            per_strategy_deployed=cast(
+                dict[str, Decimal],
+                {Decimal('1'): Decimal('1')},
+            ),
         )
 
 

--- a/tests/test_capital_state.py
+++ b/tests/test_capital_state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -177,4 +177,14 @@ def test_nan_strategy_deployed_rejected() -> None:
         CapitalState(
             capital_pool=Decimal('10000'),
             per_strategy_deployed={'momentum': Decimal('NaN')},
+        )
+
+
+def test_non_decimal_strategy_deployed_rejected() -> None:
+    '''Verify non-Decimal deployed value in per_strategy_deployed raises ValueError.'''
+
+    with pytest.raises(ValueError, match='per_strategy_deployed values'):
+        CapitalState(
+            capital_pool=Decimal('10000'),
+            per_strategy_deployed=cast(dict[str, Decimal], {'momentum': cast(Any, 1)}),
         )

--- a/tests/test_capital_state.py
+++ b/tests/test_capital_state.py
@@ -150,6 +150,16 @@ def test_non_string_strategy_key_rejected() -> None:
         )
 
 
+def test_whitespace_strategy_key_rejected() -> None:
+    '''Verify whitespace-surrounded key in per_strategy_deployed raises ValueError.'''
+
+    with pytest.raises(ValueError, match='must not contain leading or trailing'):
+        CapitalState(
+            capital_pool=Decimal('10000'),
+            per_strategy_deployed={' strat_a ': Decimal('1')},
+        )
+
+
 def test_negative_strategy_deployed_rejected() -> None:
     '''Verify negative deployed value in per_strategy_deployed raises ValueError.'''
 

--- a/tests/test_capital_state.py
+++ b/tests/test_capital_state.py
@@ -188,3 +188,23 @@ def test_non_decimal_strategy_deployed_rejected() -> None:
             capital_pool=Decimal('10000'),
             per_strategy_deployed=cast(dict[str, Decimal], {'momentum': cast(Any, 1)}),
         )
+
+
+def test_non_mapping_per_strategy_deployed_rejected() -> None:
+    '''Verify non-mapping per_strategy_deployed raises ValueError.'''
+
+    with pytest.raises(ValueError, match='per_strategy_deployed must be a mapping'):
+        CapitalState(
+            capital_pool=Decimal('10000'),
+            per_strategy_deployed=cast(dict[str, Decimal], cast(Any, None)),
+        )
+
+
+def test_per_strategy_deployed_is_copied_on_init() -> None:
+    '''Verify CapitalState owns a copied per_strategy_deployed mapping.'''
+
+    source = {'momentum': Decimal('1')}
+    cs = CapitalState(capital_pool=Decimal('10000'), per_strategy_deployed=source)
+    source['momentum'] = Decimal('2')
+
+    assert cs.per_strategy_deployed['momentum'] == Decimal('1')

--- a/tests/test_capital_state.py
+++ b/tests/test_capital_state.py
@@ -19,6 +19,7 @@ def test_valid_creation() -> None:
     assert cs.in_flight_order_notional == Decimal(0)
     assert cs.fee_reserve == Decimal(0)
     assert cs.reservation_notional == Decimal(0)
+    assert cs.per_strategy_deployed == {}
 
 
 def test_available_all_zero() -> None:
@@ -107,4 +108,49 @@ def test_nan_notional_rejected() -> None:
         CapitalState(
             capital_pool=Decimal('10000'),
             position_notional=Decimal('NaN'),
+        )
+
+
+def test_valid_per_strategy_deployed_creation() -> None:
+    '''Verify valid per_strategy_deployed map is accepted.'''
+
+    cs = CapitalState(
+        capital_pool=Decimal('10000'),
+        per_strategy_deployed={
+            'momentum': Decimal('1200'),
+            'mean_rev': Decimal('300.5'),
+        },
+    )
+
+    assert cs.per_strategy_deployed['momentum'] == Decimal('1200')
+    assert cs.per_strategy_deployed['mean_rev'] == Decimal('300.5')
+
+
+def test_empty_strategy_key_rejected() -> None:
+    '''Verify empty strategy key in per_strategy_deployed raises ValueError.'''
+
+    with pytest.raises(ValueError, match='per_strategy_deployed keys'):
+        CapitalState(
+            capital_pool=Decimal('10000'),
+            per_strategy_deployed={'': Decimal('1')},
+        )
+
+
+def test_negative_strategy_deployed_rejected() -> None:
+    '''Verify negative deployed value in per_strategy_deployed raises ValueError.'''
+
+    with pytest.raises(ValueError, match='per_strategy_deployed values'):
+        CapitalState(
+            capital_pool=Decimal('10000'),
+            per_strategy_deployed={'momentum': Decimal('-1')},
+        )
+
+
+def test_nan_strategy_deployed_rejected() -> None:
+    '''Verify NaN deployed value in per_strategy_deployed raises ValueError.'''
+
+    with pytest.raises(ValueError, match='per_strategy_deployed values'):
+        CapitalState(
+            capital_pool=Decimal('10000'),
+            per_strategy_deployed={'momentum': Decimal('NaN')},
         )

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -166,6 +166,18 @@ def test_non_string_capital_pct_key_rejected() -> None:
         )
 
 
+def test_duplicate_capital_pct_key_after_normalization_rejected() -> None:
+    '''Verify duplicate keys after normalization raise ValueError.'''
+
+    with pytest.raises(ValueError, match='duplicate keys after normalization'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            capital_pct={'momentum': Decimal('10'), ' momentum ': Decimal('20')},
+        )
+
+
 def test_nan_capital_pct_rejected() -> None:
     '''Verify NaN capital_pct value raises ValueError.'''
 

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -154,6 +154,18 @@ def test_empty_capital_pct_key_rejected() -> None:
         )
 
 
+def test_non_string_capital_pct_key_rejected() -> None:
+    '''Verify non-string capital_pct key raises ValueError.'''
+
+    with pytest.raises(ValueError, match='capital_pct keys'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            capital_pct=cast(dict[str, Decimal], {1: Decimal('10')}),
+        )
+
+
 def test_nan_capital_pct_rejected() -> None:
     '''Verify NaN capital_pct value raises ValueError.'''
 

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -20,6 +20,21 @@ def test_valid_creation() -> None:
     assert cfg.account_id == 'acc_001'
     assert cfg.venue == 'binance_spot'
     assert cfg.allocated_capital == Decimal('10000')
+    assert cfg.capital_pct == {}
+
+
+def test_valid_creation_with_capital_pct() -> None:
+    '''Verify capital_pct map is accepted when values are valid.'''
+
+    cfg = InstanceConfig(
+        account_id='acc_001',
+        venue='binance_spot',
+        allocated_capital=Decimal('10000'),
+        capital_pct={'momentum': Decimal('60'), 'mean_rev': Decimal('40')},
+    )
+
+    assert cfg.capital_pct['momentum'] == Decimal('60')
+    assert cfg.capital_pct['mean_rev'] == Decimal('40')
 
 
 def test_frozen() -> None:
@@ -108,4 +123,64 @@ def test_infinity_capital_rejected() -> None:
             account_id='acc_001',
             venue='binance_spot',
             allocated_capital=Decimal('Infinity'),
+        )
+
+
+def test_empty_capital_pct_key_rejected() -> None:
+    '''Verify empty capital_pct strategy key raises ValueError.'''
+
+    with pytest.raises(ValueError, match='capital_pct keys'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            capital_pct={'': Decimal('10')},
+        )
+
+
+def test_nan_capital_pct_rejected() -> None:
+    '''Verify NaN capital_pct value raises ValueError.'''
+
+    with pytest.raises(ValueError, match='capital_pct values'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            capital_pct={'momentum': Decimal('NaN')},
+        )
+
+
+def test_non_positive_capital_pct_rejected() -> None:
+    '''Verify non-positive capital_pct value raises ValueError.'''
+
+    with pytest.raises(ValueError, match='capital_pct values'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            capital_pct={'momentum': Decimal('0')},
+        )
+
+
+def test_capital_pct_above_100_rejected() -> None:
+    '''Verify capital_pct value above 100 raises ValueError.'''
+
+    with pytest.raises(ValueError, match='capital_pct values'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            capital_pct={'momentum': Decimal('120')},
+        )
+
+
+def test_capital_pct_total_above_100_rejected() -> None:
+    '''Verify total capital_pct above 100 raises ValueError.'''
+
+    with pytest.raises(ValueError, match='capital_pct total'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            capital_pct={'momentum': Decimal('70'), 'mean_rev': Decimal('40')},
         )

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -178,6 +178,18 @@ def test_duplicate_capital_pct_key_after_normalization_rejected() -> None:
         )
 
 
+def test_non_mapping_capital_pct_rejected() -> None:
+    '''Verify non-mapping capital_pct raises ValueError.'''
+
+    with pytest.raises(ValueError, match='capital_pct must be a mapping'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            capital_pct=cast(dict[str, Decimal], cast(object, None)),
+        )
+
+
 def test_nan_capital_pct_rejected() -> None:
     '''Verify NaN capital_pct value raises ValueError.'''
 

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import cast
 
 import pytest
 
@@ -35,6 +36,21 @@ def test_valid_creation_with_capital_pct() -> None:
 
     assert cfg.capital_pct['momentum'] == Decimal('60')
     assert cfg.capital_pct['mean_rev'] == Decimal('40')
+
+
+def test_capital_pct_mapping_is_immutable() -> None:
+    '''Verify capital_pct cannot be mutated after initialization.'''
+
+    cfg = InstanceConfig(
+        account_id='acc_001',
+        venue='binance_spot',
+        allocated_capital=Decimal('10000'),
+        capital_pct={'momentum': Decimal('60')},
+    )
+
+    mutable_view = cast(dict[str, Decimal], cfg.capital_pct)
+    with pytest.raises(TypeError):
+        mutable_view['mean_rev'] = Decimal('40')
 
 
 def test_frozen() -> None:

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -127,6 +127,22 @@ class TestAppendMutation:
         entries = wal.read_all()
         assert entries[-1].sequence == 2
 
+    def test_per_strategy_deployed_round_trips(self, tmp_path: Path) -> None:
+        '''Verify per_strategy_deployed survives append_mutation and recover.'''
+
+        store = StateStore(tmp_path / 'state')
+        state = InstanceState(
+            capital=CapitalState(
+                capital_pool=Decimal('10000'),
+                per_strategy_deployed={'strat_a': Decimal('250.5')},
+            ),
+        )
+        store.append_mutation(state)
+
+        recovered = StateStore(tmp_path / 'state').recover()
+        assert recovered is not None
+        assert recovered.capital.per_strategy_deployed == {'strat_a': Decimal('250.5')}
+
 
 class TestRecover:
     '''Verify recover behavior across scenarios.'''

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -40,6 +40,10 @@ def _make_full_state() -> InstanceState:
             in_flight_order_notional=Decimal('1000.75'),
             fee_reserve=Decimal('200'),
             reservation_notional=Decimal('3000'),
+            per_strategy_deployed={
+                'momentum': Decimal('21000.5'),
+                'mean_rev': Decimal('8000.25'),
+            },
         ),
         risk=RiskState(
             high_water_mark=Decimal('110000'),
@@ -141,6 +145,10 @@ class TestRoundTrip:
         assert (
             restored.capital.reservation_notional
             == original.capital.reservation_notional
+        )
+        assert (
+            restored.capital.per_strategy_deployed
+            == original.capital.per_strategy_deployed
         )
 
     def test_full_state_risk(self) -> None:
@@ -316,6 +324,7 @@ class TestRiskDecodeDefaults:
         assert restored.risk.total_drawdown_pct == Decimal('0')
         assert restored.risk.max_drawdown == Decimal('0')
         assert restored.risk.max_drawdown_pct == Decimal('0')
+        assert restored.capital.per_strategy_deployed == {}
 
 
 class TestMalformedPayload:


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements journal item 2.6 end-to-end for per-strategy capital tracking. Adds `CapitalState.per_strategy_deployed` with validation, adds `InstanceConfig.capital_pct` with allocation constraints, and adds `CapitalController.compute_strategy_budget()` to derive strategy budgets from `capital_pool` and `capital_pct` (including optional realized-PnL compounding). Refactors reservation checks to use controller-owned deployed state instead of caller-provided deployed inputs. Adds lifecycle accounting updates for per-strategy deployed values across reservation expiry/release and order reject/cancel paths. Extends WAL/state recovery to persist and restore per-strategy deployed maps with backward-compatible defaults. Adds comprehensive tests for validation, strategy isolation, lifecycle accounting invariants, and WAL/state-store round-trips. Bumps project version to `0.10.0` and updates changelog.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (326 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable