### PR TITLE
feat: 3.3 modify validation — delta capital and lifecycle gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@
 ## v0.13.0 on 24th of March, 2026
 
 - Add `MODIFY` edit-baseline field `current_order_notional` to `ValidationRequestContext` with strict finite/non-negative validation
-- Add capital-stage delta semantics for `MODIFY`: reserve only positive notional deltas, skip reservation for no-op/decrease edits
+- Add capital-stage delta semantics for `MODIFY`: when `current_order_notional` is provided, reserve only positive deltas and skip reservation for no-op/decrease edits; otherwise reserve full `order_notional`
 - Add strict lifecycle gate for `MODIFY` in intake hooks: require `modifiable_command_ids`, deny when unavailable, and validate command membership against modifiable set
 - Add capital-stage tests for `MODIFY` increase/decrease/no-op reservation behavior
 - Add pipeline-executor tests for `MODIFY` increase/decrease/no-op flows and deterministic deny stage/reason/message behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,3 +117,12 @@
 - Add temporal intake checks coverage for rate-window recovery and duplicate-window replay expiry behavior
 - Add explicit duplicate-hook non-ENTER bypass coverage and message-stability assertions for core intake deny paths
 - Expand validator intake test coverage and raise full-suite baseline to 470 passing tests
+
+## v0.13.0 on 24th of March, 2026
+
+- Add `MODIFY` edit-baseline fields to `ValidationRequestContext` (`current_order_notional`, `current_order_size`) with strict finite/non-negative validation
+- Add capital-stage delta semantics for `MODIFY`: reserve only positive notional deltas, skip reservation for no-op/decrease edits
+- Add strict lifecycle gate for `MODIFY` in intake hooks: require `modifiable_command_ids`, deny when unavailable, and validate command membership against modifiable set
+- Add capital-stage tests for `MODIFY` increase/decrease/no-op reservation behavior
+- Add pipeline-executor tests for `MODIFY` increase/decrease/no-op flows and deterministic deny stage/reason/message behavior
+- Expand validator test baseline to 486 passing tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@
 
 ## v0.13.0 on 24th of March, 2026
 
-- Add `MODIFY` edit-baseline fields to `ValidationRequestContext` (`current_order_notional`, `current_order_size`) with strict finite/non-negative validation
+- Add `MODIFY` edit-baseline field `current_order_notional` to `ValidationRequestContext` with strict finite/non-negative validation
 - Add capital-stage delta semantics for `MODIFY`: reserve only positive notional deltas, skip reservation for no-op/decrease edits
 - Add strict lifecycle gate for `MODIFY` in intake hooks: require `modifiable_command_ids`, deny when unavailable, and validate command membership against modifiable set
 - Add capital-stage tests for `MODIFY` increase/decrease/no-op reservation behavior

--- a/nexus/core/validator/capital_stage.py
+++ b/nexus/core/validator/capital_stage.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 from nexus.core.capital_controller.capital_controller import CapitalController
 from nexus.core.validator.pipeline_models import (
+    ValidationAction,
     ValidationDecision,
     ValidationRequestContext,
     ValidationStage,
@@ -12,6 +15,7 @@ from nexus.core.validator.pipeline_models import (
 __all__ = ['CAPITAL_RESERVATION_DENIED_CODE', 'validate_capital_stage']
 
 CAPITAL_RESERVATION_DENIED_CODE = 'CAPITAL_RESERVATION_DENIED'
+_ZERO = Decimal('0')
 
 
 def validate_capital_stage(
@@ -32,9 +36,18 @@ def validate_capital_stage(
             raise ValueError(msg)
         kwargs['ttl_seconds'] = ttl_seconds
 
+    order_notional = context.order_notional
+    if (
+        context.action == ValidationAction.MODIFY
+        and context.current_order_notional is not None
+    ):
+        order_notional = context.order_notional - context.current_order_notional
+        if order_notional <= _ZERO:
+            return ValidationDecision(allowed=True)
+
     result = capital_controller.check_and_reserve(
         strategy_id=context.strategy_id,
-        order_notional=context.order_notional,
+        order_notional=order_notional,
         estimated_fees=context.estimated_fees,
         strategy_budget=context.strategy_budget,
         **kwargs,

--- a/nexus/core/validator/capital_stage.py
+++ b/nexus/core/validator/capital_stage.py
@@ -37,6 +37,7 @@ def validate_capital_stage(
         kwargs['ttl_seconds'] = ttl_seconds
 
     order_notional = context.order_notional
+    estimated_fees = context.estimated_fees
     if (
         context.action == ValidationAction.MODIFY
         and context.current_order_notional is not None
@@ -44,11 +45,14 @@ def validate_capital_stage(
         order_notional = context.order_notional - context.current_order_notional
         if order_notional <= _ZERO:
             return ValidationDecision(allowed=True)
+        estimated_fees = (
+            context.estimated_fees * order_notional
+        ) / context.order_notional
 
     result = capital_controller.check_and_reserve(
         strategy_id=context.strategy_id,
         order_notional=order_notional,
-        estimated_fees=context.estimated_fees,
+        estimated_fees=estimated_fees,
         strategy_budget=context.strategy_budget,
         **kwargs,
     )

--- a/nexus/core/validator/intake_stage.py
+++ b/nexus/core/validator/intake_stage.py
@@ -43,9 +43,9 @@ def build_default_intake_hooks(
 
     Args:
         config: Instance config carrying duplicate-window and order-rate settings.
-        active_command_ids: Active command id set for MODIFY/ABORT checks.
-        modifiable_command_ids: Optional lifecycle-valid command ids for MODIFY.
-            When provided, MODIFY must target this set.
+        active_command_ids: Active command id set used for ABORT checks.
+        modifiable_command_ids: Lifecycle-valid command ids for MODIFY.
+            MODIFY is validated against this set; when ``None``, MODIFY is denied.
         max_order_rate: Optional max ENTER actions/sec override.
             Defaults to ``config.max_order_rate`` when not provided.
         now_fn: Optional clock override for deterministic tests.
@@ -329,6 +329,7 @@ def validate_intake_stage(
             ValidationAction.EXIT,
             ValidationAction.ABORT,
             ValidationAction.CANCEL,
+            ValidationAction.MODIFY,
         )
         and context.strategy_budget == 0
     ):

--- a/nexus/core/validator/intake_stage.py
+++ b/nexus/core/validator/intake_stage.py
@@ -35,6 +35,7 @@ def build_default_intake_hooks(
     config: InstanceConfig,
     *,
     active_command_ids: set[str] | None = None,
+    modifiable_command_ids: set[str] | None = None,
     max_order_rate: int | None = None,
     now_fn: Callable[[], datetime] | None = None,
 ) -> tuple[IntakeValidationHook, ...]:
@@ -43,6 +44,8 @@ def build_default_intake_hooks(
     Args:
         config: Instance config carrying duplicate-window and order-rate settings.
         active_command_ids: Active command id set for MODIFY/ABORT checks.
+        modifiable_command_ids: Optional lifecycle-valid command ids for MODIFY.
+            When provided, MODIFY must target this set.
         max_order_rate: Optional max ENTER actions/sec override.
             Defaults to ``config.max_order_rate`` when not provided.
         now_fn: Optional clock override for deterministic tests.
@@ -56,7 +59,8 @@ def build_default_intake_hooks(
         make_reference_integrity_hook(
             active_command_ids=(
                 active_command_ids if active_command_ids is not None else set()
-            )
+            ),
+            modifiable_command_ids=modifiable_command_ids,
         ),
     ]
 
@@ -188,6 +192,8 @@ def make_duplicate_order_hook(
 
 def make_reference_integrity_hook(
     active_command_ids: set[str],
+    *,
+    modifiable_command_ids: set[str] | None = None,
 ) -> IntakeValidationHook:
     '''Create intake hook for trade/command references and spot-direction rules.'''
 
@@ -247,15 +253,22 @@ def make_reference_integrity_hook(
                     )
 
         elif context.action == ValidationAction.MODIFY:
-            if (
+            if modifiable_command_ids is None:
+                decision = ValidationDecision(
+                    allowed=False,
+                    failed_stage=ValidationStage.INTAKE,
+                    reason_code='INTAKE_MODIFIABLE_COMMANDS_UNAVAILABLE',
+                    message='MODIFY requires modifiable_command_ids to be provided',
+                )
+            elif (
                 context.command_id is None
-                or context.command_id not in active_command_ids
+                or context.command_id not in modifiable_command_ids
             ):
                 decision = ValidationDecision(
                     allowed=False,
                     failed_stage=ValidationStage.INTAKE,
                     reason_code='INTAKE_COMMAND_REFERENCE_INVALID',
-                    message='MODIFY requires valid active command_id',
+                    message='MODIFY requires valid modifiable command_id',
                 )
             elif context.order_size is None or context.order_size <= _ZERO:
                 decision = ValidationDecision(

--- a/nexus/core/validator/pipeline_models.py
+++ b/nexus/core/validator/pipeline_models.py
@@ -67,9 +67,12 @@ class ValidationRequestContext:
         symbol: Trading symbol for this action.
         order_side: Direction for actions that carry side semantics.
         order_size: Base-asset size for actions that carry size semantics.
+        current_order_size: Current base-asset size for edit (`MODIFY`) context.
         trade_id: Trade reference for actions targeting existing positions.
         command_id: Command reference for actions targeting existing commands.
         order_notional: Requested order notional (quote units).
+        current_order_notional: Current command/order notional for edit
+            (`MODIFY`) context (quote units).
         estimated_fees: Estimated fees for the action (quote units).
         strategy_budget: Current strategy budget ceiling (quote units).
         state: Current runtime instance state snapshot.
@@ -86,8 +89,10 @@ class ValidationRequestContext:
     symbol: str = 'BTCUSDT'
     order_side: OrderSide | None = OrderSide.BUY
     order_size: Decimal | None = None
+    current_order_size: Decimal | None = None
     trade_id: str | None = None
     command_id: str | None = 'cmd_default'
+    current_order_notional: Decimal | None = None
 
     def __post_init__(self) -> None:
         '''Validate context invariants at construction time.'''
@@ -115,6 +120,17 @@ class ValidationRequestContext:
         ):
             msg = (
                 'ValidationRequestContext.order_size must be a finite '
+                'non-negative Decimal or None'
+            )
+            raise ValueError(msg)
+
+        if self.current_order_size is not None and (
+            not isinstance(self.current_order_size, Decimal)
+            or not self.current_order_size.is_finite()
+            or self.current_order_size < _ZERO
+        ):
+            msg = (
+                'ValidationRequestContext.current_order_size must be a finite '
                 'non-negative Decimal or None'
             )
             raise ValueError(msg)
@@ -148,6 +164,17 @@ class ValidationRequestContext:
                     'non-negative Decimal'
                 )
                 raise ValueError(msg)
+
+        if self.current_order_notional is not None and (
+            not isinstance(self.current_order_notional, Decimal)
+            or not self.current_order_notional.is_finite()
+            or self.current_order_notional < _ZERO
+        ):
+            msg = (
+                'ValidationRequestContext.current_order_notional must be a finite '
+                'non-negative Decimal or None'
+            )
+            raise ValueError(msg)
 
         if not isinstance(self.state, InstanceState):
             msg = 'ValidationRequestContext.state must be an InstanceState instance'

--- a/nexus/core/validator/pipeline_models.py
+++ b/nexus/core/validator/pipeline_models.py
@@ -67,7 +67,6 @@ class ValidationRequestContext:
         symbol: Trading symbol for this action.
         order_side: Direction for actions that carry side semantics.
         order_size: Base-asset size for actions that carry size semantics.
-        current_order_size: Current base-asset size for edit (`MODIFY`) context.
         trade_id: Trade reference for actions targeting existing positions.
         command_id: Command reference for actions targeting existing commands.
         order_notional: Requested order notional (quote units).
@@ -89,7 +88,6 @@ class ValidationRequestContext:
     symbol: str = 'BTCUSDT'
     order_side: OrderSide | None = OrderSide.BUY
     order_size: Decimal | None = None
-    current_order_size: Decimal | None = None
     trade_id: str | None = None
     command_id: str | None = 'cmd_default'
     current_order_notional: Decimal | None = None
@@ -120,17 +118,6 @@ class ValidationRequestContext:
         ):
             msg = (
                 'ValidationRequestContext.order_size must be a finite '
-                'non-negative Decimal or None'
-            )
-            raise ValueError(msg)
-
-        if self.current_order_size is not None and (
-            not isinstance(self.current_order_size, Decimal)
-            or not self.current_order_size.is_finite()
-            or self.current_order_size < _ZERO
-        ):
-            msg = (
-                'ValidationRequestContext.current_order_size must be a finite '
                 'non-negative Decimal or None'
             )
             raise ValueError(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.12.0"
+version = "0.13.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_validator_capital_stage.py
+++ b/tests/test_validator_capital_stage.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 import pytest
 
 from nexus.core.capital_controller.capital_controller import CapitalController
+from nexus.core.capital_controller.reservation import ReservationResult
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.validator import (
     ValidationAction,
@@ -134,6 +135,29 @@ class TestValidateCapitalStage:
         assert decision.allowed is True
         assert decision.reservation is None
         capital_controller.check_and_reserve.assert_not_called()
+
+    def test_modify_uses_delta_estimated_fees_for_capital_check(self) -> None:
+        context = _make_context(
+            action=ValidationAction.MODIFY,
+            order_notional=Decimal('120'),
+            current_order_notional=Decimal('100'),
+            estimated_fees=Decimal('6'),
+            strategy_budget=Decimal('5000'),
+        )
+        capital_controller = Mock()
+        capital_controller.check_and_reserve.return_value = ReservationResult(
+            granted=False,
+            denial_reason='denied',
+        )
+
+        _ = validate_capital_stage(context, cast(CapitalController, capital_controller))
+
+        capital_controller.check_and_reserve.assert_called_once_with(
+            strategy_id='strat_a',
+            order_notional=Decimal('20'),
+            estimated_fees=Decimal('1'),
+            strategy_budget=Decimal('5000'),
+        )
 
     @pytest.mark.parametrize('invalid_ttl', [True, 0, -1, 1.5])
     def test_rejects_invalid_ttl_seconds(self, invalid_ttl: object) -> None:

--- a/tests/test_validator_capital_stage.py
+++ b/tests/test_validator_capital_stage.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from datetime import timedelta
 from decimal import Decimal
 from typing import cast
+from unittest.mock import Mock
 
 import pytest
 
 from nexus.core.capital_controller.capital_controller import CapitalController
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.validator import (
+    ValidationAction,
     ValidationRequestContext,
     ValidationStage,
     validate_capital_stage,
@@ -19,7 +21,9 @@ from nexus.instance_config import InstanceConfig
 def _make_context(
     *,
     strategy_id: str = 'strat_a',
+    action: ValidationAction = ValidationAction.ENTER,
     order_notional: Decimal = Decimal('100'),
+    current_order_notional: Decimal | None = None,
     estimated_fees: Decimal = Decimal('1'),
     strategy_budget: Decimal = Decimal('5000'),
 ) -> ValidationRequestContext:
@@ -31,8 +35,10 @@ def _make_context(
     state = InstanceState.from_config(config)
     return ValidationRequestContext(
         strategy_id=strategy_id,
+        action=action,
         command_id='cmd_cap_1',
         order_notional=order_notional,
+        current_order_notional=current_order_notional,
         estimated_fees=estimated_fees,
         strategy_budget=strategy_budget,
         state=state,
@@ -78,6 +84,56 @@ class TestValidateCapitalStage:
             decision.reservation.expires_at - decision.reservation.created_at
             == timedelta(seconds=7)
         )
+
+    def test_modify_uses_positive_notional_delta_for_capital_check(self) -> None:
+        context = _make_context(
+            action=ValidationAction.MODIFY,
+            order_notional=Decimal('100'),
+            current_order_notional=Decimal('80'),
+            strategy_budget=Decimal('30'),
+        )
+        capital_controller = CapitalController(context.state.capital)
+
+        decision = validate_capital_stage(context, capital_controller)
+
+        assert decision.allowed is True
+        assert decision.reservation is not None
+
+    def test_modify_non_increasing_notional_skips_capital_reservation(self) -> None:
+        context = _make_context(
+            action=ValidationAction.MODIFY,
+            order_notional=Decimal('80'),
+            current_order_notional=Decimal('100'),
+            strategy_budget=Decimal('0'),
+        )
+        capital_controller = Mock()
+
+        decision = validate_capital_stage(
+            context,
+            cast(CapitalController, capital_controller),
+        )
+
+        assert decision.allowed is True
+        assert decision.reservation is None
+        capital_controller.check_and_reserve.assert_not_called()
+
+    def test_modify_same_notional_skips_capital_reservation(self) -> None:
+        context = _make_context(
+            action=ValidationAction.MODIFY,
+            order_notional=Decimal('100'),
+            current_order_notional=Decimal('100'),
+            strategy_budget=Decimal('0'),
+        )
+        capital_controller = Mock()
+
+        decision = validate_capital_stage(
+            context,
+            cast(CapitalController, capital_controller),
+        )
+
+        assert decision.allowed is True
+        assert decision.reservation is None
+        capital_controller.check_and_reserve.assert_not_called()
 
     @pytest.mark.parametrize('invalid_ttl', [True, 0, -1, 1.5])
     def test_rejects_invalid_ttl_seconds(self, invalid_ttl: object) -> None:

--- a/tests/test_validator_intake_stage.py
+++ b/tests/test_validator_intake_stage.py
@@ -413,7 +413,7 @@ class TestRfcStageOneHooks:
         assert decision.allowed is False
         assert decision.reason_code == 'INTAKE_EXIT_SIZE_EXCEEDS_REMAINING'
 
-    def test_reference_integrity_modify_requires_active_command(self) -> None:
+    def test_reference_integrity_modify_requires_modifiable_set(self) -> None:
         ref_hook = make_reference_integrity_hook(active_command_ids={'cmd_ok'})
 
         decision = validate_intake_stage(
@@ -425,10 +425,52 @@ class TestRfcStageOneHooks:
             hooks=(ref_hook,),
         )
         assert decision.allowed is False
+        assert decision.reason_code == 'INTAKE_MODIFIABLE_COMMANDS_UNAVAILABLE'
+
+    def test_reference_integrity_modify_requires_modifiable_command_when_provided(
+        self,
+    ) -> None:
+        ref_hook = make_reference_integrity_hook(
+            active_command_ids={'cmd_ok', 'cmd_finalized'},
+            modifiable_command_ids={'cmd_ok'},
+        )
+
+        decision = validate_intake_stage(
+            _make_context(
+                action=ValidationAction.MODIFY,
+                command_id='cmd_finalized',
+                order_side=None,
+            ),
+            hooks=(ref_hook,),
+        )
+
+        assert decision.allowed is False
         assert decision.reason_code == 'INTAKE_COMMAND_REFERENCE_INVALID'
 
+    def test_reference_integrity_modify_accepts_modifiable_command_when_provided(
+        self,
+    ) -> None:
+        ref_hook = make_reference_integrity_hook(
+            active_command_ids={'cmd_ok', 'cmd_finalized'},
+            modifiable_command_ids={'cmd_ok'},
+        )
+
+        decision = validate_intake_stage(
+            _make_context(
+                action=ValidationAction.MODIFY,
+                command_id='cmd_ok',
+                order_side=None,
+            ),
+            hooks=(ref_hook,),
+        )
+
+        assert decision.allowed is True
+
     def test_reference_integrity_modify_requires_positive_size(self) -> None:
-        ref_hook = make_reference_integrity_hook(active_command_ids={'cmd_ok'})
+        ref_hook = make_reference_integrity_hook(
+            active_command_ids={'cmd_ok'},
+            modifiable_command_ids={'cmd_ok'},
+        )
 
         decision = validate_intake_stage(
             _make_context(
@@ -492,7 +534,7 @@ class TestRfcStageOneHooks:
         assert d2.allowed is False
         assert d2.reason_code == 'INTAKE_DUPLICATE_ORDER_WINDOW'
 
-    def test_default_hooks_preserve_provided_empty_active_command_ids_set(self) -> None:
+    def test_default_hooks_modify_requires_modifiable_command_ids(self) -> None:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
@@ -514,7 +556,45 @@ class TestRfcStageOneHooks:
             hooks=hooks,
         )
 
-        assert decision.allowed is True
+        assert decision.allowed is False
+        assert decision.reason_code == 'INTAKE_MODIFIABLE_COMMANDS_UNAVAILABLE'
+
+    def test_default_hooks_use_provided_modifiable_command_ids(self) -> None:
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+        )
+        active_command_ids = {'cmd_mod', 'cmd_done'}
+        modifiable_command_ids: set[str] = set()
+        hooks = build_default_intake_hooks(
+            config,
+            active_command_ids=active_command_ids,
+            modifiable_command_ids=modifiable_command_ids,
+        )
+
+        modifiable_command_ids.add('cmd_mod')
+
+        denied = validate_intake_stage(
+            _make_context(
+                action=ValidationAction.MODIFY,
+                command_id='cmd_done',
+                order_side=None,
+            ),
+            hooks=hooks,
+        )
+        allowed = validate_intake_stage(
+            _make_context(
+                action=ValidationAction.MODIFY,
+                command_id='cmd_mod',
+                order_side=None,
+            ),
+            hooks=hooks,
+        )
+
+        assert denied.allowed is False
+        assert denied.reason_code == 'INTAKE_COMMAND_REFERENCE_INVALID'
+        assert allowed.allowed is True
 
     def test_default_hooks_apply_config_max_order_rate(self) -> None:
         config = InstanceConfig(

--- a/tests/test_validator_intake_stage.py
+++ b/tests/test_validator_intake_stage.py
@@ -71,6 +71,16 @@ class TestIntakeBuiltins:
         assert decision.allowed is False
         assert decision.reason_code == 'INTAKE_STRATEGY_BUDGET_ZERO'
 
+    def test_zero_strategy_budget_allowed_for_modify_builtin_gate(self) -> None:
+        decision = validate_intake_stage(
+            _make_context(
+                action=ValidationAction.MODIFY,
+                strategy_budget=Decimal('0'),
+                order_side=None,
+            )
+        )
+        assert decision.allowed is True
+
     @pytest.mark.parametrize(
         ('action', 'side'),
         [

--- a/tests/test_validator_pipeline_executor.py
+++ b/tests/test_validator_pipeline_executor.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 
+from nexus.core.capital_controller.capital_controller import CapitalController
 from nexus.core.capital_controller.reservation import Reservation
 from nexus.core.validator import (
     DEFAULT_VALIDATION_STAGE_ORDER,
@@ -17,29 +18,33 @@ from nexus.core.validator import (
     ValidationPipeline,
     ValidationRequestContext,
     ValidationStage,
+    build_default_intake_hooks,
+    validate_intake_stage,
+    validate_capital_stage,
 )
 from nexus.instance_config import InstanceConfig
 from nexus.core.domain.instance_state import InstanceState
 
 
-def _make_context(
-    *, action: ValidationAction = ValidationAction.ENTER
-) -> ValidationRequestContext:
+def _make_context(**overrides: Any) -> ValidationRequestContext:
     config = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
         allocated_capital=Decimal('10000'),
     )
-    return ValidationRequestContext(
-        strategy_id='strat_a',
-        action=action,
-        command_id='cmd_exec_1',
-        order_notional=Decimal('100'),
-        estimated_fees=Decimal('1'),
-        strategy_budget=Decimal('5000'),
-        state=InstanceState.from_config(config),
-        config=config,
-    )
+    defaults: dict[str, Any] = {
+        'strategy_id': 'strat_a',
+        'action': ValidationAction.ENTER,
+        'command_id': 'cmd_exec_1',
+        'order_notional': Decimal('100'),
+        'current_order_notional': None,
+        'estimated_fees': Decimal('1'),
+        'strategy_budget': Decimal('5000'),
+        'state': InstanceState.from_config(config),
+        'config': config,
+    }
+    defaults.update(overrides)
+    return ValidationRequestContext(**defaults)
 
 
 def _allow(_: ValidationRequestContext) -> ValidationDecision:
@@ -253,6 +258,72 @@ class TestValidationPipelineRun:
         assert decision_a.message == 'Book staleness exceeded threshold'
         assert decision_b.message == 'Book staleness exceeded threshold'
 
+    def test_modify_intake_denial_is_deterministic_when_modifiable_set_missing(
+        self,
+    ) -> None:
+        context = _make_context(
+            action=ValidationAction.MODIFY,
+            command_id='cmd_exec_1',
+            order_side=None,
+            order_size=Decimal('1'),
+        )
+        hooks = build_default_intake_hooks(
+            context.config,
+            active_command_ids={'cmd_exec_1'},
+        )
+
+        def intake(_: ValidationRequestContext) -> ValidationDecision:
+            return validate_intake_stage(_, hooks=hooks)
+
+        validators = dict.fromkeys(DEFAULT_VALIDATION_STAGE_ORDER, _allow)
+        validators[ValidationStage.INTAKE] = intake
+        pipeline = ValidationPipeline(validators=validators)
+
+        decision_a = pipeline.validate(context)
+        decision_b = pipeline.validate(context)
+
+        assert decision_a.allowed is False
+        assert decision_b.allowed is False
+        assert decision_a.failed_stage == ValidationStage.INTAKE
+        assert decision_b.failed_stage == ValidationStage.INTAKE
+        assert decision_a.reason_code == 'INTAKE_MODIFIABLE_COMMANDS_UNAVAILABLE'
+        assert decision_b.reason_code == 'INTAKE_MODIFIABLE_COMMANDS_UNAVAILABLE'
+        assert (
+            decision_a.message
+            == 'MODIFY requires modifiable_command_ids to be provided'
+        )
+        assert decision_b.message == decision_a.message
+
+    def test_modify_capital_denial_is_deterministic_for_positive_delta(self) -> None:
+        context = _make_context(
+            action=ValidationAction.MODIFY,
+            order_notional=Decimal('120'),
+            current_order_notional=Decimal('100'),
+            estimated_fees=Decimal('1'),
+            strategy_budget=Decimal('10'),
+        )
+        capital_controller = CapitalController(context.state.capital)
+
+        def capital(_: ValidationRequestContext) -> ValidationDecision:
+            return validate_capital_stage(_, capital_controller)
+
+        validators = dict.fromkeys(DEFAULT_VALIDATION_STAGE_ORDER, _allow)
+        validators[ValidationStage.CAPITAL] = capital
+        pipeline = ValidationPipeline(validators=validators)
+
+        decision_a = pipeline.validate(context)
+        decision_b = pipeline.validate(context)
+
+        assert decision_a.allowed is False
+        assert decision_b.allowed is False
+        assert decision_a.failed_stage == ValidationStage.CAPITAL
+        assert decision_b.failed_stage == ValidationStage.CAPITAL
+        assert decision_a.reason_code == 'CAPITAL_RESERVATION_DENIED'
+        assert decision_b.reason_code == 'CAPITAL_RESERVATION_DENIED'
+        assert decision_a.message is not None
+        assert decision_b.message is not None
+        assert decision_b.message == decision_a.message
+
     def test_late_denial_returns_reservation_for_cleanup(self) -> None:
         created_at = datetime.now(tz=timezone.utc)
         reservation = Reservation(
@@ -322,3 +393,66 @@ class TestValidationPipelineRun:
 
         assert decision.allowed is True
         assert decision.reservation == reservation
+
+    def test_modify_increase_runs_capital_stage_and_attaches_reservation(self) -> None:
+        context = _make_context(
+            action=ValidationAction.MODIFY,
+            order_notional=Decimal('120'),
+            current_order_notional=Decimal('100'),
+            strategy_budget=Decimal('25'),
+        )
+        capital_controller = CapitalController(context.state.capital)
+
+        def capital(_: ValidationRequestContext) -> ValidationDecision:
+            return validate_capital_stage(_, capital_controller)
+
+        validators = dict.fromkeys(DEFAULT_VALIDATION_STAGE_ORDER, _allow)
+        validators[ValidationStage.CAPITAL] = capital
+        pipeline = ValidationPipeline(validators=validators)
+
+        decision = pipeline.validate(context)
+
+        assert decision.allowed is True
+        assert decision.reservation is not None
+
+    def test_modify_decrease_skips_capital_reservation_and_still_allows(self) -> None:
+        context = _make_context(
+            action=ValidationAction.MODIFY,
+            order_notional=Decimal('80'),
+            current_order_notional=Decimal('100'),
+            strategy_budget=Decimal('0'),
+        )
+        capital_controller = CapitalController(context.state.capital)
+
+        def capital(_: ValidationRequestContext) -> ValidationDecision:
+            return validate_capital_stage(_, capital_controller)
+
+        validators = dict.fromkeys(DEFAULT_VALIDATION_STAGE_ORDER, _allow)
+        validators[ValidationStage.CAPITAL] = capital
+        pipeline = ValidationPipeline(validators=validators)
+
+        decision = pipeline.validate(context)
+
+        assert decision.allowed is True
+        assert decision.reservation is None
+
+    def test_modify_noop_skips_capital_reservation_and_still_allows(self) -> None:
+        context = _make_context(
+            action=ValidationAction.MODIFY,
+            order_notional=Decimal('100'),
+            current_order_notional=Decimal('100'),
+            strategy_budget=Decimal('0'),
+        )
+        capital_controller = CapitalController(context.state.capital)
+
+        def capital(_: ValidationRequestContext) -> ValidationDecision:
+            return validate_capital_stage(_, capital_controller)
+
+        validators = dict.fromkeys(DEFAULT_VALIDATION_STAGE_ORDER, _allow)
+        validators[ValidationStage.CAPITAL] = capital
+        pipeline = ValidationPipeline(validators=validators)
+
+        decision = pipeline.validate(context)
+
+        assert decision.allowed is True
+        assert decision.reservation is None

--- a/tests/test_validator_pipeline_models.py
+++ b/tests/test_validator_pipeline_models.py
@@ -69,19 +69,16 @@ class TestValidationRequestContext:
         assert ctx.current_order_notional is None
         assert ctx.estimated_fees == Decimal('1')
         assert ctx.strategy_budget == Decimal('5000')
-        assert ctx.current_order_size is None
 
     def test_modify_context_accepts_edit_baseline_fields(self) -> None:
         ctx = _make_context(
             action=ValidationAction.MODIFY,
             command_id='cmd_1',
             current_order_notional=Decimal('75'),
-            current_order_size=Decimal('0.005'),
             order_notional=Decimal('100'),
             order_size=Decimal('0.01'),
         )
         assert ctx.current_order_notional == Decimal('75')
-        assert ctx.current_order_size == Decimal('0.005')
 
     def test_empty_strategy_id_rejected(self) -> None:
         with pytest.raises(ValueError, match='strategy_id'):
@@ -122,14 +119,6 @@ class TestValidationRequestContext:
     def test_negative_order_size_rejected(self) -> None:
         with pytest.raises(ValueError, match='order_size'):
             _make_context(order_size=Decimal('-1'))
-
-    def test_negative_current_order_size_rejected(self) -> None:
-        with pytest.raises(ValueError, match='current_order_size'):
-            _make_context(current_order_size=Decimal('-1'))
-
-    def test_non_decimal_current_order_size_rejected(self) -> None:
-        with pytest.raises(ValueError, match='current_order_size'):
-            _make_context(current_order_size=cast(Decimal, cast(Any, 1)))
 
     def test_empty_trade_id_rejected(self) -> None:
         with pytest.raises(ValueError, match='trade_id'):

--- a/tests/test_validator_pipeline_models.py
+++ b/tests/test_validator_pipeline_models.py
@@ -66,8 +66,22 @@ class TestValidationRequestContext:
         assert ctx.symbol == 'BTCUSDT'
         assert ctx.order_side == OrderSide.BUY
         assert ctx.order_notional == Decimal('100')
+        assert ctx.current_order_notional is None
         assert ctx.estimated_fees == Decimal('1')
         assert ctx.strategy_budget == Decimal('5000')
+        assert ctx.current_order_size is None
+
+    def test_modify_context_accepts_edit_baseline_fields(self) -> None:
+        ctx = _make_context(
+            action=ValidationAction.MODIFY,
+            command_id='cmd_1',
+            current_order_notional=Decimal('75'),
+            current_order_size=Decimal('0.005'),
+            order_notional=Decimal('100'),
+            order_size=Decimal('0.01'),
+        )
+        assert ctx.current_order_notional == Decimal('75')
+        assert ctx.current_order_size == Decimal('0.005')
 
     def test_empty_strategy_id_rejected(self) -> None:
         with pytest.raises(ValueError, match='strategy_id'):
@@ -85,6 +99,14 @@ class TestValidationRequestContext:
         with pytest.raises(ValueError, match='strategy_budget'):
             _make_context(strategy_budget=Decimal('NaN'))
 
+    def test_nan_current_order_notional_rejected(self) -> None:
+        with pytest.raises(ValueError, match='current_order_notional'):
+            _make_context(current_order_notional=Decimal('NaN'))
+
+    def test_negative_current_order_notional_rejected(self) -> None:
+        with pytest.raises(ValueError, match='current_order_notional'):
+            _make_context(current_order_notional=Decimal('-1'))
+
     def test_non_validation_action_rejected(self) -> None:
         with pytest.raises(ValueError, match='action'):
             _make_context(action=cast(ValidationAction, cast(Any, 'ENTER')))
@@ -100,6 +122,14 @@ class TestValidationRequestContext:
     def test_negative_order_size_rejected(self) -> None:
         with pytest.raises(ValueError, match='order_size'):
             _make_context(order_size=Decimal('-1'))
+
+    def test_negative_current_order_size_rejected(self) -> None:
+        with pytest.raises(ValueError, match='current_order_size'):
+            _make_context(current_order_size=Decimal('-1'))
+
+    def test_non_decimal_current_order_size_rejected(self) -> None:
+        with pytest.raises(ValueError, match='current_order_size'):
+            _make_context(current_order_size=cast(Decimal, cast(Any, 1)))
 
     def test_empty_trade_id_rejected(self) -> None:
         with pytest.raises(ValueError, match='trade_id'):


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements RFC 3.3 edit (`MODIFY`) validation behavior across validator models, intake policy, capital checks, and deterministic pipeline coverage. Extends `ValidationRequestContext` with explicit edit baselines (`current_order_notional`) and strict finite/non-negative validation. Updates capital-stage handling to reserve only positive `MODIFY` deltas while skipping reservation for no-op/decrease edits. Tightens intake reference integrity by requiring `modifiable_command_ids` for `MODIFY` and denying when lifecycle-valid targets are unavailable. Adds comprehensive tests across pipeline models, capital stage, intake stage, and pipeline executor for increase/decrease/no-op flows and deterministic deny stage/reason/message behavior. Bumps package version to `0.13.0` and appends changelog entry in monotonic order.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (486 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable