### PR TITLE
feat: 3.2 order intake checks — max order rate and duplicate window hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,3 +108,12 @@
 - Add stage-6 platform-limits contracts for absolute operator limits (`max_order_notional`, `max_order_rate`, `max_position`, `max_daily_loss`, `max_capital_utilization`)
 - Add safety-action bypass for `EXIT`/`ABORT`/`CANCEL` across `CAPITAL`, `HEALTH`, and `PLATFORM_LIMITS`
 - Add deterministic denial coverage tests proving identical inputs/snapshots produce stable `failed_stage`, `reason_code`, and message outputs
+
+## v0.12.0 on 24th of March, 2026
+
+- Add `InstanceConfig.max_order_rate` as optional operator config with strict validation (reject bool/non-int/non-positive values)
+- Update default intake hook wiring to source `MAX_ORDER_RATE` from `InstanceConfig`, while preserving explicit hook override precedence
+- Add duplicate-window key regression coverage to lock idempotency semantics on (`strategy_id`, `command_id`) rather than order-shape ambiguity
+- Add temporal intake checks coverage for rate-window recovery and duplicate-window replay expiry behavior
+- Add explicit duplicate-hook non-ENTER bypass coverage and message-stability assertions for core intake deny paths
+- Expand validator intake test coverage and raise full-suite baseline to 470 passing tests

--- a/nexus/core/validator/intake_stage.py
+++ b/nexus/core/validator/intake_stage.py
@@ -43,7 +43,8 @@ def build_default_intake_hooks(
     Args:
         config: Instance config carrying duplicate window settings.
         active_command_ids: Active command id set for MODIFY/ABORT checks.
-        max_order_rate: Optional max ENTER actions per second.
+        max_order_rate: Optional max ENTER actions/sec override.
+            Defaults to ``config.max_order_rate`` when not provided.
         now_fn: Optional clock override for deterministic tests.
 
     Returns:
@@ -59,8 +60,11 @@ def build_default_intake_hooks(
         ),
     ]
 
-    if max_order_rate is not None:
-        hooks.insert(0, make_order_rate_hook(max_order_rate, now_fn=now_fn))
+    resolved_max_order_rate = (
+        config.max_order_rate if max_order_rate is None else max_order_rate
+    )
+    if resolved_max_order_rate is not None:
+        hooks.insert(0, make_order_rate_hook(resolved_max_order_rate, now_fn=now_fn))
 
     return tuple(hooks)
 

--- a/nexus/core/validator/intake_stage.py
+++ b/nexus/core/validator/intake_stage.py
@@ -41,7 +41,7 @@ def build_default_intake_hooks(
     '''Build default intake hooks from operator configuration.
 
     Args:
-        config: Instance config carrying duplicate window settings.
+        config: Instance config carrying duplicate-window and order-rate settings.
         active_command_ids: Active command id set for MODIFY/ABORT checks.
         max_order_rate: Optional max ENTER actions/sec override.
             Defaults to ``config.max_order_rate`` when not provided.

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -30,8 +30,10 @@ class InstanceConfig:
             must not exceed this value.
         duplicate_window_ms: Duplicate-order detection window for intake
             checks, in milliseconds.
-        max_order_rate: Optional cap on ENTER actions per second for intake
-            rate-limiting. ``None`` disables the rate check.
+        max_order_rate: Optional per-process cap on ENTER actions per second
+            for intake rate-limiting within this Manager process. This is not
+            a distributed/global limit across multiple processes or hosts.
+            ``None`` disables the rate check.
         capital_pct: Strategy capital-allocation percentages keyed by
             strategy_id.
     '''

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -30,6 +30,8 @@ class InstanceConfig:
             must not exceed this value.
         duplicate_window_ms: Duplicate-order detection window for intake
             checks, in milliseconds.
+        max_order_rate: Optional cap on ENTER actions per second for intake
+            rate-limiting. ``None`` disables the rate check.
         capital_pct: Strategy capital-allocation percentages keyed by
             strategy_id.
     '''

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -38,6 +38,7 @@ class InstanceConfig:
     venue: str
     allocated_capital: Decimal
     duplicate_window_ms: int = 1000
+    max_order_rate: int | None = None
     capital_pct: Mapping[str, Decimal] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -65,6 +66,18 @@ class InstanceConfig:
         if self.duplicate_window_ms <= 0:
             msg = 'InstanceConfig.duplicate_window_ms must be a positive integer'
             raise ValueError(msg)
+
+        if self.max_order_rate is not None:
+            if isinstance(self.max_order_rate, bool) or not isinstance(
+                self.max_order_rate,
+                int,
+            ):
+                msg = 'InstanceConfig.max_order_rate must be an integer'
+                raise ValueError(msg)
+
+            if self.max_order_rate <= 0:
+                msg = 'InstanceConfig.max_order_rate must be a positive integer'
+                raise ValueError(msg)
 
         if not isinstance(self.capital_pct, Mapping):
             msg = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.11.0"
+version = "0.12.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -22,6 +22,7 @@ def test_valid_creation() -> None:
     assert cfg.venue == 'binance_spot'
     assert cfg.allocated_capital == Decimal('10000')
     assert cfg.duplicate_window_ms == 1000
+    assert cfg.max_order_rate is None
     assert cfg.capital_pct == {}
 
 
@@ -35,6 +36,16 @@ def test_valid_creation_with_duplicate_window_ms() -> None:
         duplicate_window_ms=250,
     )
     assert cfg.duplicate_window_ms == 250
+
+
+def test_valid_creation_with_max_order_rate() -> None:
+    cfg = InstanceConfig(
+        account_id='acc_001',
+        venue='binance_spot',
+        allocated_capital=Decimal('10000'),
+        max_order_rate=7,
+    )
+    assert cfg.max_order_rate == 7
 
 
 def test_valid_creation_with_capital_pct() -> None:
@@ -175,6 +186,36 @@ def test_non_positive_duplicate_window_rejected() -> None:
             venue='binance_spot',
             allocated_capital=Decimal('10000'),
             duplicate_window_ms=0,
+        )
+
+
+def test_non_int_max_order_rate_rejected() -> None:
+    with pytest.raises(ValueError, match='max_order_rate'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            max_order_rate=cast(int, cast(object, '5')),
+        )
+
+
+def test_bool_max_order_rate_rejected() -> None:
+    with pytest.raises(ValueError, match='max_order_rate'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            max_order_rate=cast(int, cast(object, True)),
+        )
+
+
+def test_non_positive_max_order_rate_rejected() -> None:
+    with pytest.raises(ValueError, match='max_order_rate'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            max_order_rate=0,
         )
 
 

--- a/tests/test_validator_intake_stage.py
+++ b/tests/test_validator_intake_stage.py
@@ -203,6 +203,7 @@ class TestRfcStageOneHooks:
         assert d2.allowed is True
         assert d3.allowed is False
         assert d3.reason_code == 'INTAKE_MAX_ORDER_RATE_EXCEEDED'
+        assert d3.message == 'max_order_rate exceeded: limit=2/s'
 
     def test_max_order_rate_ignores_non_enter(self) -> None:
         rate_hook = make_order_rate_hook(1)
@@ -232,6 +233,7 @@ class TestRfcStageOneHooks:
         assert d1.allowed is True
         assert d2.allowed is False
         assert d2.reason_code == 'INTAKE_DUPLICATE_ORDER_WINDOW'
+        assert d2.message == 'duplicate command_id detected within 1000ms window'
 
     def test_duplicate_window_keyed_by_strategy_id(self) -> None:
         dupe_hook = make_duplicate_order_hook(1000)
@@ -254,6 +256,117 @@ class TestRfcStageOneHooks:
         )
         d2 = validate_intake_stage(
             _make_context(command_id='cmd_2'),
+            hooks=(dupe_hook,),
+        )
+
+        assert d1.allowed is True
+        assert d2.allowed is True
+
+    def test_duplicate_window_keys_on_command_id_not_order_shape(self) -> None:
+        times = [
+            datetime(2026, 3, 23, 10, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 3, 23, 10, 0, 0, 300000, tzinfo=timezone.utc),
+        ]
+        idx = {'n': 0}
+
+        def now_fn() -> datetime:
+            t = times[idx['n']]
+            idx['n'] += 1
+            return t
+
+        dupe_hook = make_duplicate_order_hook(1000, now_fn=now_fn)
+
+        d1 = validate_intake_stage(
+            _make_context(command_id='cmd_same', order_size=Decimal('1.0')),
+            hooks=(dupe_hook,),
+        )
+        d2 = validate_intake_stage(
+            _make_context(command_id='cmd_same', order_size=Decimal('2.0')),
+            hooks=(dupe_hook,),
+        )
+
+        assert d1.allowed is True
+        assert d2.allowed is False
+        assert d2.reason_code == 'INTAKE_DUPLICATE_ORDER_WINDOW'
+
+    def test_max_order_rate_recovers_after_window_cutoff(self) -> None:
+        times = [
+            datetime(2026, 3, 23, 10, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 3, 23, 10, 0, 0, 100000, tzinfo=timezone.utc),
+            datetime(2026, 3, 23, 10, 0, 1, 200000, tzinfo=timezone.utc),
+        ]
+        idx = {'n': 0}
+
+        def now_fn() -> datetime:
+            t = times[idx['n']]
+            idx['n'] += 1
+            return t
+
+        rate_hook = make_order_rate_hook(1, now_fn=now_fn)
+
+        d1 = validate_intake_stage(_make_context(), hooks=(rate_hook,))
+        d2 = validate_intake_stage(_make_context(), hooks=(rate_hook,))
+        d3 = validate_intake_stage(_make_context(), hooks=(rate_hook,))
+
+        assert d1.allowed is True
+        assert d2.allowed is False
+        assert d2.reason_code == 'INTAKE_MAX_ORDER_RATE_EXCEEDED'
+        assert d3.allowed is True
+
+    def test_duplicate_window_replay_block_expires_after_window(self) -> None:
+        times = [
+            datetime(2026, 3, 23, 10, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 3, 23, 10, 0, 0, 300000, tzinfo=timezone.utc),
+            datetime(2026, 3, 23, 10, 0, 1, 300000, tzinfo=timezone.utc),
+        ]
+        idx = {'n': 0}
+
+        def now_fn() -> datetime:
+            t = times[idx['n']]
+            idx['n'] += 1
+            return t
+
+        dupe_hook = make_duplicate_order_hook(1000, now_fn=now_fn)
+
+        d1 = validate_intake_stage(
+            _make_context(command_id='cmd_replay'),
+            hooks=(dupe_hook,),
+        )
+        d2 = validate_intake_stage(
+            _make_context(command_id='cmd_replay'),
+            hooks=(dupe_hook,),
+        )
+        d3 = validate_intake_stage(
+            _make_context(command_id='cmd_replay'),
+            hooks=(dupe_hook,),
+        )
+
+        assert d1.allowed is True
+        assert d2.allowed is False
+        assert d2.reason_code == 'INTAKE_DUPLICATE_ORDER_WINDOW'
+        assert d3.allowed is True
+
+    def test_duplicate_window_ignores_non_enter_without_clock_reads(self) -> None:
+        def now_fn() -> datetime:
+            msg = 'duplicate hook clock should not be used for non-ENTER actions'
+            raise AssertionError(msg)
+
+        dupe_hook = make_duplicate_order_hook(1000, now_fn=now_fn)
+
+        d1 = validate_intake_stage(
+            _make_context(
+                action=ValidationAction.EXIT,
+                order_side=OrderSide.SELL,
+                command_id='cmd_same',
+            ),
+            hooks=(dupe_hook,),
+        )
+        d2 = validate_intake_stage(
+            _make_context(
+                action=ValidationAction.EXIT,
+                order_side=OrderSide.SELL,
+                command_id='cmd_same',
+            ),
             hooks=(dupe_hook,),
         )
 

--- a/tests/test_validator_intake_stage.py
+++ b/tests/test_validator_intake_stage.py
@@ -402,3 +402,61 @@ class TestRfcStageOneHooks:
         )
 
         assert decision.allowed is True
+
+    def test_default_hooks_apply_config_max_order_rate(self) -> None:
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            max_order_rate=1,
+        )
+
+        times = [
+            datetime(2026, 3, 23, 10, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 3, 23, 10, 0, 0, 50000, tzinfo=timezone.utc),
+            datetime(2026, 3, 23, 10, 0, 0, 100000, tzinfo=timezone.utc),
+        ]
+        idx = {'n': 0}
+
+        def now_fn() -> datetime:
+            t = times[idx['n']]
+            idx['n'] += 1
+            return t
+
+        hooks = build_default_intake_hooks(config, now_fn=now_fn)
+
+        d1 = validate_intake_stage(_make_context(config=config), hooks=hooks)
+        d2 = validate_intake_stage(_make_context(config=config), hooks=hooks)
+
+        assert d1.allowed is True
+        assert d2.allowed is False
+        assert d2.reason_code == 'INTAKE_MAX_ORDER_RATE_EXCEEDED'
+
+    def test_default_hooks_max_order_rate_override_takes_precedence(self) -> None:
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            max_order_rate=2,
+        )
+
+        times = [
+            datetime(2026, 3, 23, 10, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 3, 23, 10, 0, 0, 50000, tzinfo=timezone.utc),
+            datetime(2026, 3, 23, 10, 0, 0, 100000, tzinfo=timezone.utc),
+        ]
+        idx = {'n': 0}
+
+        def now_fn() -> datetime:
+            t = times[idx['n']]
+            idx['n'] += 1
+            return t
+
+        hooks = build_default_intake_hooks(config, max_order_rate=1, now_fn=now_fn)
+
+        d1 = validate_intake_stage(_make_context(config=config), hooks=hooks)
+        d2 = validate_intake_stage(_make_context(config=config), hooks=hooks)
+
+        assert d1.allowed is True
+        assert d2.allowed is False
+        assert d2.reason_code == 'INTAKE_MAX_ORDER_RATE_EXCEEDED'


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements RFC 3.2 intake-check hardening across configuration, hook wiring, and deterministic validation coverage. Adds `InstanceConfig.max_order_rate` with strict runtime guards (reject `bool`, non-`int`, non-positive values). Updates default intake hook assembly to source `MAX_ORDER_RATE` from config while preserving explicit override precedence. Expands intake-stage tests to lock idempotency semantics on (`strategy_id`, `command_id`), verify temporal window behavior (rate-limit recovery and duplicate replay expiry), enforce non-ENTER duplicate bypass behavior, and stabilize deny reason message assertions. Updates changelog and bumps package version to v0.12.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (470 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable