### PR TITLE
feat: 4.1 Praxis Connector outbound translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.15.0 on 25th of March, 2026
+
+- Add [`stp_mode.py`](nexus/core/stp_mode.py) with `STPMode` enum (CANCEL_MAKER, CANCEL_TAKER, CANCEL_BOTH) for self-trade prevention
+- Add `stp_mode` field to `InstanceConfig` with default `CANCEL_TAKER` and validation
+- Add [`trade_command_type.py`](nexus/infrastructure/praxis_connector/trade_command_type.py) with `TradeCommandType` enum (NEW_ORDER, AMEND_ORDER, CANCEL_ORDER)
+- Add [`trade_command.py`](nexus/infrastructure/praxis_connector/trade_command.py) with frozen `TradeCommand` dataclass and command-type-specific validation
+- Add [`translate.py`](nexus/infrastructure/praxis_connector/translate.py) with `translate_to_trade_command()` mapping ValidationAction to TradeCommand
+- Add [`outbound_connector.py`](nexus/infrastructure/praxis_connector/outbound_connector.py) with `OutboundConnector` protocol for Trading sub-system dispatch
+- Add 39 tests covering STPMode, TradeCommandType, TradeCommand validation, and translation for all action types (552 total)
+
 ## v0.1.0 on 16th of March, 2026
 
 - Add CI pipeline mirroring Praxis: Ruff, Mypy strict, pytest, CodeQL workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 - Add [`trade_command.py`](nexus/infrastructure/praxis_connector/trade_command.py) with frozen `TradeCommand` dataclass and command-type-specific validation
 - Add [`translate.py`](nexus/infrastructure/praxis_connector/translate.py) with `translate_to_trade_command()` mapping ValidationAction to TradeCommand
 - Add [`outbound_connector.py`](nexus/infrastructure/praxis_connector/outbound_connector.py) with `OutboundConnector` protocol for Trading sub-system dispatch
-- Add 39 tests covering STPMode, TradeCommandType, TradeCommand validation, and translation for all action types (552 total)
+- Fix `translate_to_trade_command` to require allowed decision and non-empty `command_id` with explicit guards
+- Fix `TradeCommand` to reject `side`/`size` for `AMEND_ORDER`/`CANCEL_ORDER` command types
+- Fix test flakiness in `_reservation()` by using `timedelta` instead of `minute` replacement
+- Add 45 tests covering STPMode, TradeCommandType, TradeCommand validation, and translation for all action types (558 total)
 
 ## v0.1.0 on 16th of March, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 - Add [`trade_command.py`](nexus/infrastructure/praxis_connector/trade_command.py) with frozen `TradeCommand` dataclass and command-type-specific validation
 - Add [`translate.py`](nexus/infrastructure/praxis_connector/translate.py) with `translate_to_trade_command()` mapping ValidationAction to TradeCommand
 - Add [`outbound_connector.py`](nexus/infrastructure/praxis_connector/outbound_connector.py) with `OutboundConnector` protocol for Trading sub-system dispatch
-- Fix `translate_to_trade_command` to require allowed decision and non-empty `command_id` with explicit guards
-- Fix `TradeCommand` to reject `side`/`size` for `AMEND_ORDER`/`CANCEL_ORDER` command types
-- Fix test flakiness in `_reservation()` by using `timedelta` instead of `minute` replacement
+- Enforce `translate_to_trade_command` guards for allowed decision and non-empty `command_id`
+- Enforce `TradeCommand` rejection of `side`/`size` for `AMEND_ORDER`/`CANCEL_ORDER` command types
+- Enforce robust `expires_at` computation in tests using `timedelta` instead of `minute` replacement
 - Add 45 tests covering STPMode, TradeCommandType, TradeCommand validation, and translation for all action types (558 total)
 
 ## v0.1.0 on 16th of March, 2026

--- a/nexus/core/stp_mode.py
+++ b/nexus/core/stp_mode.py
@@ -1,0 +1,24 @@
+'''Self-trade prevention mode enum.
+
+Separate module to avoid circular imports with InstanceConfig.
+'''
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = ['STPMode']
+
+
+class STPMode(Enum):
+    '''Self-trade prevention mode for order submission.
+
+    Determines behavior when a new order would match against
+    the account's own resting order. CANCEL_MAKER cancels the
+    resting order. CANCEL_TAKER cancels the incoming order.
+    CANCEL_BOTH cancels both sides.
+    '''
+
+    CANCEL_MAKER = 'CANCEL_MAKER'
+    CANCEL_TAKER = 'CANCEL_TAKER'
+    CANCEL_BOTH = 'CANCEL_BOTH'

--- a/nexus/infrastructure/praxis_connector/outbound_connector.py
+++ b/nexus/infrastructure/praxis_connector/outbound_connector.py
@@ -1,0 +1,20 @@
+'''Outbound connector protocol for Trading sub-system dispatch.'''
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from nexus.infrastructure.praxis_connector.trade_command import TradeCommand
+
+__all__ = ['OutboundConnector']
+
+
+class OutboundConnector(Protocol):
+    '''Protocol for submitting TradeCommands to the Trading sub-system.
+
+    Concrete implementations handle transport details (HTTP, queue, etc.).
+    '''
+
+    def send_command(self, command: TradeCommand) -> None:
+        '''Submit TradeCommand to Trading sub-system.'''
+        ...

--- a/nexus/infrastructure/praxis_connector/outbound_connector.py
+++ b/nexus/infrastructure/praxis_connector/outbound_connector.py
@@ -1,4 +1,9 @@
-'''Outbound connector protocol for Trading sub-system dispatch.'''
+'''Outbound connector protocol for Trading sub-system dispatch.
+
+Defines the interface for submitting TradeCommands to the Trading
+sub-system (Praxis). Concrete implementations handle transport details
+such as HTTP, message queues, or in-memory mocks for testing.
+'''
 
 from __future__ import annotations
 

--- a/nexus/infrastructure/praxis_connector/trade_command.py
+++ b/nexus/infrastructure/praxis_connector/trade_command.py
@@ -31,7 +31,7 @@ class TradeCommand:
         size: Base asset quantity; None for AMEND_ORDER/CANCEL_ORDER.
         stp_mode: Self-trade prevention; required for NEW_ORDER, None otherwise.
         trade_id: Position reference for EXIT actions.
-        reservation_id: Capital lock reference for ENTER actions.
+        reservation_id: Capital lock reference for ENTER and size-increasing MODIFY.
     '''
 
     command_id: str

--- a/nexus/infrastructure/praxis_connector/trade_command.py
+++ b/nexus/infrastructure/praxis_connector/trade_command.py
@@ -134,11 +134,23 @@ class TradeCommand:
                 raise ValueError(msg)
 
         elif self.command_type == TradeCommandType.AMEND_ORDER:
+            if self.side is not None:
+                msg = 'TradeCommand: AMEND_ORDER must not have side'
+                raise ValueError(msg)
+            if self.size is not None:
+                msg = 'TradeCommand: AMEND_ORDER must not have size'
+                raise ValueError(msg)
             if self.stp_mode is not None:
                 msg = 'TradeCommand: AMEND_ORDER must not have stp_mode'
                 raise ValueError(msg)
 
         elif self.command_type == TradeCommandType.CANCEL_ORDER:
+            if self.side is not None:
+                msg = 'TradeCommand: CANCEL_ORDER must not have side'
+                raise ValueError(msg)
+            if self.size is not None:
+                msg = 'TradeCommand: CANCEL_ORDER must not have size'
+                raise ValueError(msg)
             if self.stp_mode is not None:
                 msg = 'TradeCommand: CANCEL_ORDER must not have stp_mode'
                 raise ValueError(msg)

--- a/nexus/infrastructure/praxis_connector/trade_command.py
+++ b/nexus/infrastructure/praxis_connector/trade_command.py
@@ -27,8 +27,8 @@ class TradeCommand:
         symbol: Trading pair.
         notional: Quote asset amount.
         created_at: Command creation timestamp.
-        side: BUY/SELL direction; None for CANCEL_ORDER.
-        size: Base asset quantity; None for CANCEL_ORDER.
+        side: BUY/SELL direction; None for AMEND_ORDER/CANCEL_ORDER.
+        size: Base asset quantity; None for AMEND_ORDER/CANCEL_ORDER.
         stp_mode: Self-trade prevention; required for NEW_ORDER, None otherwise.
         trade_id: Position reference for EXIT actions.
         reservation_id: Capital lock reference for ENTER actions.

--- a/nexus/infrastructure/praxis_connector/trade_command.py
+++ b/nexus/infrastructure/praxis_connector/trade_command.py
@@ -1,0 +1,144 @@
+'''TradeCommand dataclass for Praxis Connector outbound translation.'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from nexus.core.domain.enums import OrderSide
+from nexus.core.stp_mode import STPMode
+from nexus.infrastructure.praxis_connector.trade_command_type import TradeCommandType
+
+__all__ = ['TradeCommand']
+
+_ZERO = Decimal(0)
+
+
+@dataclass(frozen=True)
+class TradeCommand:
+    '''Immutable command for Trading sub-system dispatch.
+
+    Args:
+        command_id: Unique command reference.
+        command_type: NEW_ORDER, AMEND_ORDER, or CANCEL_ORDER.
+        account_id: Trading account identity.
+        venue: Target venue.
+        symbol: Trading pair.
+        notional: Quote asset amount.
+        created_at: Command creation timestamp.
+        side: BUY/SELL direction; None for CANCEL_ORDER.
+        size: Base asset quantity; None for CANCEL_ORDER.
+        stp_mode: Self-trade prevention; required for NEW_ORDER, None otherwise.
+        trade_id: Position reference for EXIT actions.
+        reservation_id: Capital lock reference for ENTER actions.
+    '''
+
+    command_id: str
+    command_type: TradeCommandType
+    account_id: str
+    venue: str
+    symbol: str
+    notional: Decimal
+    created_at: datetime
+    side: OrderSide | None = None
+    size: Decimal | None = None
+    stp_mode: STPMode | None = None
+    trade_id: str | None = None
+    reservation_id: str | None = None
+
+    def __post_init__(self) -> None:
+        '''Validate command invariants at construction time.'''
+
+        if not isinstance(self.command_id, str) or not self.command_id.strip():
+            msg = 'TradeCommand.command_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.command_type, TradeCommandType):
+            msg = 'TradeCommand.command_type must be a TradeCommandType member'
+            raise ValueError(msg)
+
+        if not isinstance(self.account_id, str) or not self.account_id.strip():
+            msg = 'TradeCommand.account_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.venue, str) or not self.venue.strip():
+            msg = 'TradeCommand.venue must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.symbol, str) or not self.symbol.strip():
+            msg = 'TradeCommand.symbol must be a non-empty string'
+            raise ValueError(msg)
+
+        if (
+            not isinstance(self.notional, Decimal)
+            or not self.notional.is_finite()
+            or self.notional < _ZERO
+        ):
+            msg = 'TradeCommand.notional must be a finite non-negative Decimal'
+            raise ValueError(msg)
+
+        if not isinstance(self.created_at, datetime):
+            msg = 'TradeCommand.created_at must be a datetime'
+            raise ValueError(msg)
+
+        if (
+            self.created_at.tzinfo is None
+            or self.created_at.tzinfo.utcoffset(self.created_at) is None
+        ):
+            msg = 'TradeCommand.created_at must be timezone-aware'
+            raise ValueError(msg)
+
+        if self.side is not None and not isinstance(self.side, OrderSide):
+            msg = 'TradeCommand.side must be an OrderSide member or None'
+            raise ValueError(msg)
+
+        if self.size is not None and (
+            not isinstance(self.size, Decimal)
+            or not self.size.is_finite()
+            or self.size <= _ZERO
+        ):
+            msg = 'TradeCommand.size must be a finite positive Decimal or None'
+            raise ValueError(msg)
+
+        if self.stp_mode is not None and not isinstance(self.stp_mode, STPMode):
+            msg = 'TradeCommand.stp_mode must be an STPMode member or None'
+            raise ValueError(msg)
+
+        if self.trade_id is not None and (
+            not isinstance(self.trade_id, str) or not self.trade_id.strip()
+        ):
+            msg = 'TradeCommand.trade_id must be a non-empty string or None'
+            raise ValueError(msg)
+
+        if self.reservation_id is not None and (
+            not isinstance(self.reservation_id, str) or not self.reservation_id.strip()
+        ):
+            msg = 'TradeCommand.reservation_id must be a non-empty string or None'
+            raise ValueError(msg)
+
+        self._validate_command_type_invariants()
+
+    def _validate_command_type_invariants(self) -> None:
+        '''Validate fields based on command_type.'''
+
+        if self.command_type == TradeCommandType.NEW_ORDER:
+            if self.side is None:
+                msg = 'TradeCommand: NEW_ORDER requires side'
+                raise ValueError(msg)
+            if self.size is None:
+                msg = 'TradeCommand: NEW_ORDER requires size'
+                raise ValueError(msg)
+            if self.stp_mode is None:
+                msg = 'TradeCommand: NEW_ORDER requires stp_mode'
+                raise ValueError(msg)
+
+        elif self.command_type == TradeCommandType.AMEND_ORDER:
+            if self.stp_mode is not None:
+                msg = 'TradeCommand: AMEND_ORDER must not have stp_mode'
+                raise ValueError(msg)
+
+        elif self.command_type == TradeCommandType.CANCEL_ORDER:
+            if self.stp_mode is not None:
+                msg = 'TradeCommand: CANCEL_ORDER must not have stp_mode'
+                raise ValueError(msg)

--- a/nexus/infrastructure/praxis_connector/trade_command_type.py
+++ b/nexus/infrastructure/praxis_connector/trade_command_type.py
@@ -1,4 +1,9 @@
-'''Trade command type enum for Praxis Connector outbound translation.'''
+'''Trade command type enum for Praxis Connector outbound translation.
+
+Maps ValidationAction intents to Trading sub-system command semantics.
+ENTER/EXIT become NEW_ORDER, MODIFY becomes AMEND_ORDER, ABORT/CANCEL
+become CANCEL_ORDER.
+'''
 
 from __future__ import annotations
 

--- a/nexus/infrastructure/praxis_connector/trade_command_type.py
+++ b/nexus/infrastructure/praxis_connector/trade_command_type.py
@@ -1,0 +1,20 @@
+'''Trade command type enum for Praxis Connector outbound translation.'''
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = ['TradeCommandType']
+
+
+class TradeCommandType(Enum):
+    '''Command type for Trading sub-system dispatch.
+
+    NEW_ORDER submits a new order (ENTER/EXIT actions).
+    AMEND_ORDER modifies an in-flight order (MODIFY action).
+    CANCEL_ORDER cancels an order (ABORT/CANCEL actions).
+    '''
+
+    NEW_ORDER = 'NEW_ORDER'
+    AMEND_ORDER = 'AMEND_ORDER'
+    CANCEL_ORDER = 'CANCEL_ORDER'

