### PR TITLE
feat: 3.4 price validation — staleness, spread, deviation, reference source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,3 +126,12 @@
 - Add capital-stage tests for `MODIFY` increase/decrease/no-op reservation behavior
 - Add pipeline-executor tests for `MODIFY` increase/decrease/no-op flows and deterministic deny stage/reason/message behavior
 - Expand validator test baseline to 486 passing tests
+
+## v0.14.0 on 24th of March, 2026
+
+- Add RFC 3.4 price-validation config fields to `InstanceConfig`: `book_staleness_max_seconds`, `max_spread_bps`, `price_deviation_max_bps`, `reference_price_source`
+- Add strict validation for 3.4 config fields: positive staleness seconds, finite non-negative bps thresholds, allowed `reference_price_source`, and deviation-source requirement
+- Add `build_price_stage_limits_from_config(...)` to map `book_staleness_max_seconds` to `max_staleness_ms` and wire spread/deviation/source limits into Stage 3
+- Add reference-source identity to price contracts via `PriceCheckSnapshot.reference_price_source` and `PriceStageLimits.reference_price_source` with non-empty validation
+- Fix deviation-stage behavior to deny deterministically when reference source is missing or mismatched (`PRICE_SYSTEM_DATA_UNAVAILABLE`/`PRICE_SNAPSHOT_INVALID`)
+- Add and expand tests for 3.4 config validation, source-aware deviation paths, consequence routing (stale => platform-critical, spread/deviation => strategy-warning), and full-suite stability (512 passing tests)

--- a/nexus/core/validator/__init__.py
+++ b/nexus/core/validator/__init__.py
@@ -25,6 +25,7 @@ from nexus.core.validator.price_stage import (
     PriceCheckSnapshot,
     PriceFailureConsequence,
     PriceStageLimits,
+    build_price_stage_limits_from_config,
     derive_price_failure_consequence,
     validate_price_stage,
 )
@@ -97,6 +98,7 @@ __all__ = [
     'ValidationRequestContext',
     'ValidationStage',
     'build_default_intake_hooks',
+    'build_price_stage_limits_from_config',
     'derive_price_failure_consequence',
     'evaluate_health_status',
     'evaluate_risk_breach',

--- a/nexus/core/validator/price_stage.py
+++ b/nexus/core/validator/price_stage.py
@@ -136,6 +136,7 @@ class PriceFailureConsequence:
 
 
 def build_price_stage_limits_from_config(config: InstanceConfig) -> PriceStageLimits:
+    """Build Stage-3 price limits from runtime config."""
     if not isinstance(config, InstanceConfig):
         msg = 'config must be an InstanceConfig instance'
         raise ValueError(msg)

--- a/nexus/core/validator/price_stage.py
+++ b/nexus/core/validator/price_stage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import Decimal
 
+from nexus.instance_config import InstanceConfig
 from nexus.core.validator.pipeline_models import (
     ValidationDecision,
     ValidationRequestContext,
@@ -15,11 +16,13 @@ __all__ = [
     'PriceCheckSnapshot',
     'PriceFailureConsequence',
     'PriceStageLimits',
+    'build_price_stage_limits_from_config',
     'derive_price_failure_consequence',
     'validate_price_stage',
 ]
 
 _ZERO_DECIMAL = Decimal(0)
+_MILLISECONDS_PER_SECOND = 1000
 
 
 @dataclass(frozen=True)
@@ -30,6 +33,7 @@ class PriceCheckSnapshot:
     book_timestamp_ms: int | None = None
     spread_bps: Decimal | None = None
     deviation_bps: Decimal | None = None
+    reference_price_source: str | None = None
 
     def __post_init__(self) -> None:
         '''Validate snapshot field invariants.'''
@@ -65,6 +69,16 @@ class PriceCheckSnapshot:
                 )
                 raise ValueError(msg)
 
+        if self.reference_price_source is not None and (
+            not isinstance(self.reference_price_source, str)
+            or not self.reference_price_source.strip()
+        ):
+            msg = (
+                'PriceCheckSnapshot.reference_price_source must be a non-empty '
+                'string or None'
+            )
+            raise ValueError(msg)
+
 
 @dataclass(frozen=True)
 class PriceStageLimits:
@@ -73,6 +87,7 @@ class PriceStageLimits:
     max_staleness_ms: int | None = None
     max_spread_bps: Decimal | None = None
     max_deviation_bps: Decimal | None = None
+    reference_price_source: str | None = None
 
     def __post_init__(self) -> None:
         '''Validate configured price-stage thresholds.'''
@@ -100,6 +115,16 @@ class PriceStageLimits:
                 )
                 raise ValueError(msg)
 
+        if self.reference_price_source is not None and (
+            not isinstance(self.reference_price_source, str)
+            or not self.reference_price_source.strip()
+        ):
+            msg = (
+                'PriceStageLimits.reference_price_source must be a non-empty '
+                'string or None'
+            )
+            raise ValueError(msg)
+
 
 @dataclass(frozen=True)
 class PriceFailureConsequence:
@@ -108,6 +133,23 @@ class PriceFailureConsequence:
     notify_strategy_owner: bool
     notify_platform_ops: bool
     severity: str
+
+
+def build_price_stage_limits_from_config(config: InstanceConfig) -> PriceStageLimits:
+    if not isinstance(config, InstanceConfig):
+        msg = 'config must be an InstanceConfig instance'
+        raise ValueError(msg)
+
+    max_staleness_ms: int | None = None
+    if config.book_staleness_max_seconds is not None:
+        max_staleness_ms = config.book_staleness_max_seconds * _MILLISECONDS_PER_SECOND
+
+    return PriceStageLimits(
+        max_staleness_ms=max_staleness_ms,
+        max_spread_bps=config.max_spread_bps,
+        max_deviation_bps=config.price_deviation_max_bps,
+        reference_price_source=config.reference_price_source,
+    )
 
 
 def derive_price_failure_consequence(

--- a/nexus/core/validator/price_stage.py
+++ b/nexus/core/validator/price_stage.py
@@ -254,12 +254,39 @@ def validate_price_stage(
             )
 
     if limits.max_deviation_bps is not None and decision is None:
-        if snapshot is None or snapshot.deviation_bps is None:
+        if limits.reference_price_source is None:
             decision = ValidationDecision(
                 allowed=False,
                 failed_stage=ValidationStage.PRICE,
                 reason_code='PRICE_SYSTEM_DATA_UNAVAILABLE',
-                message='Price system data unavailable: deviation_bps missing',
+                message=(
+                    'Price system data unavailable: reference_price_source '
+                    'missing for deviation validation'
+                ),
+            )
+        elif (
+            snapshot is None
+            or snapshot.deviation_bps is None
+            or snapshot.reference_price_source is None
+        ):
+            decision = ValidationDecision(
+                allowed=False,
+                failed_stage=ValidationStage.PRICE,
+                reason_code='PRICE_SYSTEM_DATA_UNAVAILABLE',
+                message=(
+                    'Price system data unavailable: deviation_bps/'
+                    'reference_price_source missing'
+                ),
+            )
+        elif (
+            snapshot.reference_price_source.strip().lower()
+            != limits.reference_price_source.strip().lower()
+        ):
+            decision = ValidationDecision(
+                allowed=False,
+                failed_stage=ValidationStage.PRICE,
+                reason_code='PRICE_SNAPSHOT_INVALID',
+                message='Price snapshot reference source is inconsistent',
             )
         elif snapshot.deviation_bps > limits.max_deviation_bps:
             decision = ValidationDecision(

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -16,6 +16,7 @@ __all__ = ['InstanceConfig']
 
 _ZERO = Decimal('0')
 _ONE_HUNDRED = Decimal('100')
+_ALLOWED_REFERENCE_PRICE_SOURCES = frozenset({'origo_mid'})
 
 
 @dataclass(frozen=True)
@@ -34,6 +35,13 @@ class InstanceConfig:
             for intake rate-limiting within this Manager process. This is not
             a distributed/global limit across multiple processes or hosts.
             ``None`` disables the rate check.
+        book_staleness_max_seconds: Optional Stage-3 price staleness threshold
+            in seconds.
+        max_spread_bps: Optional Stage-3 max spread threshold in bps.
+        price_deviation_max_bps: Optional Stage-3 max deviation threshold in
+            bps.
+        reference_price_source: Optional Stage-3 reference price source
+            identifier used for deviation checks.
         capital_pct: Strategy capital-allocation percentages keyed by
             strategy_id.
     '''
@@ -43,6 +51,10 @@ class InstanceConfig:
     allocated_capital: Decimal
     duplicate_window_ms: int = 1000
     max_order_rate: int | None = None
+    book_staleness_max_seconds: int | None = None
+    max_spread_bps: Decimal | None = None
+    price_deviation_max_bps: Decimal | None = None
+    reference_price_source: str | None = None
     capital_pct: Mapping[str, Decimal] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -82,6 +94,70 @@ class InstanceConfig:
             if self.max_order_rate <= 0:
                 msg = 'InstanceConfig.max_order_rate must be a positive integer'
                 raise ValueError(msg)
+
+        if self.book_staleness_max_seconds is not None:
+            if isinstance(self.book_staleness_max_seconds, bool) or not isinstance(
+                self.book_staleness_max_seconds,
+                int,
+            ):
+                msg = 'InstanceConfig.book_staleness_max_seconds must be an integer'
+                raise ValueError(msg)
+
+            if self.book_staleness_max_seconds <= 0:
+                msg = (
+                    'InstanceConfig.book_staleness_max_seconds must be a positive '
+                    'integer'
+                )
+                raise ValueError(msg)
+
+        for field_name in ('max_spread_bps', 'price_deviation_max_bps'):
+            value = getattr(self, field_name)
+            if value is None:
+                continue
+            if not isinstance(value, Decimal) or not value.is_finite() or value < _ZERO:
+                msg = (
+                    f'InstanceConfig.{field_name} must be a finite non-negative Decimal'
+                )
+                raise ValueError(msg)
+
+        if self.reference_price_source is not None:
+            if not isinstance(self.reference_price_source, str):
+                msg = 'InstanceConfig.reference_price_source must be a string'
+                raise ValueError(msg)
+
+            normalized_reference_price_source = (
+                self.reference_price_source.strip().lower()
+            )
+            if not normalized_reference_price_source:
+                msg = 'InstanceConfig.reference_price_source must be a non-empty string'
+                raise ValueError(msg)
+
+            if (
+                normalized_reference_price_source
+                not in _ALLOWED_REFERENCE_PRICE_SOURCES
+            ):
+                allowed_values = ', '.join(sorted(_ALLOWED_REFERENCE_PRICE_SOURCES))
+                msg = (
+                    'InstanceConfig.reference_price_source must be one of '
+                    f'{allowed_values}'
+                )
+                raise ValueError(msg)
+
+            object.__setattr__(
+                self,
+                'reference_price_source',
+                normalized_reference_price_source,
+            )
+
+        if (
+            self.price_deviation_max_bps is not None
+            and self.reference_price_source is None
+        ):
+            msg = (
+                'InstanceConfig.reference_price_source is required when '
+                'price_deviation_max_bps is set'
+            )
+            raise ValueError(msg)
 
         if not isinstance(self.capital_pct, Mapping):
             msg = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.13.0"
+version = "0.14.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -302,6 +302,16 @@ def test_negative_max_spread_bps_rejected() -> None:
         )
 
 
+def test_nan_max_spread_bps_rejected() -> None:
+    with pytest.raises(ValueError, match='max_spread_bps'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            max_spread_bps=Decimal('NaN'),
+        )
+
+
 def test_non_decimal_price_deviation_max_bps_rejected() -> None:
     with pytest.raises(ValueError, match='price_deviation_max_bps'):
         InstanceConfig(
@@ -320,6 +330,17 @@ def test_negative_price_deviation_max_bps_rejected() -> None:
             venue='binance_spot',
             allocated_capital=Decimal('10000'),
             price_deviation_max_bps=Decimal('-0.1'),
+            reference_price_source='origo_mid',
+        )
+
+
+def test_nan_price_deviation_max_bps_rejected() -> None:
+    with pytest.raises(ValueError, match='price_deviation_max_bps'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            price_deviation_max_bps=Decimal('NaN'),
             reference_price_source='origo_mid',
         )
 

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -23,6 +23,10 @@ def test_valid_creation() -> None:
     assert cfg.allocated_capital == Decimal('10000')
     assert cfg.duplicate_window_ms == 1000
     assert cfg.max_order_rate is None
+    assert cfg.book_staleness_max_seconds is None
+    assert cfg.max_spread_bps is None
+    assert cfg.price_deviation_max_bps is None
+    assert cfg.reference_price_source is None
     assert cfg.capital_pct == {}
 
 
@@ -46,6 +50,35 @@ def test_valid_creation_with_max_order_rate() -> None:
         max_order_rate=7,
     )
     assert cfg.max_order_rate == 7
+
+
+def test_valid_creation_with_price_validation_fields() -> None:
+    cfg = InstanceConfig(
+        account_id='acc_001',
+        venue='binance_spot',
+        allocated_capital=Decimal('10000'),
+        book_staleness_max_seconds=3,
+        max_spread_bps=Decimal('7.5'),
+        price_deviation_max_bps=Decimal('12.0'),
+        reference_price_source='origo_mid',
+    )
+
+    assert cfg.book_staleness_max_seconds == 3
+    assert cfg.max_spread_bps == Decimal('7.5')
+    assert cfg.price_deviation_max_bps == Decimal('12.0')
+    assert cfg.reference_price_source == 'origo_mid'
+
+
+def test_reference_price_source_is_normalized() -> None:
+    cfg = InstanceConfig(
+        account_id='acc_001',
+        venue='binance_spot',
+        allocated_capital=Decimal('10000'),
+        price_deviation_max_bps=Decimal('5'),
+        reference_price_source='  ORIGO_MID ',
+    )
+
+    assert cfg.reference_price_source == 'origo_mid'
 
 
 def test_valid_creation_with_capital_pct() -> None:
@@ -216,6 +249,110 @@ def test_non_positive_max_order_rate_rejected() -> None:
             venue='binance_spot',
             allocated_capital=Decimal('10000'),
             max_order_rate=0,
+        )
+
+
+def test_non_int_book_staleness_max_seconds_rejected() -> None:
+    with pytest.raises(ValueError, match='book_staleness_max_seconds'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            book_staleness_max_seconds=cast(int, cast(object, '3')),
+        )
+
+
+def test_bool_book_staleness_max_seconds_rejected() -> None:
+    with pytest.raises(ValueError, match='book_staleness_max_seconds'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            book_staleness_max_seconds=cast(int, cast(object, True)),
+        )
+
+
+def test_non_positive_book_staleness_max_seconds_rejected() -> None:
+    with pytest.raises(ValueError, match='book_staleness_max_seconds'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            book_staleness_max_seconds=0,
+        )
+
+
+def test_non_decimal_max_spread_bps_rejected() -> None:
+    with pytest.raises(ValueError, match='max_spread_bps'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            max_spread_bps=cast(Decimal, cast(object, 5)),
+        )
+
+
+def test_negative_max_spread_bps_rejected() -> None:
+    with pytest.raises(ValueError, match='max_spread_bps'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            max_spread_bps=Decimal('-0.1'),
+        )
+
+
+def test_non_decimal_price_deviation_max_bps_rejected() -> None:
+    with pytest.raises(ValueError, match='price_deviation_max_bps'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            price_deviation_max_bps=cast(Decimal, cast(object, 5)),
+            reference_price_source='origo_mid',
+        )
+
+
+def test_negative_price_deviation_max_bps_rejected() -> None:
+    with pytest.raises(ValueError, match='price_deviation_max_bps'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            price_deviation_max_bps=Decimal('-0.1'),
+            reference_price_source='origo_mid',
+        )
+
+
+def test_price_deviation_without_reference_source_rejected() -> None:
+    with pytest.raises(ValueError, match='reference_price_source'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            price_deviation_max_bps=Decimal('5'),
+        )
+
+
+def test_empty_reference_price_source_rejected() -> None:
+    with pytest.raises(ValueError, match='reference_price_source'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            price_deviation_max_bps=Decimal('5'),
+            reference_price_source='   ',
+        )
+
+
+def test_invalid_reference_price_source_rejected() -> None:
+    with pytest.raises(ValueError, match='reference_price_source'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            price_deviation_max_bps=Decimal('5'),
+            reference_price_source='origo_last',
         )
 
 

--- a/tests/test_validator_price_stage.py
+++ b/tests/test_validator_price_stage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -14,6 +14,7 @@ from nexus.core.validator import (
     PriceStageLimits,
     ValidationRequestContext,
     ValidationStage,
+    build_price_stage_limits_from_config,
     derive_price_failure_consequence,
     validate_price_stage,
 )
@@ -62,6 +63,49 @@ class TestPriceContracts:
 
         with pytest.raises(ValueError, match='book_timestamp_ms'):
             PriceCheckSnapshot(book_timestamp_ms=False)
+
+    def test_rejects_empty_snapshot_reference_source(self) -> None:
+        with pytest.raises(ValueError, match='reference_price_source'):
+            PriceCheckSnapshot(reference_price_source='   ')
+
+    def test_rejects_empty_limits_reference_source(self) -> None:
+        with pytest.raises(ValueError, match='reference_price_source'):
+            PriceStageLimits(reference_price_source='')
+
+    def test_build_limits_maps_seconds_to_milliseconds(self) -> None:
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            book_staleness_max_seconds=3,
+            max_spread_bps=Decimal('7'),
+            price_deviation_max_bps=Decimal('9'),
+            reference_price_source='origo_mid',
+        )
+
+        limits = build_price_stage_limits_from_config(config)
+
+        assert limits.max_staleness_ms == 3000
+        assert limits.max_spread_bps == Decimal('7')
+        assert limits.max_deviation_bps == Decimal('9')
+        assert limits.reference_price_source == 'origo_mid'
+
+    def test_build_limits_keeps_none_when_staleness_seconds_missing(self) -> None:
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+        )
+
+        limits = build_price_stage_limits_from_config(config)
+
+        assert limits.max_staleness_ms is None
+
+    def test_build_limits_requires_instance_config(self) -> None:
+        with pytest.raises(ValueError, match='InstanceConfig'):
+            build_price_stage_limits_from_config(
+                cast(InstanceConfig, cast(object, None)),
+            )
 
 
 class TestPriceStage:

--- a/tests/test_validator_price_stage.py
+++ b/tests/test_validator_price_stage.py
@@ -239,8 +239,53 @@ class TestPriceStage:
         assert decision.reason_code == 'PRICE_SNAPSHOT_INVALID'
         assert decision.message == 'Price snapshot reference source is inconsistent'
 
+    def test_denies_when_deviation_snapshot_is_missing(self) -> None:
+        decision = validate_price_stage(
+            _make_context(),
+            PriceStageLimits(
+                max_deviation_bps=Decimal('10'),
+                reference_price_source='origo_mid',
+            ),
+            snapshot=None,
+        )
+        assert decision.allowed is False
+        assert decision.failed_stage == ValidationStage.PRICE
+        assert decision.reason_code == 'PRICE_SYSTEM_DATA_UNAVAILABLE'
+        assert decision.message == (
+            'Price system data unavailable: deviation_bps/reference_price_source '
+            'missing'
+        )
+
+    def test_allows_deviation_when_source_matches_case_insensitively(self) -> None:
+        decision = validate_price_stage(
+            _make_context(),
+            PriceStageLimits(
+                max_deviation_bps=Decimal('10'),
+                reference_price_source='ORIGO_MID',
+            ),
+            snapshot=PriceCheckSnapshot(
+                deviation_bps=Decimal('9'),
+                reference_price_source=' origo_mid ',
+            ),
+        )
+        assert decision.allowed is True
+
 
 class TestPriceFailureConsequence:
+    def test_book_stale_routes_to_platform(self) -> None:
+        decision = validate_price_stage(
+            _make_context(),
+            PriceStageLimits(max_staleness_ms=100),
+            snapshot=PriceCheckSnapshot(now_ms=1300, book_timestamp_ms=1000),
+        )
+        consequence = derive_price_failure_consequence(decision)
+
+        assert consequence == PriceFailureConsequence(
+            notify_strategy_owner=True,
+            notify_platform_ops=True,
+            severity='critical',
+        )
+
     def test_system_data_unavailable_routes_to_platform(self) -> None:
         decision = validate_price_stage(
             _make_context(),
@@ -260,6 +305,26 @@ class TestPriceFailureConsequence:
             _make_context(),
             PriceStageLimits(max_spread_bps=Decimal('5')),
             snapshot=PriceCheckSnapshot(spread_bps=Decimal('7')),
+        )
+        consequence = derive_price_failure_consequence(decision)
+
+        assert consequence == PriceFailureConsequence(
+            notify_strategy_owner=True,
+            notify_platform_ops=False,
+            severity='warning',
+        )
+
+    def test_deviation_limit_stays_strategy_scoped(self) -> None:
+        decision = validate_price_stage(
+            _make_context(),
+            PriceStageLimits(
+                max_deviation_bps=Decimal('5'),
+                reference_price_source='origo_mid',
+            ),
+            snapshot=PriceCheckSnapshot(
+                deviation_bps=Decimal('7'),
+                reference_price_source='origo_mid',
+            ),
         )
         consequence = derive_price_failure_consequence(decision)
 

--- a/tests/test_validator_price_stage.py
+++ b/tests/test_validator_price_stage.py
@@ -334,6 +334,26 @@ class TestPriceFailureConsequence:
             severity='warning',
         )
 
+    def test_snapshot_invalid_routes_to_platform(self) -> None:
+        decision = validate_price_stage(
+            _make_context(),
+            PriceStageLimits(
+                max_deviation_bps=Decimal('10'),
+                reference_price_source='origo_mid',
+            ),
+            snapshot=PriceCheckSnapshot(
+                deviation_bps=Decimal('5'),
+                reference_price_source='origo_last',
+            ),
+        )
+        consequence = derive_price_failure_consequence(decision)
+
+        assert consequence == PriceFailureConsequence(
+            notify_strategy_owner=True,
+            notify_platform_ops=True,
+            severity='critical',
+        )
+
     def test_allowed_decision_has_no_consequence(self) -> None:
         allow = validate_price_stage(_make_context(), PriceStageLimits(), snapshot=None)
         assert allow.allowed is True

--- a/tests/test_validator_price_stage.py
+++ b/tests/test_validator_price_stage.py
@@ -139,8 +139,14 @@ class TestPriceStage:
     def test_denies_when_deviation_exceeds_limit(self) -> None:
         decision = validate_price_stage(
             _make_context(),
-            PriceStageLimits(max_deviation_bps=Decimal('10')),
-            snapshot=PriceCheckSnapshot(deviation_bps=Decimal('11')),
+            PriceStageLimits(
+                max_deviation_bps=Decimal('10'),
+                reference_price_source='origo_mid',
+            ),
+            snapshot=PriceCheckSnapshot(
+                deviation_bps=Decimal('11'),
+                reference_price_source='origo_mid',
+            ),
         )
         assert decision.allowed is False
         assert decision.reason_code == 'PRICE_DEVIATION_LIMIT'
@@ -170,15 +176,68 @@ class TestPriceStage:
                 max_staleness_ms=500,
                 max_spread_bps=Decimal('10'),
                 max_deviation_bps=Decimal('15'),
+                reference_price_source='origo_mid',
             ),
             snapshot=PriceCheckSnapshot(
                 now_ms=1500,
                 book_timestamp_ms=1200,
                 spread_bps=Decimal('6'),
                 deviation_bps=Decimal('8'),
+                reference_price_source='origo_mid',
             ),
         )
         assert decision.allowed is True
+
+    def test_denies_when_deviation_limit_has_no_reference_source(self) -> None:
+        decision = validate_price_stage(
+            _make_context(),
+            PriceStageLimits(max_deviation_bps=Decimal('10')),
+            snapshot=PriceCheckSnapshot(
+                deviation_bps=Decimal('5'),
+                reference_price_source='origo_mid',
+            ),
+        )
+        assert decision.allowed is False
+        assert decision.failed_stage == ValidationStage.PRICE
+        assert decision.reason_code == 'PRICE_SYSTEM_DATA_UNAVAILABLE'
+        assert decision.message == (
+            'Price system data unavailable: reference_price_source missing '
+            'for deviation validation'
+        )
+
+    def test_denies_when_deviation_snapshot_source_missing(self) -> None:
+        decision = validate_price_stage(
+            _make_context(),
+            PriceStageLimits(
+                max_deviation_bps=Decimal('10'),
+                reference_price_source='origo_mid',
+            ),
+            snapshot=PriceCheckSnapshot(deviation_bps=Decimal('5')),
+        )
+        assert decision.allowed is False
+        assert decision.failed_stage == ValidationStage.PRICE
+        assert decision.reason_code == 'PRICE_SYSTEM_DATA_UNAVAILABLE'
+        assert decision.message == (
+            'Price system data unavailable: deviation_bps/reference_price_source '
+            'missing'
+        )
+
+    def test_denies_when_deviation_snapshot_source_mismatches(self) -> None:
+        decision = validate_price_stage(
+            _make_context(),
+            PriceStageLimits(
+                max_deviation_bps=Decimal('10'),
+                reference_price_source='origo_mid',
+            ),
+            snapshot=PriceCheckSnapshot(
+                deviation_bps=Decimal('5'),
+                reference_price_source='origo_last',
+            ),
+        )
+        assert decision.allowed is False
+        assert decision.failed_stage == ValidationStage.PRICE
+        assert decision.reason_code == 'PRICE_SNAPSHOT_INVALID'
+        assert decision.message == 'Price snapshot reference source is inconsistent'
 
 
 class TestPriceFailureConsequence:


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

RFC 3.4 price validation implementation covering:
- Adds price-validation config fields to `InstanceConfig`: `book_staleness_max_seconds`, `max_spread_bps`, `price_deviation_max_bps`, `reference_price_source`
- Adds strict validation for config fields: positive staleness seconds, finite non-negative bps thresholds, allowed `reference_price_source`, and deviation-source requirement
- Adds `build_price_stage_limits_from_config(...)` to map `book_staleness_max_seconds` to `max_staleness_ms` and wire spread/deviation/source limits into Stage 3
- Adds reference-source identity to price contracts via `PriceCheckSnapshot.reference_price_source` and `PriceStageLimits.reference_price_source`
- Fixes deviation-stage behavior to deny deterministically when reference source is missing or mismatched
- Expands test coverage for config validation, source-aware deviation paths, consequence routing (stale => platform-critical, spread/deviation => strategy-warning)
- Bumps to v0.14.0

## Checklist

- [x] I have reviewed full diff in \"Files changed\"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (512 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., \"Fixes #123\") when applicable