--- a/nexus/infrastructure/praxis_connector/translate.py
+++ b/nexus/infrastructure/praxis_connector/translate.py
@@ -34,7 +34,7 @@ def translate_to_trade_command(
 
     Args:
         context: Validated action request context.
-        decision: Validation pipeline decision (caller ensures allowed).
+        decision: Validation pipeline decision (must be allowed).
         config: Instance configuration for account/venue/stp_mode.
         now: Timestamp for command creation.
 
@@ -42,11 +42,20 @@ def translate_to_trade_command(
         TradeCommand ready for Trading sub-system dispatch.
 
     Raises:
-        ValueError: If now is not timezone-aware.
+        ValueError: If decision is not allowed, command_id is missing,
+            or now is not timezone-aware.
     '''
+
+    if not decision.allowed:
+        msg = 'translate_to_trade_command: decision must be allowed'
+        raise ValueError(msg)
 
     if now.tzinfo is None or now.tzinfo.utcoffset(now) is None:
         msg = 'translate_to_trade_command requires timezone-aware datetime'
+        raise ValueError(msg)
+
+    if not context.command_id:
+        msg = 'translate_to_trade_command requires non-empty command_id'
         raise ValueError(msg)
 
     command_type = _ACTION_TO_COMMAND_TYPE[context.action]
@@ -57,7 +66,7 @@ def translate_to_trade_command(
         reservation_id = decision.reservation.reservation_id
 
     return TradeCommand(
-        command_id=context.command_id or '',
+        command_id=context.command_id,
         command_type=command_type,
         account_id=config.account_id,
         venue=config.venue,

--- a/nexus/infrastructure/praxis_connector/translate.py
+++ b/nexus/infrastructure/praxis_connector/translate.py
@@ -1,0 +1,72 @@
+'''Translate validated actions to TradeCommands for Trading sub-system.'''
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from nexus.core.validator.pipeline_models import (
+    ValidationAction,
+    ValidationDecision,
+    ValidationRequestContext,
+)
+from nexus.infrastructure.praxis_connector.trade_command import TradeCommand
+from nexus.infrastructure.praxis_connector.trade_command_type import TradeCommandType
+from nexus.instance_config import InstanceConfig
+
+__all__ = ['translate_to_trade_command']
+
+_ACTION_TO_COMMAND_TYPE: dict[ValidationAction, TradeCommandType] = {
+    ValidationAction.ENTER: TradeCommandType.NEW_ORDER,
+    ValidationAction.EXIT: TradeCommandType.NEW_ORDER,
+    ValidationAction.MODIFY: TradeCommandType.AMEND_ORDER,
+    ValidationAction.ABORT: TradeCommandType.CANCEL_ORDER,
+    ValidationAction.CANCEL: TradeCommandType.CANCEL_ORDER,
+}
+
+
+def translate_to_trade_command(
+    context: ValidationRequestContext,
+    decision: ValidationDecision,
+    config: InstanceConfig,
+    now: datetime,
+) -> TradeCommand:
+    '''Translate validated action to TradeCommand for Trading sub-system.
+
+    Args:
+        context: Validated action request context.
+        decision: Validation pipeline decision (caller ensures allowed).
+        config: Instance configuration for account/venue/stp_mode.
+        now: Timestamp for command creation.
+
+    Returns:
+        TradeCommand ready for Trading sub-system dispatch.
+
+    Raises:
+        ValueError: If now is not timezone-aware.
+    '''
+
+    if now.tzinfo is None or now.tzinfo.utcoffset(now) is None:
+        msg = 'translate_to_trade_command requires timezone-aware datetime'
+        raise ValueError(msg)
+
+    command_type = _ACTION_TO_COMMAND_TYPE[context.action]
+    is_new_order = command_type == TradeCommandType.NEW_ORDER
+
+    reservation_id = None
+    if decision.reservation is not None:
+        reservation_id = decision.reservation.reservation_id
+
+    return TradeCommand(
+        command_id=context.command_id or '',
+        command_type=command_type,
+        account_id=config.account_id,
+        venue=config.venue,
+        symbol=context.symbol,
+        notional=context.order_notional,
+        created_at=now,
+        side=context.order_side if is_new_order else None,
+        size=context.order_size if is_new_order else None,
+        stp_mode=config.stp_mode if is_new_order else None,
+        trade_id=context.trade_id,
+        reservation_id=reservation_id,
+    )

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from types import MappingProxyType
 
+from nexus.core.stp_mode import STPMode
+
 __all__ = ['InstanceConfig']
 
 _ZERO = Decimal('0')
@@ -42,6 +44,9 @@ class InstanceConfig:
             bps.
         reference_price_source: Optional Stage-3 reference price source
             identifier used for deviation checks.
+        stp_mode: Self-trade prevention mode for order submission. Determines
+            behavior when a new order would match the account's own resting
+            order. Defaults to ``CANCEL_TAKER``.
         capital_pct: Strategy capital-allocation percentages keyed by
             strategy_id.
     '''
@@ -55,6 +60,7 @@ class InstanceConfig:
     max_spread_bps: Decimal | None = None
     price_deviation_max_bps: Decimal | None = None
     reference_price_source: str | None = None
+    stp_mode: STPMode = STPMode.CANCEL_TAKER
     capital_pct: Mapping[str, Decimal] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -157,6 +163,10 @@ class InstanceConfig:
                 'InstanceConfig.reference_price_source is required when '
                 'price_deviation_max_bps is set'
             )
+            raise ValueError(msg)
+
+        if not isinstance(self.stp_mode, STPMode):
+            msg = 'InstanceConfig.stp_mode must be an STPMode member'
             raise ValueError(msg)
 
         if not isinstance(self.capital_pct, Mapping):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.14.0"
+version = "0.15.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from nexus.core.domain.enums import BreachLevel, OperationalMode, OrderSide
+from nexus.core.stp_mode import STPMode
 
 
 def test_operational_mode_members() -> None:
@@ -38,3 +39,21 @@ def test_breach_level_members() -> None:
         BreachLevel.BREACH,
         BreachLevel.HALT,
     }
+
+
+def test_stp_mode_members() -> None:
+    '''Verify STPMode has exactly three members.'''
+
+    assert set(STPMode) == {
+        STPMode.CANCEL_MAKER,
+        STPMode.CANCEL_TAKER,
+        STPMode.CANCEL_BOTH,
+    }
+
+
+def test_stp_mode_values() -> None:
+    '''Verify STPMode string values.'''
+
+    assert STPMode.CANCEL_MAKER.value == 'CANCEL_MAKER'
+    assert STPMode.CANCEL_TAKER.value == 'CANCEL_TAKER'
+    assert STPMode.CANCEL_BOTH.value == 'CANCEL_BOTH'

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import pytest
 
+from nexus.core.stp_mode import STPMode
 from nexus.instance_config import InstanceConfig
 
 
@@ -27,6 +28,7 @@ def test_valid_creation() -> None:
     assert cfg.max_spread_bps is None
     assert cfg.price_deviation_max_bps is None
     assert cfg.reference_price_source is None
+    assert cfg.stp_mode == STPMode.CANCEL_TAKER
     assert cfg.capital_pct == {}
 
 
@@ -374,6 +376,36 @@ def test_invalid_reference_price_source_rejected() -> None:
             allocated_capital=Decimal('10000'),
             price_deviation_max_bps=Decimal('5'),
             reference_price_source='origo_last',
+        )
+
+
+def test_valid_creation_with_stp_mode_cancel_maker() -> None:
+    cfg = InstanceConfig(
+        account_id='acc_001',
+        venue='binance_spot',
+        allocated_capital=Decimal('10000'),
+        stp_mode=STPMode.CANCEL_MAKER,
+    )
+    assert cfg.stp_mode == STPMode.CANCEL_MAKER
+
+
+def test_valid_creation_with_stp_mode_cancel_both() -> None:
+    cfg = InstanceConfig(
+        account_id='acc_001',
+        venue='binance_spot',
+        allocated_capital=Decimal('10000'),
+        stp_mode=STPMode.CANCEL_BOTH,
+    )
+    assert cfg.stp_mode == STPMode.CANCEL_BOTH
+
+
+def test_invalid_stp_mode_rejected() -> None:
+    with pytest.raises(ValueError, match='stp_mode'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            stp_mode=cast(STPMode, cast(object, 'CANCEL_TAKER')),
         )
 
 

--- a/tests/test_trade_command.py
+++ b/tests/test_trade_command.py
@@ -396,3 +396,59 @@ def test_cancel_order_with_stp_mode_rejected() -> None:
             created_at=_now(),
             stp_mode=STPMode.CANCEL_TAKER,
         )
+
+
+def test_amend_order_with_side_rejected() -> None:
+    with pytest.raises(ValueError, match='AMEND_ORDER must not have side'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.AMEND_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1500'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+        )
+
+
+def test_amend_order_with_size_rejected() -> None:
+    with pytest.raises(ValueError, match='AMEND_ORDER must not have size'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.AMEND_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1500'),
+            created_at=_now(),
+            size=Decimal('0.02'),
+        )
+
+
+def test_cancel_order_with_side_rejected() -> None:
+    with pytest.raises(ValueError, match='CANCEL_ORDER must not have side'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.CANCEL_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('0'),
+            created_at=_now(),
+            side=OrderSide.SELL,
+        )
+
+
+def test_cancel_order_with_size_rejected() -> None:
+    with pytest.raises(ValueError, match='CANCEL_ORDER must not have size'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.CANCEL_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('0'),
+            created_at=_now(),
+            size=Decimal('0.01'),
+        )

--- a/tests/test_trade_command.py
+++ b/tests/test_trade_command.py
@@ -1,0 +1,398 @@
+'''Verify TradeCommand creation and validation.'''
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import cast
+
+import pytest
+
+from nexus.core.domain.enums import OrderSide
+from nexus.core.stp_mode import STPMode
+from nexus.infrastructure.praxis_connector.trade_command import TradeCommand
+from nexus.infrastructure.praxis_connector.trade_command_type import TradeCommandType
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def test_valid_new_order_creation() -> None:
+    cmd = TradeCommand(
+        command_id='cmd_001',
+        command_type=TradeCommandType.NEW_ORDER,
+        account_id='acc_001',
+        venue='binance_spot',
+        symbol='BTCUSDT',
+        notional=Decimal('1000'),
+        created_at=_now(),
+        side=OrderSide.BUY,
+        size=Decimal('0.01'),
+        stp_mode=STPMode.CANCEL_TAKER,
+        reservation_id='res_001',
+    )
+    assert cmd.command_type == TradeCommandType.NEW_ORDER
+    assert cmd.side == OrderSide.BUY
+    assert cmd.stp_mode == STPMode.CANCEL_TAKER
+
+
+def test_valid_new_order_with_trade_id() -> None:
+    cmd = TradeCommand(
+        command_id='cmd_002',
+        command_type=TradeCommandType.NEW_ORDER,
+        account_id='acc_001',
+        venue='binance_spot',
+        symbol='BTCUSDT',
+        notional=Decimal('1000'),
+        created_at=_now(),
+        side=OrderSide.SELL,
+        size=Decimal('0.01'),
+        stp_mode=STPMode.CANCEL_MAKER,
+        trade_id='trade_001',
+    )
+    assert cmd.trade_id == 'trade_001'
+
+
+def test_valid_amend_order_creation() -> None:
+    cmd = TradeCommand(
+        command_id='cmd_003',
+        command_type=TradeCommandType.AMEND_ORDER,
+        account_id='acc_001',
+        venue='binance_spot',
+        symbol='BTCUSDT',
+        notional=Decimal('1500'),
+        created_at=_now(),
+    )
+    assert cmd.command_type == TradeCommandType.AMEND_ORDER
+    assert cmd.stp_mode is None
+
+
+def test_valid_cancel_order_creation() -> None:
+    cmd = TradeCommand(
+        command_id='cmd_004',
+        command_type=TradeCommandType.CANCEL_ORDER,
+        account_id='acc_001',
+        venue='binance_spot',
+        symbol='BTCUSDT',
+        notional=Decimal('0'),
+        created_at=_now(),
+    )
+    assert cmd.command_type == TradeCommandType.CANCEL_ORDER
+    assert cmd.stp_mode is None
+
+
+def test_frozen() -> None:
+    cmd = TradeCommand(
+        command_id='cmd_001',
+        command_type=TradeCommandType.NEW_ORDER,
+        account_id='acc_001',
+        venue='binance_spot',
+        symbol='BTCUSDT',
+        notional=Decimal('1000'),
+        created_at=_now(),
+        side=OrderSide.BUY,
+        size=Decimal('0.01'),
+        stp_mode=STPMode.CANCEL_TAKER,
+    )
+    with pytest.raises(AttributeError):
+        cmd.command_id = 'cmd_002'  # type: ignore[misc]
+
+
+def test_empty_command_id_rejected() -> None:
+    with pytest.raises(ValueError, match='command_id'):
+        TradeCommand(
+            command_id='',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_invalid_command_type_rejected() -> None:
+    with pytest.raises(ValueError, match='command_type'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=cast(TradeCommandType, cast(object, 'NEW_ORDER')),
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_empty_account_id_rejected() -> None:
+    with pytest.raises(ValueError, match='account_id'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_empty_venue_rejected() -> None:
+    with pytest.raises(ValueError, match='venue'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_empty_symbol_rejected() -> None:
+    with pytest.raises(ValueError, match='symbol'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_negative_notional_rejected() -> None:
+    with pytest.raises(ValueError, match='notional'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('-100'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_nan_notional_rejected() -> None:
+    with pytest.raises(ValueError, match='notional'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('NaN'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_naive_datetime_rejected() -> None:
+    with pytest.raises(ValueError, match='created_at'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=datetime.now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_invalid_side_rejected() -> None:
+    with pytest.raises(ValueError, match='side'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=cast(OrderSide, cast(object, 'BUY')),
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_zero_size_rejected() -> None:
+    with pytest.raises(ValueError, match='size'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_negative_size_rejected() -> None:
+    with pytest.raises(ValueError, match='size'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('-0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_invalid_stp_mode_rejected() -> None:
+    with pytest.raises(ValueError, match='stp_mode'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            stp_mode=cast(STPMode, cast(object, 'CANCEL_TAKER')),
+        )
+
+
+def test_empty_trade_id_rejected() -> None:
+    with pytest.raises(ValueError, match='trade_id'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+            trade_id='   ',
+        )
+
+
+def test_empty_reservation_id_rejected() -> None:
+    with pytest.raises(ValueError, match='reservation_id'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+            reservation_id='',
+        )
+
+
+def test_new_order_without_side_rejected() -> None:
+    with pytest.raises(ValueError, match='NEW_ORDER requires side'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            size=Decimal('0.01'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_new_order_without_size_rejected() -> None:
+    with pytest.raises(ValueError, match='NEW_ORDER requires size'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_new_order_without_stp_mode_rejected() -> None:
+    with pytest.raises(ValueError, match='NEW_ORDER requires stp_mode'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.NEW_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+        )
+
+
+def test_amend_order_with_stp_mode_rejected() -> None:
+    with pytest.raises(ValueError, match='AMEND_ORDER must not have stp_mode'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.AMEND_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('1000'),
+            created_at=_now(),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+
+
+def test_cancel_order_with_stp_mode_rejected() -> None:
+    with pytest.raises(ValueError, match='CANCEL_ORDER must not have stp_mode'):
+        TradeCommand(
+            command_id='cmd_001',
+            command_type=TradeCommandType.CANCEL_ORDER,
+            account_id='acc_001',
+            venue='binance_spot',
+            symbol='BTCUSDT',
+            notional=Decimal('0'),
+            created_at=_now(),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )

--- a/tests/test_trade_command_type.py
+++ b/tests/test_trade_command_type.py
@@ -1,0 +1,23 @@
+'''Verify TradeCommandType enum members and values.'''
+
+from __future__ import annotations
+
+from nexus.infrastructure.praxis_connector.trade_command_type import TradeCommandType
+
+
+def test_trade_command_type_members() -> None:
+    '''Verify TradeCommandType has exactly three members.'''
+
+    assert set(TradeCommandType) == {
+        TradeCommandType.NEW_ORDER,
+        TradeCommandType.AMEND_ORDER,
+        TradeCommandType.CANCEL_ORDER,
+    }
+
+
+def test_trade_command_type_values() -> None:
+    '''Verify TradeCommandType string values.'''
+
+    assert TradeCommandType.NEW_ORDER.value == 'NEW_ORDER'
+    assert TradeCommandType.AMEND_ORDER.value == 'AMEND_ORDER'
+    assert TradeCommandType.CANCEL_ORDER.value == 'CANCEL_ORDER'

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -14,6 +14,7 @@ from nexus.core.validator.pipeline_models import (
     ValidationAction,
     ValidationDecision,
     ValidationRequestContext,
+    ValidationStage,
 )
 from nexus.core.capital_controller.reservation import Reservation
 from nexus.infrastructure.praxis_connector.trade_command_type import TradeCommandType
@@ -46,7 +47,7 @@ def _reservation() -> Reservation:
         notional=Decimal('1000'),
         estimated_fees=Decimal('1'),
         created_at=now,
-        expires_at=now.replace(minute=now.minute + 1),
+        expires_at=now + timedelta(minutes=1),
     )
 
 
@@ -235,3 +236,41 @@ def test_stp_mode_from_config() -> None:
         config = _config(stp_mode=mode)
         cmd = translate_to_trade_command(context, decision, config, now)
         assert cmd.stp_mode == mode
+
+
+def test_denied_decision_rejected() -> None:
+    context = _enter_context()
+    decision = ValidationDecision(
+        allowed=False,
+        failed_stage=ValidationStage.CAPITAL,
+        reason_code='CAPITAL_INSUFFICIENT',
+        message='Insufficient capital',
+    )
+    config = _config()
+    now = _now()
+
+    with pytest.raises(ValueError, match='decision must be allowed'):
+        translate_to_trade_command(context, decision, config, now)
+
+
+def test_missing_command_id_rejected() -> None:
+    context = ValidationRequestContext(
+        strategy_id='strat_001',
+        action=ValidationAction.EXIT,
+        symbol='BTCUSDT',
+        order_side=OrderSide.SELL,
+        order_size=Decimal('0.01'),
+        command_id=None,
+        trade_id='trade_001',
+        order_notional=Decimal('1000'),
+        estimated_fees=Decimal('1'),
+        strategy_budget=Decimal('5000'),
+        state=_state(),
+        config=_config(),
+    )
+    decision = ValidationDecision(allowed=True)
+    config = _config()
+    now = _now()
+
+    with pytest.raises(ValueError, match='non-empty command_id'):
+        translate_to_trade_command(context, decision, config, now)

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,0 +1,237 @@
+'''Verify translate_to_trade_command function.'''
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from nexus.core.domain.enums import OrderSide
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.stp_mode import STPMode
+from nexus.core.validator.pipeline_models import (
+    ValidationAction,
+    ValidationDecision,
+    ValidationRequestContext,
+)
+from nexus.core.capital_controller.reservation import Reservation
+from nexus.infrastructure.praxis_connector.trade_command_type import TradeCommandType
+from nexus.infrastructure.praxis_connector.translate import translate_to_trade_command
+from nexus.instance_config import InstanceConfig
+
+
+def _config(stp_mode: STPMode = STPMode.CANCEL_TAKER) -> InstanceConfig:
+    return InstanceConfig(
+        account_id='acc_001',
+        venue='binance_spot',
+        allocated_capital=Decimal('10000'),
+        stp_mode=stp_mode,
+    )
+
+
+def _state() -> InstanceState:
+    return InstanceState.from_config(_config())
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _reservation() -> Reservation:
+    now = _now()
+    return Reservation(
+        reservation_id='res_001',
+        strategy_id='strat_001',
+        notional=Decimal('1000'),
+        estimated_fees=Decimal('1'),
+        created_at=now,
+        expires_at=now.replace(minute=now.minute + 1),
+    )
+
+
+def _enter_context() -> ValidationRequestContext:
+    return ValidationRequestContext(
+        strategy_id='strat_001',
+        action=ValidationAction.ENTER,
+        symbol='BTCUSDT',
+        order_side=OrderSide.BUY,
+        order_size=Decimal('0.01'),
+        command_id='cmd_001',
+        order_notional=Decimal('1000'),
+        estimated_fees=Decimal('1'),
+        strategy_budget=Decimal('5000'),
+        state=_state(),
+        config=_config(),
+    )
+
+
+def _exit_context() -> ValidationRequestContext:
+    return ValidationRequestContext(
+        strategy_id='strat_001',
+        action=ValidationAction.EXIT,
+        symbol='BTCUSDT',
+        order_side=OrderSide.SELL,
+        order_size=Decimal('0.01'),
+        command_id='cmd_002',
+        trade_id='trade_001',
+        order_notional=Decimal('1000'),
+        estimated_fees=Decimal('1'),
+        strategy_budget=Decimal('5000'),
+        state=_state(),
+        config=_config(),
+    )
+
+
+def _modify_context() -> ValidationRequestContext:
+    return ValidationRequestContext(
+        strategy_id='strat_001',
+        action=ValidationAction.MODIFY,
+        symbol='BTCUSDT',
+        command_id='cmd_003',
+        order_notional=Decimal('1500'),
+        current_order_notional=Decimal('1000'),
+        estimated_fees=Decimal('1'),
+        strategy_budget=Decimal('5000'),
+        state=_state(),
+        config=_config(),
+    )
+
+
+def _abort_context() -> ValidationRequestContext:
+    return ValidationRequestContext(
+        strategy_id='strat_001',
+        action=ValidationAction.ABORT,
+        symbol='BTCUSDT',
+        command_id='cmd_004',
+        order_notional=Decimal('0'),
+        estimated_fees=Decimal('0'),
+        strategy_budget=Decimal('5000'),
+        state=_state(),
+        config=_config(),
+    )
+
+
+def _cancel_context() -> ValidationRequestContext:
+    return ValidationRequestContext(
+        strategy_id='strat_001',
+        action=ValidationAction.CANCEL,
+        symbol='BTCUSDT',
+        command_id='cmd_005',
+        order_notional=Decimal('0'),
+        estimated_fees=Decimal('0'),
+        strategy_budget=Decimal('5000'),
+        state=_state(),
+        config=_config(),
+    )
+
+
+def test_enter_translation() -> None:
+    context = _enter_context()
+    decision = ValidationDecision(allowed=True, reservation=_reservation())
+    config = _config()
+    now = _now()
+
+    cmd = translate_to_trade_command(context, decision, config, now)
+
+    assert cmd.command_type == TradeCommandType.NEW_ORDER
+    assert cmd.command_id == 'cmd_001'
+    assert cmd.account_id == 'acc_001'
+    assert cmd.venue == 'binance_spot'
+    assert cmd.symbol == 'BTCUSDT'
+    assert cmd.side == OrderSide.BUY
+    assert cmd.size == Decimal('0.01')
+    assert cmd.notional == Decimal('1000')
+    assert cmd.stp_mode == STPMode.CANCEL_TAKER
+    assert cmd.reservation_id == 'res_001'
+    assert cmd.created_at == now
+
+
+def test_exit_translation() -> None:
+    context = _exit_context()
+    decision = ValidationDecision(allowed=True)
+    config = _config(stp_mode=STPMode.CANCEL_MAKER)
+    now = _now()
+
+    cmd = translate_to_trade_command(context, decision, config, now)
+
+    assert cmd.command_type == TradeCommandType.NEW_ORDER
+    assert cmd.side == OrderSide.SELL
+    assert cmd.stp_mode == STPMode.CANCEL_MAKER
+    assert cmd.trade_id == 'trade_001'
+    assert cmd.reservation_id is None
+
+
+def test_modify_translation() -> None:
+    context = _modify_context()
+    decision = ValidationDecision(allowed=True)
+    config = _config()
+    now = _now()
+
+    cmd = translate_to_trade_command(context, decision, config, now)
+
+    assert cmd.command_type == TradeCommandType.AMEND_ORDER
+    assert cmd.command_id == 'cmd_003'
+    assert cmd.notional == Decimal('1500')
+    assert cmd.side is None
+    assert cmd.size is None
+    assert cmd.stp_mode is None
+
+
+def test_abort_translation() -> None:
+    context = _abort_context()
+    decision = ValidationDecision(allowed=True)
+    config = _config()
+    now = _now()
+
+    cmd = translate_to_trade_command(context, decision, config, now)
+
+    assert cmd.command_type == TradeCommandType.CANCEL_ORDER
+    assert cmd.command_id == 'cmd_004'
+    assert cmd.stp_mode is None
+
+
+def test_cancel_translation() -> None:
+    context = _cancel_context()
+    decision = ValidationDecision(allowed=True)
+    config = _config()
+    now = _now()
+
+    cmd = translate_to_trade_command(context, decision, config, now)
+
+    assert cmd.command_type == TradeCommandType.CANCEL_ORDER
+    assert cmd.command_id == 'cmd_005'
+    assert cmd.stp_mode is None
+
+
+def test_naive_datetime_rejected() -> None:
+    context = _enter_context()
+    decision = ValidationDecision(allowed=True, reservation=_reservation())
+    config = _config()
+    now = datetime.now()
+
+    with pytest.raises(ValueError, match='timezone-aware'):
+        translate_to_trade_command(context, decision, config, now)
+
+
+def test_deterministic_output() -> None:
+    context = _enter_context()
+    decision = ValidationDecision(allowed=True, reservation=_reservation())
+    config = _config()
+    now = datetime(2026, 3, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+    cmd1 = translate_to_trade_command(context, decision, config, now)
+    cmd2 = translate_to_trade_command(context, decision, config, now)
+
+    assert cmd1 == cmd2
+
+
+def test_stp_mode_from_config() -> None:
+    context = _enter_context()
+    decision = ValidationDecision(allowed=True, reservation=_reservation())
+    now = _now()
+
+    for mode in STPMode:
+        config = _config(stp_mode=mode)
+        cmd = translate_to_trade_command(context, decision, config, now)
+        assert cmd.stp_mode == mode


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Phase 4.1 Praxis Connector outbound translation (from RFC-3001 Manager Sub-System). Adds `STPMode` enum for self-trade prevention with three modes (CANCEL_MAKER, CANCEL_TAKER default, CANCEL_BOTH). Extends `InstanceConfig` with `stp_mode` field. Adds `TradeCommandType` enum mapping ValidationAction to Trading sub-system command semantics (ENTER/EXIT → NEW_ORDER, MODIFY → AMEND_ORDER, ABORT/CANCEL → CANCEL_ORDER). Adds frozen `TradeCommand` dataclass with command-type-specific validation (NEW_ORDER requires side/size/stp_mode; AMEND/CANCEL reject side/size/stp_mode). Adds `translate_to_trade_command()` for deterministic action-to-command mapping with explicit guards for allowed decisions and non-empty command_id. Adds `OutboundConnector` protocol defining the Trading sub-system dispatch interface. Adds 45 new tests (558 total). Bumps to v0.15.0.

## Checklist

- [ ] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (558 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable