### PR TITLE
feat: 4.2 Praxis Connector inbound trade outcome processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.16.0 on 27th of March, 2026
+
+- Add [`trade_outcome_type.py`](nexus/infrastructure/praxis_connector/trade_outcome_type.py) with `TradeOutcomeType` enum (ACK, PARTIAL, FILLED, REJECTED, EXPIRED, CANCELED)
+- Add [`trade_outcome.py`](nexus/infrastructure/praxis_connector/trade_outcome.py) with frozen `TradeOutcome` dataclass and outcome-type-specific validation (fill outcomes require `actual_fees`)
+- Add [`inbound_connector.py`](nexus/infrastructure/praxis_connector/inbound_connector.py) with `InboundConnector` protocol for receiving outcomes from Trading sub-system
+- Add [`order_context.py`](nexus/infrastructure/praxis_connector/order_context.py) with frozen `OrderContext` dataclass bridging outcome processing with order metadata (side, trade_id, estimated_fees)
+- Add [`process_result.py`](nexus/infrastructure/praxis_connector/process_result.py) with frozen `ProcessResult` dataclass for outcome processing results
+- Extend `CapitalController.order_fill()` with `actual_fees` parameter and fee reconciliation against `fee_reserve`
+- Add [`outcome_processor.py`](nexus/infrastructure/praxis_connector/outcome_processor.py) with `OutcomeProcessor` routing outcomes to Capital Controller lifecycle methods
+- Add position growth with VWAP entry price calculation on entry fills
+- Add position reduction with `pending_exit` clearing on exit fills, removing closed positions from state
+- Add 126 tests covering TradeOutcome validation, OutcomeProcessor routing, position growth/reduction, and fee reconciliation (638 total)
+
 ## v0.15.0 on 25th of March, 2026
 
 - Add [`stp_mode.py`](nexus/core/stp_mode.py) with `STPMode` enum (CANCEL_MAKER, CANCEL_TAKER, CANCEL_BOTH) for self-trade prevention

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -490,6 +490,9 @@ class CapitalController:
             self._state.position_notional += fill_notional + actual_fees
             self._state.fee_reserve += fee_delta
 
+            if fee_delta != _ZERO:
+                self._adjust_strategy_deployed(order.strategy_id, -fee_delta)
+
             return True
 
     def order_cancel(self, order_id: str) -> bool:

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -405,22 +405,27 @@ class CapitalController:
 
             return True
 
-    def order_fill(self, order_id: str, fill_notional: Decimal) -> bool:
+    def order_fill(
+        self,
+        order_id: str,
+        fill_notional: Decimal,
+        actual_fees: Decimal,
+    ) -> bool:
         '''Handle a fill (partial or full) on a working order.
 
         Moves capital from working_order_notional to position_notional.
-        The moved amount includes the fill plus its proportional share of
-        estimated fees. Partial fills update remaining_notional; full fills
-        remove the order.
+        Working decreases by estimated amount; position increases by actual
+        cost (fill_notional + actual_fees). Fee variance is reconciled against
+        fee_reserve: surplus adds, deficit draws.
 
         Args:
             order_id: ID of the filled order.
-            fill_notional: Quote capital filled (excluding fees). The
-                proportional fee component is computed and added.
+            fill_notional: Quote capital filled (excluding fees).
+            actual_fees: Actual fees charged by venue for this fill.
 
         Returns:
             True if successful, False if order not found, wrong state,
-            or fill_notional exceeds remaining.
+            fill_notional exceeds remaining, or insufficient fee_reserve.
         '''
 
         if not isinstance(fill_notional, Decimal) or not fill_notional.is_finite():
@@ -429,6 +434,14 @@ class CapitalController:
 
         if fill_notional <= _ZERO:
             msg = f'fill_notional must be positive: {fill_notional}'
+            raise ValueError(msg)
+
+        if not isinstance(actual_fees, Decimal) or not actual_fees.is_finite():
+            msg = f'actual_fees must be a finite Decimal: {actual_fees}'
+            raise ValueError(msg)
+
+        if actual_fees < _ZERO:
+            msg = f'actual_fees must be non-negative: {actual_fees}'
             raise ValueError(msg)
 
         with self._lock:
@@ -447,8 +460,8 @@ class CapitalController:
             new_remaining = order.remaining_notional - fill_notional
 
             if new_remaining == _ZERO:
-                fill_with_fees = pre_fill_remaining
-                self._orders.pop(order_id)
+                fill_with_estimated = pre_fill_remaining
+                proportional_estimated = pre_fill_remaining - order.remaining_notional
             else:
                 updated = TrackedOrder(
                     order_id=order.order_id,
@@ -460,11 +473,22 @@ class CapitalController:
                     state=OrderLifecycleState.WORKING,
                     created_at=order.created_at,
                 )
-                fill_with_fees = pre_fill_remaining - updated.remaining_total
+                fill_with_estimated = pre_fill_remaining - updated.remaining_total
+                proportional_estimated = fill_with_estimated - fill_notional
+
+            fee_delta = proportional_estimated - actual_fees
+
+            if fee_delta < _ZERO and abs(fee_delta) > self._state.fee_reserve:
+                return False
+
+            if new_remaining == _ZERO:
+                self._orders.pop(order_id)
+            else:
                 self._orders[order_id] = updated
 
-            self._state.working_order_notional -= fill_with_fees
-            self._state.position_notional += fill_with_fees
+            self._state.working_order_notional -= fill_with_estimated
+            self._state.position_notional += fill_notional + actual_fees
+            self._state.fee_reserve += fee_delta
 
             return True
 

--- a/nexus/core/domain/instance_state.py
+++ b/nexus/core/domain/instance_state.py
@@ -40,7 +40,9 @@ class InstanceState:
 
         for key, pos in self.positions.items():
             if not isinstance(pos, Position):
-                msg = f'InstanceState.positions value for key {key!r} must be a Position'
+                msg = (
+                    f'InstanceState.positions value for key {key!r} must be a Position'
+                )
                 raise ValueError(msg)
             if key != pos.trade_id:
                 msg = f'InstanceState.positions key {key!r} does not match trade_id {pos.trade_id!r}'

--- a/nexus/infrastructure/praxis_connector/inbound_connector.py
+++ b/nexus/infrastructure/praxis_connector/inbound_connector.py
@@ -1,0 +1,30 @@
+'''Inbound connector protocol for Trading sub-system result consumption.
+
+Defines the interface for receiving TradeOutcomes from the Trading
+sub-system (Praxis). Concrete implementations handle transport details
+such as polling, WebSocket push, or in-memory mocks for testing.
+'''
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+
+__all__ = ['InboundConnector']
+
+
+class InboundConnector(Protocol):
+    '''Protocol for receiving TradeOutcomes from the Trading sub-system.
+
+    Concrete implementations handle transport details (polling, push, etc.).
+    '''
+
+    def receive_outcome(self) -> TradeOutcome | None:
+        '''Receive next TradeOutcome from Trading sub-system.
+
+        Returns:
+            TradeOutcome if available, None if no outcome pending.
+        '''
+
+        ...

--- a/nexus/infrastructure/praxis_connector/order_context.py
+++ b/nexus/infrastructure/praxis_connector/order_context.py
@@ -1,0 +1,97 @@
+'''OrderContext dataclass for outcome processing metadata.
+
+Provides the metadata needed to process TradeOutcomes, since outcomes
+only carry command_id. Stored when order is dispatched, retrieved when
+outcome arrives.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from nexus.core.domain.enums import OrderSide
+
+__all__ = ['OrderContext']
+
+_ZERO = Decimal(0)
+
+
+@dataclass(frozen=True)
+class OrderContext:
+    '''Metadata for processing TradeOutcomes.
+
+    Args:
+        command_id: Links to TradeCommand and TradeOutcome.
+        strategy_id: Which strategy owns this order.
+        trade_id: Position reference; None for new entries until assigned.
+        side: Order direction (BUY for entry, SELL for exit).
+        order_size: Original order size in base asset.
+        order_notional: Original order notional in quote asset.
+        estimated_fees: Estimated fees at reservation time for reconciliation.
+    '''
+
+    command_id: str
+    strategy_id: str
+    trade_id: str | None
+    side: OrderSide
+    order_size: Decimal
+    order_notional: Decimal
+    estimated_fees: Decimal
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if not isinstance(self.command_id, str) or not self.command_id.strip():
+            msg = 'OrderContext.command_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.strategy_id, str) or not self.strategy_id.strip():
+            msg = 'OrderContext.strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if self.trade_id is not None and (
+            not isinstance(self.trade_id, str) or not self.trade_id.strip()
+        ):
+            msg = 'OrderContext.trade_id must be a non-empty string if provided'
+            raise ValueError(msg)
+
+        if not isinstance(self.side, OrderSide):
+            msg = 'OrderContext.side must be an OrderSide member'
+            raise ValueError(msg)
+
+        if not isinstance(self.order_size, Decimal) or not self.order_size.is_finite():
+            msg = 'OrderContext.order_size must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.order_size <= _ZERO:
+            msg = 'OrderContext.order_size must be positive'
+            raise ValueError(msg)
+
+        if not isinstance(self.order_notional, Decimal) or not self.order_notional.is_finite():
+            msg = 'OrderContext.order_notional must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.order_notional <= _ZERO:
+            msg = 'OrderContext.order_notional must be positive'
+            raise ValueError(msg)
+
+        if not isinstance(self.estimated_fees, Decimal) or not self.estimated_fees.is_finite():
+            msg = 'OrderContext.estimated_fees must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.estimated_fees < _ZERO:
+            msg = 'OrderContext.estimated_fees must be non-negative'
+            raise ValueError(msg)
+
+    @property
+    def is_entry(self) -> bool:
+        '''Return True if this is an entry order (BUY side).'''
+
+        return self.side == OrderSide.BUY
+
+    @property
+    def is_exit(self) -> bool:
+        '''Return True if this is an exit order (SELL side).'''
+
+        return self.side == OrderSide.SELL

--- a/nexus/infrastructure/praxis_connector/order_context.py
+++ b/nexus/infrastructure/praxis_connector/order_context.py
@@ -68,7 +68,10 @@ class OrderContext:
             msg = 'OrderContext.order_size must be positive'
             raise ValueError(msg)
 
-        if not isinstance(self.order_notional, Decimal) or not self.order_notional.is_finite():
+        if (
+            not isinstance(self.order_notional, Decimal)
+            or not self.order_notional.is_finite()
+        ):
             msg = 'OrderContext.order_notional must be a finite Decimal'
             raise ValueError(msg)
 
@@ -76,7 +79,10 @@ class OrderContext:
             msg = 'OrderContext.order_notional must be positive'
             raise ValueError(msg)
 
-        if not isinstance(self.estimated_fees, Decimal) or not self.estimated_fees.is_finite():
+        if (
+            not isinstance(self.estimated_fees, Decimal)
+            or not self.estimated_fees.is_finite()
+        ):
             msg = 'OrderContext.estimated_fees must be a finite Decimal'
             raise ValueError(msg)
 

--- a/nexus/infrastructure/praxis_connector/outcome_processor.py
+++ b/nexus/infrastructure/praxis_connector/outcome_processor.py
@@ -1,0 +1,244 @@
+'''OutcomeProcessor for routing TradeOutcomes to Capital Controller.
+
+Routes inbound TradeOutcomes to appropriate Capital Controller lifecycle
+methods and updates positions on fill outcomes.
+'''
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from nexus.core.capital_controller.capital_controller import CapitalController
+from nexus.core.domain.instance_state import InstanceState
+from nexus.infrastructure.praxis_connector.order_context import OrderContext
+from nexus.infrastructure.praxis_connector.process_result import ProcessResult
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+
+__all__ = ['OutcomeProcessor']
+
+_ZERO = Decimal(0)
+
+
+class OutcomeProcessor:
+    '''Routes TradeOutcomes to Capital Controller and updates positions.
+
+    Args:
+        capital_controller: Capital lifecycle manager.
+        instance_state: Runtime state containing positions.
+    '''
+
+    def __init__(
+        self,
+        capital_controller: CapitalController,
+        instance_state: InstanceState,
+    ) -> None:
+        self._capital = capital_controller
+        self._state = instance_state
+
+    def process(
+        self,
+        outcome: TradeOutcome,
+        context: OrderContext,
+    ) -> ProcessResult:
+        '''Process a TradeOutcome and update state accordingly.
+
+        Args:
+            outcome: Inbound outcome from Trading sub-system.
+            context: Metadata for outcome processing.
+
+        Returns:
+            ProcessResult indicating success and what was updated.
+        '''
+
+        if outcome.outcome_type == TradeOutcomeType.ACK:
+            return self._handle_ack(outcome)
+
+        if outcome.outcome_type in (TradeOutcomeType.PARTIAL, TradeOutcomeType.FILLED):
+            return self._handle_fill(outcome, context)
+
+        if outcome.outcome_type == TradeOutcomeType.REJECTED:
+            return self._handle_reject(outcome, context)
+
+        return self._handle_cancel(outcome, context)
+
+    def _handle_ack(self, outcome: TradeOutcome) -> ProcessResult:
+        success = self._capital.order_ack(outcome.command_id)
+
+        if not success:
+            return ProcessResult(
+                success=False,
+                outcome_type=outcome.outcome_type,
+                error_reason='order_ack failed: order not found or wrong state',
+            )
+
+        return ProcessResult(
+            success=True,
+            outcome_type=outcome.outcome_type,
+            capital_updated=True,
+        )
+
+    def _handle_fill(
+        self,
+        outcome: TradeOutcome,
+        context: OrderContext,
+    ) -> ProcessResult:
+        assert outcome.fill_notional is not None
+        assert outcome.actual_fees is not None
+        assert outcome.fill_size is not None
+        assert outcome.fill_price is not None
+
+        success = self._capital.order_fill(
+            outcome.command_id,
+            outcome.fill_notional,
+            outcome.actual_fees,
+        )
+
+        if not success:
+            return ProcessResult(
+                success=False,
+                outcome_type=outcome.outcome_type,
+                error_reason='order_fill failed: order not found, wrong state, or insufficient fee_reserve',
+            )
+
+        position_updated = self._update_position_on_fill(outcome, context)
+
+        return ProcessResult(
+            success=True,
+            outcome_type=outcome.outcome_type,
+            position_updated=position_updated,
+            capital_updated=True,
+        )
+
+    def _handle_reject(
+        self,
+        outcome: TradeOutcome,
+        context: OrderContext,
+    ) -> ProcessResult:
+        success = self._capital.order_reject(outcome.command_id)
+
+        if not success:
+            return ProcessResult(
+                success=False,
+                outcome_type=outcome.outcome_type,
+                error_reason='order_reject failed: order not found or wrong state',
+            )
+
+        position_updated = False
+
+        if context.is_exit:
+            position_updated = self._clear_pending_exit(context, context.order_size)
+
+        return ProcessResult(
+            success=True,
+            outcome_type=outcome.outcome_type,
+            position_updated=position_updated,
+            capital_updated=True,
+        )
+
+    def _handle_cancel(
+        self,
+        outcome: TradeOutcome,
+        context: OrderContext,
+    ) -> ProcessResult:
+        success = self._capital.order_cancel(outcome.command_id)
+
+        if not success:
+            return ProcessResult(
+                success=False,
+                outcome_type=outcome.outcome_type,
+                error_reason='order_cancel failed: order not found or wrong state',
+            )
+
+        position_updated = False
+
+        if context.is_exit:
+            position_updated = self._clear_pending_exit(context, context.order_size)
+
+        return ProcessResult(
+            success=True,
+            outcome_type=outcome.outcome_type,
+            position_updated=position_updated,
+            capital_updated=True,
+        )
+
+    def _update_position_on_fill(
+        self,
+        outcome: TradeOutcome,
+        context: OrderContext,
+    ) -> bool:
+        assert outcome.fill_size is not None
+        assert outcome.fill_price is not None
+
+        if context.is_entry:
+            return self._grow_position(outcome, context)
+
+        return self._reduce_position(outcome, context)
+
+    def _grow_position(
+        self,
+        outcome: TradeOutcome,
+        context: OrderContext,
+    ) -> bool:
+        assert outcome.fill_size is not None
+        assert outcome.fill_price is not None
+
+        if context.trade_id is None:
+            return False
+
+        position = self._state.positions.get(context.trade_id)
+
+        if position is None:
+            return False
+
+        old_size = position.size
+        fill_size = outcome.fill_size
+        fill_price = outcome.fill_price
+
+        new_size = old_size + fill_size
+        new_entry_price = (
+            (old_size * position.entry_price + fill_size * fill_price) / new_size
+        )
+
+        position.size = new_size
+        position.entry_price = new_entry_price
+
+        return True
+
+    def _reduce_position(
+        self,
+        outcome: TradeOutcome,
+        context: OrderContext,
+    ) -> bool:
+        assert outcome.fill_size is not None
+
+        if context.trade_id is None:
+            return False
+
+        position = self._state.positions.get(context.trade_id)
+
+        if position is None:
+            return False
+
+        fill_size = outcome.fill_size
+
+        position.size = position.size - fill_size
+        position.pending_exit = max(_ZERO, position.pending_exit - fill_size)
+
+        if position.is_closed:
+            del self._state.positions[context.trade_id]
+
+        return True
+
+    def _clear_pending_exit(self, context: OrderContext, size: Decimal) -> bool:
+        if context.trade_id is None:
+            return False
+
+        position = self._state.positions.get(context.trade_id)
+
+        if position is None:
+            return False
+
+        position.pending_exit = max(_ZERO, position.pending_exit - size)
+
+        return True

--- a/nexus/infrastructure/praxis_connector/outcome_processor.py
+++ b/nexus/infrastructure/praxis_connector/outcome_processor.py
@@ -98,18 +98,23 @@ class OutcomeProcessor:
         assert outcome.fill_size is not None
         assert outcome.fill_price is not None
 
-        success = self._capital.order_fill(
-            outcome.command_id,
-            outcome.fill_notional,
-            outcome.actual_fees,
-        )
+        capital_updated = False
 
-        if not success:
-            return ProcessResult(
-                success=False,
-                outcome_type=outcome.outcome_type,
-                error_reason='order_fill failed: order not found, wrong state, fill_notional exceeds remaining, or insufficient fee_reserve',
+        if context.is_entry:
+            success = self._capital.order_fill(
+                outcome.command_id,
+                outcome.fill_notional,
+                outcome.actual_fees,
             )
+
+            if not success:
+                return ProcessResult(
+                    success=False,
+                    outcome_type=outcome.outcome_type,
+                    error_reason='order_fill failed: order not found, wrong state, fill_notional exceeds remaining, or insufficient fee_reserve',
+                )
+
+            capital_updated = True
 
         position_updated = self._update_position_on_fill(outcome, context)
 
@@ -117,7 +122,7 @@ class OutcomeProcessor:
             success=True,
             outcome_type=outcome.outcome_type,
             position_updated=position_updated,
-            capital_updated=True,
+            capital_updated=capital_updated,
         )
 
     def _handle_reject(

--- a/nexus/infrastructure/praxis_connector/outcome_processor.py
+++ b/nexus/infrastructure/praxis_connector/outcome_processor.py
@@ -108,7 +108,7 @@ class OutcomeProcessor:
             return ProcessResult(
                 success=False,
                 outcome_type=outcome.outcome_type,
-                error_reason='order_fill failed: order not found, wrong state, or insufficient fee_reserve',
+                error_reason='order_fill failed: order not found, wrong state, fill_notional exceeds remaining, or insufficient fee_reserve',
             )
 
         position_updated = self._update_position_on_fill(outcome, context)
@@ -163,10 +163,11 @@ class OutcomeProcessor:
         position_updated = False
 
         if context.is_exit:
-            clear_size = (
+            clear_size = min(
                 outcome.remaining_size
                 if outcome.remaining_size is not None
-                else context.order_size
+                else context.order_size,
+                context.order_size,
             )
             position_updated = self._clear_pending_exit(context, clear_size)
 

--- a/nexus/infrastructure/praxis_connector/outcome_processor.py
+++ b/nexus/infrastructure/praxis_connector/outcome_processor.py
@@ -197,8 +197,8 @@ class OutcomeProcessor:
 
         new_size = old_size + fill_size
         new_entry_price = (
-            (old_size * position.entry_price + fill_size * fill_price) / new_size
-        )
+            old_size * position.entry_price + fill_size * fill_price
+        ) / new_size
 
         position.size = new_size
         position.entry_price = new_entry_price

--- a/nexus/infrastructure/praxis_connector/outcome_processor.py
+++ b/nexus/infrastructure/praxis_connector/outcome_processor.py
@@ -51,6 +51,16 @@ class OutcomeProcessor:
             ProcessResult indicating success and what was updated.
         '''
 
+        if context.command_id != outcome.command_id:
+            return ProcessResult(
+                success=False,
+                outcome_type=outcome.outcome_type,
+                error_reason=(
+                    f'context.command_id {context.command_id!r} does not match '
+                    f'outcome.command_id {outcome.command_id!r}'
+                ),
+            )
+
         if outcome.outcome_type == TradeOutcomeType.ACK:
             return self._handle_ack(outcome)
 

--- a/nexus/infrastructure/praxis_connector/outcome_processor.py
+++ b/nexus/infrastructure/praxis_connector/outcome_processor.py
@@ -153,7 +153,12 @@ class OutcomeProcessor:
         position_updated = False
 
         if context.is_exit:
-            position_updated = self._clear_pending_exit(context, context.order_size)
+            clear_size = (
+                outcome.remaining_size
+                if outcome.remaining_size is not None
+                else context.order_size
+            )
+            position_updated = self._clear_pending_exit(context, clear_size)
 
         return ProcessResult(
             success=True,
@@ -221,6 +226,9 @@ class OutcomeProcessor:
             return False
 
         fill_size = outcome.fill_size
+
+        if fill_size > position.size:
+            return False
 
         position.size = position.size - fill_size
         position.pending_exit = max(_ZERO, position.pending_exit - fill_size)

--- a/nexus/infrastructure/praxis_connector/process_result.py
+++ b/nexus/infrastructure/praxis_connector/process_result.py
@@ -1,0 +1,47 @@
+'''ProcessResult dataclass for outcome processing results.
+
+Captures the result of processing a TradeOutcome, including success
+status and any state changes that occurred.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+
+__all__ = ['ProcessResult']
+
+
+@dataclass(frozen=True)
+class ProcessResult:
+    '''Result of processing a TradeOutcome.
+
+    Args:
+        success: Whether processing completed successfully.
+        outcome_type: The type of outcome that was processed.
+        position_updated: Whether position was modified.
+        capital_updated: Whether capital state was modified.
+        error_reason: Reason for failure if success is False.
+    '''
+
+    success: bool
+    outcome_type: TradeOutcomeType
+    position_updated: bool = False
+    capital_updated: bool = False
+    error_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if not isinstance(self.outcome_type, TradeOutcomeType):
+            msg = 'ProcessResult.outcome_type must be a TradeOutcomeType member'
+            raise ValueError(msg)
+
+        if not self.success and self.error_reason is None:
+            msg = 'ProcessResult.error_reason required when success is False'
+            raise ValueError(msg)
+
+        if self.success and self.error_reason is not None:
+            msg = 'ProcessResult.error_reason must be None when success is True'
+            raise ValueError(msg)

--- a/nexus/infrastructure/praxis_connector/trade_outcome.py
+++ b/nexus/infrastructure/praxis_connector/trade_outcome.py
@@ -62,7 +62,10 @@ class TradeOutcome:
             msg = 'TradeOutcome.outcome_type must be a TradeOutcomeType member'
             raise ValueError(msg)
 
-        if self.timestamp.tzinfo is None or self.timestamp.tzinfo.utcoffset(self.timestamp) is None:
+        if (
+            self.timestamp.tzinfo is None
+            or self.timestamp.tzinfo.utcoffset(self.timestamp) is None
+        ):
             msg = 'TradeOutcome.timestamp must be timezone-aware'
             raise ValueError(msg)
 
@@ -76,7 +79,10 @@ class TradeOutcome:
             raise ValueError(msg)
 
         if self.remaining_size is not None:
-            if not isinstance(self.remaining_size, Decimal) or not self.remaining_size.is_finite():
+            if (
+                not isinstance(self.remaining_size, Decimal)
+                or not self.remaining_size.is_finite()
+            ):
                 msg = 'TradeOutcome.remaining_size must be a finite Decimal'
                 raise ValueError(msg)
 
@@ -115,7 +121,10 @@ class TradeOutcome:
             msg = 'TradeOutcome.fill_notional required for fill outcomes'
             raise ValueError(msg)
 
-        if not isinstance(self.fill_notional, Decimal) or not self.fill_notional.is_finite():
+        if (
+            not isinstance(self.fill_notional, Decimal)
+            or not self.fill_notional.is_finite()
+        ):
             msg = 'TradeOutcome.fill_notional must be a finite Decimal'
             raise ValueError(msg)
 
@@ -127,7 +136,10 @@ class TradeOutcome:
             msg = 'TradeOutcome.actual_fees required for fill outcomes'
             raise ValueError(msg)
 
-        if not isinstance(self.actual_fees, Decimal) or not self.actual_fees.is_finite():
+        if (
+            not isinstance(self.actual_fees, Decimal)
+            or not self.actual_fees.is_finite()
+        ):
             msg = 'TradeOutcome.actual_fees must be a finite Decimal'
             raise ValueError(msg)
 

--- a/nexus/infrastructure/praxis_connector/trade_outcome.py
+++ b/nexus/infrastructure/praxis_connector/trade_outcome.py
@@ -87,6 +87,17 @@ class TradeOutcome:
             msg = 'TradeOutcome.reject_reason must be None for non-REJECTED outcomes'
             raise ValueError(msg)
 
+        if self.outcome_type == TradeOutcomeType.CANCELED:
+            if self.cancel_reason is not None and not self.cancel_reason.strip():
+                msg = (
+                    'TradeOutcome.cancel_reason must be non-empty when provided '
+                    'for CANCELED outcome'
+                )
+                raise ValueError(msg)
+        elif self.cancel_reason is not None:
+            msg = 'TradeOutcome.cancel_reason must be None for non-CANCELED outcomes'
+            raise ValueError(msg)
+
         if self.remaining_size is not None:
             if (
                 not isinstance(self.remaining_size, Decimal)

--- a/nexus/infrastructure/praxis_connector/trade_outcome.py
+++ b/nexus/infrastructure/praxis_connector/trade_outcome.py
@@ -76,11 +76,15 @@ class TradeOutcome:
 
         if self.outcome_type.is_fill:
             self._validate_fill_fields()
+        else:
+            self._validate_non_fill_fields()
 
-        if self.outcome_type == TradeOutcomeType.REJECTED and (
-            self.reject_reason is None or not self.reject_reason.strip()
-        ):
-            msg = 'TradeOutcome.reject_reason required for REJECTED outcome'
+        if self.outcome_type == TradeOutcomeType.REJECTED:
+            if self.reject_reason is None or not self.reject_reason.strip():
+                msg = 'TradeOutcome.reject_reason required for REJECTED outcome'
+                raise ValueError(msg)
+        elif self.reject_reason is not None:
+            msg = 'TradeOutcome.reject_reason must be None for non-REJECTED outcomes'
             raise ValueError(msg)
 
         if self.remaining_size is not None:
@@ -150,4 +154,23 @@ class TradeOutcome:
 
         if self.actual_fees < _ZERO:
             msg = 'TradeOutcome.actual_fees must be non-negative'
+            raise ValueError(msg)
+
+    def _validate_non_fill_fields(self) -> None:
+        '''Validate that fill-specific fields are absent for non-fill outcomes.'''
+
+        if self.fill_size is not None:
+            msg = 'TradeOutcome.fill_size must be None for non-fill outcomes'
+            raise ValueError(msg)
+
+        if self.fill_price is not None:
+            msg = 'TradeOutcome.fill_price must be None for non-fill outcomes'
+            raise ValueError(msg)
+
+        if self.fill_notional is not None:
+            msg = 'TradeOutcome.fill_notional must be None for non-fill outcomes'
+            raise ValueError(msg)
+
+        if self.actual_fees is not None:
+            msg = 'TradeOutcome.actual_fees must be None for non-fill outcomes'
             raise ValueError(msg)

--- a/nexus/infrastructure/praxis_connector/trade_outcome.py
+++ b/nexus/infrastructure/praxis_connector/trade_outcome.py
@@ -62,6 +62,10 @@ class TradeOutcome:
             msg = 'TradeOutcome.outcome_type must be a TradeOutcomeType member'
             raise ValueError(msg)
 
+        if not isinstance(self.timestamp, datetime):
+            msg = 'TradeOutcome.timestamp must be a datetime instance'
+            raise ValueError(msg)
+
         if (
             self.timestamp.tzinfo is None
             or self.timestamp.tzinfo.utcoffset(self.timestamp) is None

--- a/nexus/infrastructure/praxis_connector/trade_outcome.py
+++ b/nexus/infrastructure/praxis_connector/trade_outcome.py
@@ -30,7 +30,8 @@ class TradeOutcome:
         fill_price: Execution price; required for PARTIAL/FILLED.
         fill_notional: Quote amount filled; required for PARTIAL/FILLED.
         actual_fees: Actual fees charged; required for PARTIAL/FILLED.
-        remaining_size: Size still working; None for terminal outcomes.
+        remaining_size: Size still working. Present on PARTIAL fills; may be
+            provided on CANCELED/EXPIRED to indicate unfilled remainder.
         reject_reason: Venue rejection reason; required for REJECTED.
         cancel_reason: Cancellation reason; optional for CANCELED.
     '''

--- a/nexus/infrastructure/praxis_connector/trade_outcome.py
+++ b/nexus/infrastructure/praxis_connector/trade_outcome.py
@@ -1,0 +1,136 @@
+'''TradeOutcome dataclass for Praxis Connector inbound processing.
+
+Represents execution results from Trading sub-system. Fill outcomes
+(PARTIAL, FILLED) carry fill details and actual fees for reconciliation.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+
+__all__ = ['TradeOutcome']
+
+_ZERO = Decimal(0)
+
+
+@dataclass(frozen=True)
+class TradeOutcome:
+    '''Immutable execution result from Trading sub-system.
+
+    Args:
+        outcome_id: Unique outcome reference.
+        command_id: Links to original TradeCommand.
+        outcome_type: ACK, PARTIAL, FILLED, REJECTED, EXPIRED, or CANCELED.
+        timestamp: When outcome occurred (must be timezone-aware).
+        fill_size: Base asset filled; required for PARTIAL/FILLED.
+        fill_price: Execution price; required for PARTIAL/FILLED.
+        fill_notional: Quote amount filled; required for PARTIAL/FILLED.
+        actual_fees: Actual fees charged; required for PARTIAL/FILLED.
+        remaining_size: Size still working; None for terminal outcomes.
+        reject_reason: Venue rejection reason; required for REJECTED.
+        cancel_reason: Cancellation reason; optional for CANCELED.
+    '''
+
+    outcome_id: str
+    command_id: str
+    outcome_type: TradeOutcomeType
+    timestamp: datetime
+    fill_size: Decimal | None = None
+    fill_price: Decimal | None = None
+    fill_notional: Decimal | None = None
+    actual_fees: Decimal | None = None
+    remaining_size: Decimal | None = None
+    reject_reason: str | None = None
+    cancel_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if not isinstance(self.outcome_id, str) or not self.outcome_id.strip():
+            msg = 'TradeOutcome.outcome_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.command_id, str) or not self.command_id.strip():
+            msg = 'TradeOutcome.command_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.outcome_type, TradeOutcomeType):
+            msg = 'TradeOutcome.outcome_type must be a TradeOutcomeType member'
+            raise ValueError(msg)
+
+        if self.timestamp.tzinfo is None or self.timestamp.tzinfo.utcoffset(self.timestamp) is None:
+            msg = 'TradeOutcome.timestamp must be timezone-aware'
+            raise ValueError(msg)
+
+        if self.outcome_type.is_fill:
+            self._validate_fill_fields()
+
+        if self.outcome_type == TradeOutcomeType.REJECTED and (
+            self.reject_reason is None or not self.reject_reason.strip()
+        ):
+            msg = 'TradeOutcome.reject_reason required for REJECTED outcome'
+            raise ValueError(msg)
+
+        if self.remaining_size is not None:
+            if not isinstance(self.remaining_size, Decimal) or not self.remaining_size.is_finite():
+                msg = 'TradeOutcome.remaining_size must be a finite Decimal'
+                raise ValueError(msg)
+
+            if self.remaining_size < _ZERO:
+                msg = 'TradeOutcome.remaining_size must be non-negative'
+                raise ValueError(msg)
+
+    def _validate_fill_fields(self) -> None:
+        '''Validate fill-specific fields for PARTIAL/FILLED outcomes.'''
+
+        if self.fill_size is None:
+            msg = 'TradeOutcome.fill_size required for fill outcomes'
+            raise ValueError(msg)
+
+        if not isinstance(self.fill_size, Decimal) or not self.fill_size.is_finite():
+            msg = 'TradeOutcome.fill_size must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.fill_size <= _ZERO:
+            msg = 'TradeOutcome.fill_size must be positive'
+            raise ValueError(msg)
+
+        if self.fill_price is None:
+            msg = 'TradeOutcome.fill_price required for fill outcomes'
+            raise ValueError(msg)
+
+        if not isinstance(self.fill_price, Decimal) or not self.fill_price.is_finite():
+            msg = 'TradeOutcome.fill_price must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.fill_price <= _ZERO:
+            msg = 'TradeOutcome.fill_price must be positive'
+            raise ValueError(msg)
+
+        if self.fill_notional is None:
+            msg = 'TradeOutcome.fill_notional required for fill outcomes'
+            raise ValueError(msg)
+
+        if not isinstance(self.fill_notional, Decimal) or not self.fill_notional.is_finite():
+            msg = 'TradeOutcome.fill_notional must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.fill_notional <= _ZERO:
+            msg = 'TradeOutcome.fill_notional must be positive'
+            raise ValueError(msg)
+
+        if self.actual_fees is None:
+            msg = 'TradeOutcome.actual_fees required for fill outcomes'
+            raise ValueError(msg)
+
+        if not isinstance(self.actual_fees, Decimal) or not self.actual_fees.is_finite():
+            msg = 'TradeOutcome.actual_fees must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.actual_fees < _ZERO:
+            msg = 'TradeOutcome.actual_fees must be non-negative'
+            raise ValueError(msg)

--- a/nexus/infrastructure/praxis_connector/trade_outcome_type.py
+++ b/nexus/infrastructure/praxis_connector/trade_outcome_type.py
@@ -1,0 +1,48 @@
+'''Trade outcome type enum for Praxis Connector inbound processing.
+
+Classifies execution results from Trading sub-system. Terminal outcomes
+(FILLED, REJECTED, EXPIRED, CANCELED) end the order lifecycle.
+Non-terminal outcomes (ACK, PARTIAL) indicate ongoing order state.
+'''
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = ['TradeOutcomeType']
+
+
+class TradeOutcomeType(Enum):
+    '''Outcome type for Trading sub-system execution results.
+
+    ACK indicates order accepted and working on venue.
+    PARTIAL indicates partial fill with order still working.
+    FILLED indicates full fill and order complete.
+    REJECTED indicates venue rejected the order.
+    EXPIRED indicates order expired (TTL or session).
+    CANCELED indicates order canceled (by request or venue).
+    '''
+
+    ACK = 'ACK'
+    PARTIAL = 'PARTIAL'
+    FILLED = 'FILLED'
+    REJECTED = 'REJECTED'
+    EXPIRED = 'EXPIRED'
+    CANCELED = 'CANCELED'
+
+    @property
+    def is_terminal(self) -> bool:
+        '''Return True if this outcome ends the order lifecycle.'''
+
+        return self in (
+            TradeOutcomeType.FILLED,
+            TradeOutcomeType.REJECTED,
+            TradeOutcomeType.EXPIRED,
+            TradeOutcomeType.CANCELED,
+        )
+
+    @property
+    def is_fill(self) -> bool:
+        '''Return True if this outcome represents a fill (partial or full).'''
+
+        return self in (TradeOutcomeType.PARTIAL, TradeOutcomeType.FILLED)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.15.0"
+version = "0.16.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -630,6 +630,23 @@ class TestOrderFill:
         with pytest.raises(ValueError, match='non-negative'):
             ctrl.order_fill('ORD-001', Decimal('100'), Decimal('-1'))
 
+    def test_order_fill_fee_reserve_insufficiency_rejected(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        pre_working = ctrl._state.working_order_notional
+        pre_position = ctrl._state.position_notional
+        pre_reserve = ctrl._state.fee_reserve
+
+        filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('10'))
+        assert filled is False
+        assert ctrl._state.working_order_notional == pre_working
+        assert ctrl._state.position_notional == pre_position
+        assert ctrl._state.fee_reserve == pre_reserve
+
 
 class TestOrderCancel:
     def test_order_cancel_success(self) -> None:

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -737,9 +737,15 @@ class TestNonTerminatingFeeRatio:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        ctrl.order_fill('ORD-001', Decimal('1'), Decimal('0.333333333333333333333333333'))
-        ctrl.order_fill('ORD-001', Decimal('1'), Decimal('0.333333333333333333333333333'))
-        ctrl.order_fill('ORD-001', Decimal('1'), Decimal('0.333333333333333333333333334'))
+        ctrl.order_fill(
+            'ORD-001', Decimal('1'), Decimal('0.333333333333333333333333333')
+        )
+        ctrl.order_fill(
+            'ORD-001', Decimal('1'), Decimal('0.333333333333333333333333333')
+        )
+        ctrl.order_fill(
+            'ORD-001', Decimal('1'), Decimal('0.333333333333333333333333334')
+        )
 
         assert ctrl._state.working_order_notional == _ZERO
         assert ctrl._state.position_notional == Decimal('4')
@@ -752,7 +758,9 @@ class TestNonTerminatingFeeRatio:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        ctrl.order_fill('ORD-001', Decimal('1'), Decimal('0.333333333333333333333333333'))
+        ctrl.order_fill(
+            'ORD-001', Decimal('1'), Decimal('0.333333333333333333333333333')
+        )
         ctrl.order_cancel('ORD-001')
 
         assert ctrl._state.working_order_notional == _ZERO
@@ -780,7 +788,9 @@ class TestLifecycleConcurrency:
                     sent = ctrl.send_order(res.reservation.reservation_id, f'ORD-{idx}')
                     if sent:
                         acked = ctrl.order_ack(f'ORD-{idx}')
-                        filled = ctrl.order_fill(f'ORD-{idx}', Decimal('500'), Decimal('5'))
+                        filled = ctrl.order_fill(
+                            f'ORD-{idx}', Decimal('500'), Decimal('5')
+                        )
                         if not acked or not filled:
                             msg = (
                                 f'Lifecycle failure ORD-{idx}: '

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -647,6 +647,35 @@ class TestOrderFill:
         assert ctrl._state.position_notional == pre_position
         assert ctrl._state.fee_reserve == pre_reserve
 
+    def test_order_fill_adjusts_per_strategy_deployed_on_fee_surplus(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='10')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        pre_deployed = ctrl._state.per_strategy_deployed.get('strat_a', Decimal(0))
+
+        ctrl.order_fill('ORD-001', Decimal('100'), Decimal('5'))
+
+        post_deployed = ctrl._state.per_strategy_deployed.get('strat_a', Decimal(0))
+        assert post_deployed == pre_deployed - Decimal('5')
+
+    def test_order_fill_adjusts_per_strategy_deployed_on_fee_deficit(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='5')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        ctrl._state.fee_reserve = Decimal('10')
+        pre_deployed = ctrl._state.per_strategy_deployed.get('strat_a', Decimal(0))
+
+        ctrl.order_fill('ORD-001', Decimal('100'), Decimal('8'))
+
+        post_deployed = ctrl._state.per_strategy_deployed.get('strat_a', Decimal(0))
+        assert post_deployed == pre_deployed + Decimal('3')
+
 
 class TestOrderCancel:
     def test_order_cancel_success(self) -> None:

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -564,7 +564,7 @@ class TestOrderFill:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        filled = ctrl.order_fill('ORD-001', Decimal('100'))
+        filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('1'))
         assert filled is True
         assert ctrl._state.working_order_notional == _ZERO
         assert ctrl._state.position_notional == Decimal('101')
@@ -577,7 +577,7 @@ class TestOrderFill:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        filled = ctrl.order_fill('ORD-001', Decimal('400'))
+        filled = ctrl.order_fill('ORD-001', Decimal('400'), Decimal('4'))
         assert filled is True
         assert ctrl._state.working_order_notional == Decimal('606')
         assert ctrl._state.position_notional == Decimal('404')
@@ -591,14 +591,14 @@ class TestOrderFill:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        filled = ctrl.order_fill('ORD-001', Decimal('200'))
+        filled = ctrl.order_fill('ORD-001', Decimal('200'), Decimal('2'))
         assert filled is False
         assert ctrl._state.working_order_notional == Decimal('101')
         assert ctrl._state.position_notional == _ZERO
 
     def test_order_fill_not_found(self) -> None:
         ctrl = _make_controller()
-        filled = ctrl.order_fill('nonexistent', Decimal('100'))
+        filled = ctrl.order_fill('nonexistent', Decimal('100'), Decimal('1'))
         assert filled is False
 
     def test_order_fill_wrong_state(self) -> None:
@@ -607,7 +607,7 @@ class TestOrderFill:
         assert result.reservation is not None
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
 
-        filled = ctrl.order_fill('ORD-001', Decimal('100'))
+        filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('1'))
         assert filled is False
 
     def test_order_fill_invalid_notional(self) -> None:
@@ -618,7 +618,17 @@ class TestOrderFill:
         ctrl.order_ack('ORD-001')
 
         with pytest.raises(ValueError, match='positive'):
-            ctrl.order_fill('ORD-001', Decimal('0'))
+            ctrl.order_fill('ORD-001', Decimal('0'), Decimal('0'))
+
+    def test_order_fill_invalid_actual_fees(self) -> None:
+        ctrl = _make_controller()
+        result = _reserve(ctrl, notional='100', fees='1')
+        assert result.reservation is not None
+        ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
+        ctrl.order_ack('ORD-001')
+
+        with pytest.raises(ValueError, match='non-negative'):
+            ctrl.order_fill('ORD-001', Decimal('100'), Decimal('-1'))
 
 
 class TestOrderCancel:
@@ -642,7 +652,7 @@ class TestOrderCancel:
         assert result.reservation is not None
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
-        ctrl.order_fill('ORD-001', Decimal('400'))
+        ctrl.order_fill('ORD-001', Decimal('400'), Decimal('4'))
 
         canceled = ctrl.order_cancel('ORD-001')
         assert canceled is True
@@ -681,7 +691,7 @@ class TestLifecycleHappyPath:
         assert ctrl._state.in_flight_order_notional == _ZERO
         assert ctrl._state.working_order_notional == Decimal('505')
 
-        ctrl.order_fill('ORD-001', Decimal('500'))
+        ctrl.order_fill('ORD-001', Decimal('500'), Decimal('5'))
         assert ctrl._state.working_order_notional == _ZERO
         assert ctrl._state.position_notional == Decimal('505')
         assert ctrl._state.per_strategy_deployed['strat_a'] == Decimal('505')
@@ -727,9 +737,9 @@ class TestNonTerminatingFeeRatio:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        ctrl.order_fill('ORD-001', Decimal('1'))
-        ctrl.order_fill('ORD-001', Decimal('1'))
-        ctrl.order_fill('ORD-001', Decimal('1'))
+        ctrl.order_fill('ORD-001', Decimal('1'), Decimal('0.333333333333333333333333333'))
+        ctrl.order_fill('ORD-001', Decimal('1'), Decimal('0.333333333333333333333333333'))
+        ctrl.order_fill('ORD-001', Decimal('1'), Decimal('0.333333333333333333333333334'))
 
         assert ctrl._state.working_order_notional == _ZERO
         assert ctrl._state.position_notional == Decimal('4')
@@ -742,7 +752,7 @@ class TestNonTerminatingFeeRatio:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
         ctrl.order_ack('ORD-001')
 
-        ctrl.order_fill('ORD-001', Decimal('1'))
+        ctrl.order_fill('ORD-001', Decimal('1'), Decimal('0.333333333333333333333333333'))
         ctrl.order_cancel('ORD-001')
 
         assert ctrl._state.working_order_notional == _ZERO
@@ -770,7 +780,7 @@ class TestLifecycleConcurrency:
                     sent = ctrl.send_order(res.reservation.reservation_id, f'ORD-{idx}')
                     if sent:
                         acked = ctrl.order_ack(f'ORD-{idx}')
-                        filled = ctrl.order_fill(f'ORD-{idx}', Decimal('500'))
+                        filled = ctrl.order_fill(f'ORD-{idx}', Decimal('500'), Decimal('5'))
                         if not acked or not filled:
                             msg = (
                                 f'Lifecycle failure ORD-{idx}: '
@@ -852,7 +862,7 @@ class TestPerStrategyDeployedInvariants:
 
         ctrl.send_order(res_a.reservation.reservation_id, 'ORD-A')
         ctrl.order_ack('ORD-A')
-        ctrl.order_fill('ORD-A', Decimal('150'))
+        ctrl.order_fill('ORD-A', Decimal('150'), Decimal('1.5'))
         ctrl.order_cancel('ORD-A')
 
         ctrl.send_order(res_b.reservation.reservation_id, 'ORD-B')

--- a/tests/test_order_context.py
+++ b/tests/test_order_context.py
@@ -31,7 +31,6 @@ def _exit_context() -> OrderContext:
 
 
 class TestOrderContextConstruction:
-
     def test_entry_context_valid(self) -> None:
         ctx = _entry_context()
         assert ctx.command_id == 'cmd_001'
@@ -55,7 +54,6 @@ class TestOrderContextConstruction:
 
 
 class TestOrderContextIsEntryExit:
-
     def test_is_entry_for_buy(self) -> None:
         ctx = _entry_context()
         assert ctx.is_entry is True
@@ -68,7 +66,6 @@ class TestOrderContextIsEntryExit:
 
 
 class TestOrderContextIdValidation:
-
     def test_empty_command_id_rejected(self) -> None:
         with pytest.raises(ValueError, match='command_id must be a non-empty string'):
             OrderContext(
@@ -106,7 +103,9 @@ class TestOrderContextIdValidation:
             )
 
     def test_empty_trade_id_rejected(self) -> None:
-        with pytest.raises(ValueError, match='trade_id must be a non-empty string if provided'):
+        with pytest.raises(
+            ValueError, match='trade_id must be a non-empty string if provided'
+        ):
             OrderContext(
                 command_id='cmd_001',
                 strategy_id='strat_001',
@@ -118,7 +117,9 @@ class TestOrderContextIdValidation:
             )
 
     def test_whitespace_trade_id_rejected(self) -> None:
-        with pytest.raises(ValueError, match='trade_id must be a non-empty string if provided'):
+        with pytest.raises(
+            ValueError, match='trade_id must be a non-empty string if provided'
+        ):
             OrderContext(
                 command_id='cmd_001',
                 strategy_id='strat_001',
@@ -131,7 +132,6 @@ class TestOrderContextIdValidation:
 
 
 class TestOrderContextNumericValidation:
-
     def test_order_size_zero_rejected(self) -> None:
         with pytest.raises(ValueError, match='order_size must be positive'):
             OrderContext(

--- a/tests/test_order_context.py
+++ b/tests/test_order_context.py
@@ -1,0 +1,229 @@
+from decimal import Decimal
+
+import pytest
+
+from nexus.core.domain.enums import OrderSide
+from nexus.infrastructure.praxis_connector.order_context import OrderContext
+
+
+def _entry_context() -> OrderContext:
+    return OrderContext(
+        command_id='cmd_001',
+        strategy_id='strat_001',
+        trade_id=None,
+        side=OrderSide.BUY,
+        order_size=Decimal('0.01'),
+        order_notional=Decimal('500'),
+        estimated_fees=Decimal('0.5'),
+    )
+
+
+def _exit_context() -> OrderContext:
+    return OrderContext(
+        command_id='cmd_002',
+        strategy_id='strat_001',
+        trade_id='trade_001',
+        side=OrderSide.SELL,
+        order_size=Decimal('0.01'),
+        order_notional=Decimal('510'),
+        estimated_fees=Decimal('0.51'),
+    )
+
+
+class TestOrderContextConstruction:
+
+    def test_entry_context_valid(self) -> None:
+        ctx = _entry_context()
+        assert ctx.command_id == 'cmd_001'
+        assert ctx.strategy_id == 'strat_001'
+        assert ctx.trade_id is None
+        assert ctx.side == OrderSide.BUY
+        assert ctx.order_size == Decimal('0.01')
+        assert ctx.order_notional == Decimal('500')
+        assert ctx.estimated_fees == Decimal('0.5')
+
+    def test_exit_context_valid(self) -> None:
+        ctx = _exit_context()
+        assert ctx.command_id == 'cmd_002'
+        assert ctx.trade_id == 'trade_001'
+        assert ctx.side == OrderSide.SELL
+
+    def test_frozen(self) -> None:
+        ctx = _entry_context()
+        with pytest.raises(AttributeError):
+            ctx.command_id = 'changed'  # type: ignore[misc]
+
+
+class TestOrderContextIsEntryExit:
+
+    def test_is_entry_for_buy(self) -> None:
+        ctx = _entry_context()
+        assert ctx.is_entry is True
+        assert ctx.is_exit is False
+
+    def test_is_exit_for_sell(self) -> None:
+        ctx = _exit_context()
+        assert ctx.is_entry is False
+        assert ctx.is_exit is True
+
+
+class TestOrderContextIdValidation:
+
+    def test_empty_command_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='command_id must be a non-empty string'):
+            OrderContext(
+                command_id='',
+                strategy_id='strat_001',
+                trade_id=None,
+                side=OrderSide.BUY,
+                order_size=Decimal('0.01'),
+                order_notional=Decimal('500'),
+                estimated_fees=Decimal('0.5'),
+            )
+
+    def test_whitespace_command_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='command_id must be a non-empty string'):
+            OrderContext(
+                command_id='   ',
+                strategy_id='strat_001',
+                trade_id=None,
+                side=OrderSide.BUY,
+                order_size=Decimal('0.01'),
+                order_notional=Decimal('500'),
+                estimated_fees=Decimal('0.5'),
+            )
+
+    def test_empty_strategy_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='strategy_id must be a non-empty string'):
+            OrderContext(
+                command_id='cmd_001',
+                strategy_id='',
+                trade_id=None,
+                side=OrderSide.BUY,
+                order_size=Decimal('0.01'),
+                order_notional=Decimal('500'),
+                estimated_fees=Decimal('0.5'),
+            )
+
+    def test_empty_trade_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='trade_id must be a non-empty string if provided'):
+            OrderContext(
+                command_id='cmd_001',
+                strategy_id='strat_001',
+                trade_id='',
+                side=OrderSide.BUY,
+                order_size=Decimal('0.01'),
+                order_notional=Decimal('500'),
+                estimated_fees=Decimal('0.5'),
+            )
+
+    def test_whitespace_trade_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='trade_id must be a non-empty string if provided'):
+            OrderContext(
+                command_id='cmd_001',
+                strategy_id='strat_001',
+                trade_id='   ',
+                side=OrderSide.BUY,
+                order_size=Decimal('0.01'),
+                order_notional=Decimal('500'),
+                estimated_fees=Decimal('0.5'),
+            )
+
+
+class TestOrderContextNumericValidation:
+
+    def test_order_size_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match='order_size must be positive'):
+            OrderContext(
+                command_id='cmd_001',
+                strategy_id='strat_001',
+                trade_id=None,
+                side=OrderSide.BUY,
+                order_size=Decimal('0'),
+                order_notional=Decimal('500'),
+                estimated_fees=Decimal('0.5'),
+            )
+
+    def test_order_size_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match='order_size must be positive'):
+            OrderContext(
+                command_id='cmd_001',
+                strategy_id='strat_001',
+                trade_id=None,
+                side=OrderSide.BUY,
+                order_size=Decimal('-0.01'),
+                order_notional=Decimal('500'),
+                estimated_fees=Decimal('0.5'),
+            )
+
+    def test_order_size_nan_rejected(self) -> None:
+        with pytest.raises(ValueError, match='order_size must be a finite Decimal'):
+            OrderContext(
+                command_id='cmd_001',
+                strategy_id='strat_001',
+                trade_id=None,
+                side=OrderSide.BUY,
+                order_size=Decimal('NaN'),
+                order_notional=Decimal('500'),
+                estimated_fees=Decimal('0.5'),
+            )
+
+    def test_order_notional_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match='order_notional must be positive'):
+            OrderContext(
+                command_id='cmd_001',
+                strategy_id='strat_001',
+                trade_id=None,
+                side=OrderSide.BUY,
+                order_size=Decimal('0.01'),
+                order_notional=Decimal('0'),
+                estimated_fees=Decimal('0.5'),
+            )
+
+    def test_order_notional_nan_rejected(self) -> None:
+        with pytest.raises(ValueError, match='order_notional must be a finite Decimal'):
+            OrderContext(
+                command_id='cmd_001',
+                strategy_id='strat_001',
+                trade_id=None,
+                side=OrderSide.BUY,
+                order_size=Decimal('0.01'),
+                order_notional=Decimal('NaN'),
+                estimated_fees=Decimal('0.5'),
+            )
+
+    def test_estimated_fees_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match='estimated_fees must be non-negative'):
+            OrderContext(
+                command_id='cmd_001',
+                strategy_id='strat_001',
+                trade_id=None,
+                side=OrderSide.BUY,
+                order_size=Decimal('0.01'),
+                order_notional=Decimal('500'),
+                estimated_fees=Decimal('-0.5'),
+            )
+
+    def test_estimated_fees_nan_rejected(self) -> None:
+        with pytest.raises(ValueError, match='estimated_fees must be a finite Decimal'):
+            OrderContext(
+                command_id='cmd_001',
+                strategy_id='strat_001',
+                trade_id=None,
+                side=OrderSide.BUY,
+                order_size=Decimal('0.01'),
+                order_notional=Decimal('500'),
+                estimated_fees=Decimal('NaN'),
+            )
+
+    def test_estimated_fees_zero_valid(self) -> None:
+        ctx = OrderContext(
+            command_id='cmd_001',
+            strategy_id='strat_001',
+            trade_id=None,
+            side=OrderSide.BUY,
+            order_size=Decimal('0.01'),
+            order_notional=Decimal('500'),
+            estimated_fees=Decimal('0'),
+        )
+        assert ctx.estimated_fees == Decimal('0')

--- a/tests/test_outcome_processor.py
+++ b/tests/test_outcome_processor.py
@@ -432,3 +432,72 @@ class TestPositionReduction:
 
         proc.process(outcome, _exit_context())
         assert 'trade_001' not in state.positions
+
+    def test_exit_fill_overfill_rejected(self) -> None:
+        proc, ctrl, state = _make_processor()
+        _setup_working_order(ctrl)
+
+        state.positions['trade_001'] = Position(
+            trade_id='trade_001',
+            strategy_id='strat_001',
+            symbol='BTCUSD',
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            entry_price=Decimal('50000'),
+            pending_exit=Decimal('0.01'),
+        )
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.FILLED,
+            timestamp=_now(),
+            fill_size=Decimal('0.02'),
+            fill_price=Decimal('51000'),
+            fill_notional=Decimal('100'),
+            actual_fees=Decimal('1'),
+        )
+
+        result = proc.process(outcome, _exit_context())
+        assert result.success is True
+        assert result.position_updated is False
+        assert state.positions['trade_001'].size == Decimal('0.01')
+
+
+class TestCancelUsesRemainingSize:
+    def test_cancel_after_partial_fill_uses_remaining_size(self) -> None:
+        proc, ctrl, state = _make_processor()
+        _setup_working_order(ctrl)
+
+        state.positions['trade_001'] = Position(
+            trade_id='trade_001',
+            strategy_id='strat_001',
+            symbol='BTCUSD',
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            entry_price=Decimal('50000'),
+            pending_exit=Decimal('0.01'),
+        )
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.CANCELED,
+            timestamp=_now(),
+            remaining_size=Decimal('0.005'),
+        )
+
+        ctx = OrderContext(
+            command_id='cmd_001',
+            strategy_id='strat_001',
+            trade_id='trade_001',
+            side=OrderSide.SELL,
+            order_size=Decimal('0.01'),
+            order_notional=Decimal('100'),
+            estimated_fees=Decimal('1'),
+        )
+
+        result = proc.process(outcome, ctx)
+        assert result.success is True
+        assert result.position_updated is True
+        assert state.positions['trade_001'].pending_exit == Decimal('0.005')

--- a/tests/test_outcome_processor.py
+++ b/tests/test_outcome_processor.py
@@ -95,7 +95,17 @@ class TestOutcomeProcessorAck:
             timestamp=_now(),
         )
 
-        result = proc.process(outcome, _entry_context())
+        ctx = OrderContext(
+            command_id='nonexistent',
+            strategy_id='strat_001',
+            trade_id=None,
+            side=OrderSide.BUY,
+            order_size=Decimal('0.01'),
+            order_notional=Decimal('100'),
+            estimated_fees=Decimal('1'),
+        )
+
+        result = proc.process(outcome, ctx)
         assert result.success is False
         assert result.error_reason is not None
         assert 'order_ack failed' in result.error_reason
@@ -184,7 +194,17 @@ class TestOutcomeProcessorFill:
             actual_fees=Decimal('1'),
         )
 
-        result = proc.process(outcome, _entry_context())
+        ctx = OrderContext(
+            command_id='nonexistent',
+            strategy_id='strat_001',
+            trade_id='trade_001',
+            side=OrderSide.BUY,
+            order_size=Decimal('0.01'),
+            order_notional=Decimal('100'),
+            estimated_fees=Decimal('1'),
+        )
+
+        result = proc.process(outcome, ctx)
         assert result.success is False
         assert result.error_reason is not None
         assert 'order_fill failed' in result.error_reason
@@ -462,6 +482,38 @@ class TestPositionReduction:
         assert result.success is True
         assert result.position_updated is False
         assert state.positions['trade_001'].size == Decimal('0.01')
+
+
+class TestCommandIdMismatch:
+    def test_command_id_mismatch_rejected(self) -> None:
+        proc, ctrl, _ = _make_processor()
+        _setup_working_order(ctrl)
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.FILLED,
+            timestamp=_now(),
+            fill_size=Decimal('0.01'),
+            fill_price=Decimal('50000'),
+            fill_notional=Decimal('100'),
+            actual_fees=Decimal('1'),
+        )
+
+        mismatched_ctx = OrderContext(
+            command_id='cmd_999',
+            strategy_id='strat_001',
+            trade_id='trade_001',
+            side=OrderSide.BUY,
+            order_size=Decimal('0.01'),
+            order_notional=Decimal('100'),
+            estimated_fees=Decimal('1'),
+        )
+
+        result = proc.process(outcome, mismatched_ctx)
+        assert result.success is False
+        assert result.error_reason is not None
+        assert 'does not match' in result.error_reason
 
 
 class TestCancelUsesRemainingSize:

--- a/tests/test_outcome_processor.py
+++ b/tests/test_outcome_processor.py
@@ -1,0 +1,434 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from nexus.core.capital_controller.capital_controller import CapitalController
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OrderSide
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.position import Position
+from nexus.infrastructure.praxis_connector.order_context import OrderContext
+from nexus.infrastructure.praxis_connector.outcome_processor import OutcomeProcessor
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+
+_POOL = Decimal('10000')
+_ZERO = Decimal(0)
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _make_processor() -> tuple[OutcomeProcessor, CapitalController, InstanceState]:
+    capital_state = CapitalState(capital_pool=_POOL)
+    instance_state = InstanceState(capital=capital_state)
+    controller = CapitalController(capital_state)
+    processor = OutcomeProcessor(controller, instance_state)
+    return processor, controller, instance_state
+
+
+def _setup_in_flight_order(ctrl: CapitalController, order_id: str = 'cmd_001') -> None:
+    result = ctrl.check_and_reserve(
+        strategy_id='strat_001',
+        order_notional=Decimal('100'),
+        estimated_fees=Decimal('1'),
+        strategy_budget=Decimal('5000'),
+    )
+    assert result.reservation is not None
+    ctrl.send_order(result.reservation.reservation_id, order_id)
+
+
+def _setup_working_order(ctrl: CapitalController, order_id: str = 'cmd_001') -> None:
+    _setup_in_flight_order(ctrl, order_id)
+    ctrl.order_ack(order_id)
+
+
+def _entry_context(trade_id: str = 'trade_001') -> OrderContext:
+    return OrderContext(
+        command_id='cmd_001',
+        strategy_id='strat_001',
+        trade_id=trade_id,
+        side=OrderSide.BUY,
+        order_size=Decimal('0.01'),
+        order_notional=Decimal('100'),
+        estimated_fees=Decimal('1'),
+    )
+
+
+def _exit_context(trade_id: str = 'trade_001') -> OrderContext:
+    return OrderContext(
+        command_id='cmd_001',
+        strategy_id='strat_001',
+        trade_id=trade_id,
+        side=OrderSide.SELL,
+        order_size=Decimal('0.01'),
+        order_notional=Decimal('100'),
+        estimated_fees=Decimal('1'),
+    )
+
+
+class TestOutcomeProcessorAck:
+    def test_ack_success(self) -> None:
+        proc, ctrl, _ = _make_processor()
+        _setup_in_flight_order(ctrl)
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.ACK,
+            timestamp=_now(),
+        )
+
+        result = proc.process(outcome, _entry_context())
+        assert result.success is True
+        assert result.outcome_type == TradeOutcomeType.ACK
+        assert result.capital_updated is True
+        assert result.position_updated is False
+
+    def test_ack_order_not_found(self) -> None:
+        proc, _, _ = _make_processor()
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='nonexistent',
+            outcome_type=TradeOutcomeType.ACK,
+            timestamp=_now(),
+        )
+
+        result = proc.process(outcome, _entry_context())
+        assert result.success is False
+        assert result.error_reason is not None
+        assert 'order_ack failed' in result.error_reason
+
+
+class TestOutcomeProcessorFill:
+    def test_fill_success(self) -> None:
+        proc, ctrl, state = _make_processor()
+        _setup_working_order(ctrl)
+
+        state.positions['trade_001'] = Position(
+            trade_id='trade_001',
+            strategy_id='strat_001',
+            symbol='BTCUSD',
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            entry_price=Decimal('50000'),
+        )
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.FILLED,
+            timestamp=_now(),
+            fill_size=Decimal('0.01'),
+            fill_price=Decimal('50000'),
+            fill_notional=Decimal('100'),
+            actual_fees=Decimal('1'),
+        )
+
+        result = proc.process(outcome, _entry_context())
+        assert result.success is True
+        assert result.outcome_type == TradeOutcomeType.FILLED
+        assert result.capital_updated is True
+        assert result.position_updated is True
+
+    def test_partial_fill_success(self) -> None:
+        proc, ctrl, state = _make_processor()
+
+        res = ctrl.check_and_reserve(
+            strategy_id='strat_001',
+            order_notional=Decimal('1000'),
+            estimated_fees=Decimal('10'),
+            strategy_budget=Decimal('5000'),
+        )
+        assert res.reservation is not None
+        ctrl.send_order(res.reservation.reservation_id, 'cmd_001')
+        ctrl.order_ack('cmd_001')
+
+        state.positions['trade_001'] = Position(
+            trade_id='trade_001',
+            strategy_id='strat_001',
+            symbol='BTCUSD',
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            entry_price=Decimal('50000'),
+        )
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.PARTIAL,
+            timestamp=_now(),
+            fill_size=Decimal('0.005'),
+            fill_price=Decimal('50000'),
+            fill_notional=Decimal('500'),
+            actual_fees=Decimal('5'),
+            remaining_size=Decimal('0.005'),
+        )
+
+        result = proc.process(outcome, _entry_context())
+        assert result.success is True
+        assert result.outcome_type == TradeOutcomeType.PARTIAL
+
+    def test_fill_order_not_found(self) -> None:
+        proc, _, _ = _make_processor()
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='nonexistent',
+            outcome_type=TradeOutcomeType.FILLED,
+            timestamp=_now(),
+            fill_size=Decimal('0.01'),
+            fill_price=Decimal('50000'),
+            fill_notional=Decimal('100'),
+            actual_fees=Decimal('1'),
+        )
+
+        result = proc.process(outcome, _entry_context())
+        assert result.success is False
+        assert result.error_reason is not None
+        assert 'order_fill failed' in result.error_reason
+
+
+class TestOutcomeProcessorReject:
+    def test_reject_entry_order(self) -> None:
+        proc, ctrl, _ = _make_processor()
+        _setup_in_flight_order(ctrl)
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.REJECTED,
+            timestamp=_now(),
+            reject_reason='Insufficient balance',
+        )
+
+        result = proc.process(outcome, _entry_context())
+        assert result.success is True
+        assert result.outcome_type == TradeOutcomeType.REJECTED
+        assert result.capital_updated is True
+        assert result.position_updated is False
+
+    def test_reject_exit_order_clears_pending_exit(self) -> None:
+        proc, ctrl, state = _make_processor()
+        _setup_in_flight_order(ctrl)
+
+        state.positions['trade_001'] = Position(
+            trade_id='trade_001',
+            strategy_id='strat_001',
+            symbol='BTCUSD',
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            entry_price=Decimal('50000'),
+            pending_exit=Decimal('0.01'),
+        )
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.REJECTED,
+            timestamp=_now(),
+            reject_reason='Insufficient balance',
+        )
+
+        result = proc.process(outcome, _exit_context())
+        assert result.success is True
+        assert result.position_updated is True
+        assert state.positions['trade_001'].pending_exit == _ZERO
+
+
+class TestOutcomeProcessorCancel:
+    def test_cancel_success(self) -> None:
+        proc, ctrl, _ = _make_processor()
+        _setup_working_order(ctrl)
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.CANCELED,
+            timestamp=_now(),
+        )
+
+        result = proc.process(outcome, _entry_context())
+        assert result.success is True
+        assert result.outcome_type == TradeOutcomeType.CANCELED
+        assert result.capital_updated is True
+
+    def test_expired_success(self) -> None:
+        proc, ctrl, _ = _make_processor()
+        _setup_working_order(ctrl)
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.EXPIRED,
+            timestamp=_now(),
+        )
+
+        result = proc.process(outcome, _entry_context())
+        assert result.success is True
+        assert result.outcome_type == TradeOutcomeType.EXPIRED
+
+    def test_cancel_exit_order_clears_pending_exit(self) -> None:
+        proc, ctrl, state = _make_processor()
+        _setup_working_order(ctrl)
+
+        state.positions['trade_001'] = Position(
+            trade_id='trade_001',
+            strategy_id='strat_001',
+            symbol='BTCUSD',
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            entry_price=Decimal('50000'),
+            pending_exit=Decimal('0.01'),
+        )
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.CANCELED,
+            timestamp=_now(),
+        )
+
+        result = proc.process(outcome, _exit_context())
+        assert result.success is True
+        assert result.position_updated is True
+        assert state.positions['trade_001'].pending_exit == _ZERO
+
+
+class TestPositionGrowth:
+    def test_entry_fill_grows_position(self) -> None:
+        proc, ctrl, state = _make_processor()
+        _setup_working_order(ctrl)
+
+        state.positions['trade_001'] = Position(
+            trade_id='trade_001',
+            strategy_id='strat_001',
+            symbol='BTCUSD',
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            entry_price=Decimal('50000'),
+        )
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.FILLED,
+            timestamp=_now(),
+            fill_size=Decimal('0.01'),
+            fill_price=Decimal('50000'),
+            fill_notional=Decimal('100'),
+            actual_fees=Decimal('1'),
+        )
+
+        proc.process(outcome, _entry_context())
+        assert state.positions['trade_001'].size == Decimal('0.02')
+
+    def test_entry_fill_calculates_vwap(self) -> None:
+        proc, ctrl, state = _make_processor()
+        _setup_working_order(ctrl)
+
+        state.positions['trade_001'] = Position(
+            trade_id='trade_001',
+            strategy_id='strat_001',
+            symbol='BTCUSD',
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            entry_price=Decimal('50000'),
+        )
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.FILLED,
+            timestamp=_now(),
+            fill_size=Decimal('0.02'),
+            fill_price=Decimal('60000'),
+            fill_notional=Decimal('100'),
+            actual_fees=Decimal('1'),
+        )
+
+        proc.process(outcome, _entry_context())
+
+        expected = (
+            Decimal('0.01') * Decimal('50000') + Decimal('0.02') * Decimal('60000')
+        ) / Decimal('0.03')
+        assert state.positions['trade_001'].entry_price == expected
+
+    def test_entry_fill_no_position_returns_false(self) -> None:
+        proc, ctrl, _ = _make_processor()
+        _setup_working_order(ctrl)
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.FILLED,
+            timestamp=_now(),
+            fill_size=Decimal('0.01'),
+            fill_price=Decimal('50000'),
+            fill_notional=Decimal('100'),
+            actual_fees=Decimal('1'),
+        )
+
+        result = proc.process(outcome, _entry_context())
+        assert result.success is True
+        assert result.position_updated is False
+
+
+class TestPositionReduction:
+    def test_exit_fill_reduces_position(self) -> None:
+        proc, ctrl, state = _make_processor()
+        _setup_working_order(ctrl)
+
+        state.positions['trade_001'] = Position(
+            trade_id='trade_001',
+            strategy_id='strat_001',
+            symbol='BTCUSD',
+            side=OrderSide.BUY,
+            size=Decimal('0.02'),
+            entry_price=Decimal('50000'),
+            pending_exit=Decimal('0.01'),
+        )
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.FILLED,
+            timestamp=_now(),
+            fill_size=Decimal('0.01'),
+            fill_price=Decimal('51000'),
+            fill_notional=Decimal('100'),
+            actual_fees=Decimal('1'),
+        )
+
+        proc.process(outcome, _exit_context())
+        assert state.positions['trade_001'].size == Decimal('0.01')
+        assert state.positions['trade_001'].pending_exit == _ZERO
+
+    def test_exit_fill_removes_closed_position(self) -> None:
+        proc, ctrl, state = _make_processor()
+        _setup_working_order(ctrl)
+
+        state.positions['trade_001'] = Position(
+            trade_id='trade_001',
+            strategy_id='strat_001',
+            symbol='BTCUSD',
+            side=OrderSide.BUY,
+            size=Decimal('0.01'),
+            entry_price=Decimal('50000'),
+            pending_exit=Decimal('0.01'),
+        )
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.FILLED,
+            timestamp=_now(),
+            fill_size=Decimal('0.01'),
+            fill_price=Decimal('51000'),
+            fill_notional=Decimal('100'),
+            actual_fees=Decimal('1'),
+        )
+
+        proc.process(outcome, _exit_context())
+        assert 'trade_001' not in state.positions

--- a/tests/test_process_result.py
+++ b/tests/test_process_result.py
@@ -5,7 +5,6 @@ from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcom
 
 
 class TestProcessResultConstruction:
-
     def test_success_result_valid(self) -> None:
         result = ProcessResult(
             success=True,
@@ -48,7 +47,6 @@ class TestProcessResultConstruction:
 
 
 class TestProcessResultValidation:
-
     def test_invalid_outcome_type_rejected(self) -> None:
         with pytest.raises(ValueError, match='outcome_type must be a TradeOutcomeType'):
             ProcessResult(
@@ -57,14 +55,18 @@ class TestProcessResultValidation:
             )
 
     def test_failure_without_error_reason_rejected(self) -> None:
-        with pytest.raises(ValueError, match='error_reason required when success is False'):
+        with pytest.raises(
+            ValueError, match='error_reason required when success is False'
+        ):
             ProcessResult(
                 success=False,
                 outcome_type=TradeOutcomeType.REJECTED,
             )
 
     def test_success_with_error_reason_rejected(self) -> None:
-        with pytest.raises(ValueError, match='error_reason must be None when success is True'):
+        with pytest.raises(
+            ValueError, match='error_reason must be None when success is True'
+        ):
             ProcessResult(
                 success=True,
                 outcome_type=TradeOutcomeType.ACK,
@@ -73,7 +75,6 @@ class TestProcessResultValidation:
 
 
 class TestProcessResultDefaults:
-
     def test_defaults_for_minimal_success(self) -> None:
         result = ProcessResult(
             success=True,

--- a/tests/test_process_result.py
+++ b/tests/test_process_result.py
@@ -1,0 +1,93 @@
+import pytest
+
+from nexus.infrastructure.praxis_connector.process_result import ProcessResult
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+
+
+class TestProcessResultConstruction:
+
+    def test_success_result_valid(self) -> None:
+        result = ProcessResult(
+            success=True,
+            outcome_type=TradeOutcomeType.FILLED,
+            position_updated=True,
+            capital_updated=True,
+        )
+        assert result.success is True
+        assert result.outcome_type == TradeOutcomeType.FILLED
+        assert result.position_updated is True
+        assert result.capital_updated is True
+        assert result.error_reason is None
+
+    def test_failure_result_valid(self) -> None:
+        result = ProcessResult(
+            success=False,
+            outcome_type=TradeOutcomeType.FILLED,
+            error_reason='Insufficient fee_reserve',
+        )
+        assert result.success is False
+        assert result.error_reason == 'Insufficient fee_reserve'
+
+    def test_ack_result_valid(self) -> None:
+        result = ProcessResult(
+            success=True,
+            outcome_type=TradeOutcomeType.ACK,
+            capital_updated=True,
+        )
+        assert result.outcome_type == TradeOutcomeType.ACK
+        assert result.capital_updated is True
+        assert result.position_updated is False
+
+    def test_frozen(self) -> None:
+        result = ProcessResult(
+            success=True,
+            outcome_type=TradeOutcomeType.ACK,
+        )
+        with pytest.raises(AttributeError):
+            result.success = False  # type: ignore[misc]
+
+
+class TestProcessResultValidation:
+
+    def test_invalid_outcome_type_rejected(self) -> None:
+        with pytest.raises(ValueError, match='outcome_type must be a TradeOutcomeType'):
+            ProcessResult(
+                success=True,
+                outcome_type='FILLED',  # type: ignore[arg-type]
+            )
+
+    def test_failure_without_error_reason_rejected(self) -> None:
+        with pytest.raises(ValueError, match='error_reason required when success is False'):
+            ProcessResult(
+                success=False,
+                outcome_type=TradeOutcomeType.REJECTED,
+            )
+
+    def test_success_with_error_reason_rejected(self) -> None:
+        with pytest.raises(ValueError, match='error_reason must be None when success is True'):
+            ProcessResult(
+                success=True,
+                outcome_type=TradeOutcomeType.ACK,
+                error_reason='Should not be here',
+            )
+
+
+class TestProcessResultDefaults:
+
+    def test_defaults_for_minimal_success(self) -> None:
+        result = ProcessResult(
+            success=True,
+            outcome_type=TradeOutcomeType.ACK,
+        )
+        assert result.position_updated is False
+        assert result.capital_updated is False
+        assert result.error_reason is None
+
+    def test_defaults_for_minimal_failure(self) -> None:
+        result = ProcessResult(
+            success=False,
+            outcome_type=TradeOutcomeType.REJECTED,
+            error_reason='Order rejected',
+        )
+        assert result.position_updated is False
+        assert result.capital_updated is False

--- a/tests/test_trade_outcome.py
+++ b/tests/test_trade_outcome.py
@@ -21,7 +21,9 @@ def _ack_outcome() -> TradeOutcome:
     )
 
 
-def _fill_outcome(outcome_type: TradeOutcomeType = TradeOutcomeType.FILLED) -> TradeOutcome:
+def _fill_outcome(
+    outcome_type: TradeOutcomeType = TradeOutcomeType.FILLED,
+) -> TradeOutcome:
     return TradeOutcome(
         outcome_id='out_001',
         command_id='cmd_001',
@@ -35,7 +37,6 @@ def _fill_outcome(outcome_type: TradeOutcomeType = TradeOutcomeType.FILLED) -> T
 
 
 class TestTradeOutcomeConstruction:
-
     def test_ack_outcome_valid(self) -> None:
         outcome = _ack_outcome()
         assert outcome.outcome_type == TradeOutcomeType.ACK
@@ -111,7 +112,6 @@ class TestTradeOutcomeConstruction:
 
 
 class TestTradeOutcomeIdValidation:
-
     def test_empty_outcome_id_rejected(self) -> None:
         with pytest.raises(ValueError, match='outcome_id must be a non-empty string'):
             TradeOutcome(
@@ -150,7 +150,6 @@ class TestTradeOutcomeIdValidation:
 
 
 class TestTradeOutcomeTimestampValidation:
-
     def test_naive_timestamp_rejected(self) -> None:
         with pytest.raises(ValueError, match='timestamp must be timezone-aware'):
             TradeOutcome(
@@ -162,7 +161,6 @@ class TestTradeOutcomeTimestampValidation:
 
 
 class TestTradeOutcomeFillValidation:
-
     def test_filled_missing_fill_size_rejected(self) -> None:
         with pytest.raises(ValueError, match='fill_size required for fill outcomes'):
             TradeOutcome(
@@ -188,7 +186,9 @@ class TestTradeOutcomeFillValidation:
             )
 
     def test_filled_missing_fill_notional_rejected(self) -> None:
-        with pytest.raises(ValueError, match='fill_notional required for fill outcomes'):
+        with pytest.raises(
+            ValueError, match='fill_notional required for fill outcomes'
+        ):
             TradeOutcome(
                 outcome_id='out_001',
                 command_id='cmd_001',
@@ -313,7 +313,6 @@ class TestTradeOutcomeFillValidation:
 
 
 class TestTradeOutcomeRejectValidation:
-
     def test_rejected_missing_reason_rejected(self) -> None:
         with pytest.raises(ValueError, match='reject_reason required for REJECTED'):
             TradeOutcome(
@@ -345,7 +344,6 @@ class TestTradeOutcomeRejectValidation:
 
 
 class TestTradeOutcomeRemainingSizeValidation:
-
     def test_remaining_size_negative_rejected(self) -> None:
         with pytest.raises(ValueError, match='remaining_size must be non-negative'):
             TradeOutcome(

--- a/tests/test_trade_outcome.py
+++ b/tests/test_trade_outcome.py
@@ -1,0 +1,377 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _ack_outcome() -> TradeOutcome:
+    return TradeOutcome(
+        outcome_id='out_001',
+        command_id='cmd_001',
+        outcome_type=TradeOutcomeType.ACK,
+        timestamp=_now(),
+        remaining_size=Decimal('0.01'),
+    )
+
+
+def _fill_outcome(outcome_type: TradeOutcomeType = TradeOutcomeType.FILLED) -> TradeOutcome:
+    return TradeOutcome(
+        outcome_id='out_001',
+        command_id='cmd_001',
+        outcome_type=outcome_type,
+        timestamp=_now(),
+        fill_size=Decimal('0.01'),
+        fill_price=Decimal('50000'),
+        fill_notional=Decimal('500'),
+        actual_fees=Decimal('0.5'),
+    )
+
+
+class TestTradeOutcomeConstruction:
+
+    def test_ack_outcome_valid(self) -> None:
+        outcome = _ack_outcome()
+        assert outcome.outcome_type == TradeOutcomeType.ACK
+        assert outcome.remaining_size == Decimal('0.01')
+
+    def test_filled_outcome_valid(self) -> None:
+        outcome = _fill_outcome()
+        assert outcome.outcome_type == TradeOutcomeType.FILLED
+        assert outcome.fill_size == Decimal('0.01')
+        assert outcome.fill_price == Decimal('50000')
+        assert outcome.fill_notional == Decimal('500')
+        assert outcome.actual_fees == Decimal('0.5')
+
+    def test_partial_outcome_valid(self) -> None:
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.PARTIAL,
+            timestamp=_now(),
+            fill_size=Decimal('0.005'),
+            fill_price=Decimal('50000'),
+            fill_notional=Decimal('250'),
+            actual_fees=Decimal('0.25'),
+            remaining_size=Decimal('0.005'),
+        )
+        assert outcome.outcome_type == TradeOutcomeType.PARTIAL
+        assert outcome.remaining_size == Decimal('0.005')
+
+    def test_rejected_outcome_valid(self) -> None:
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.REJECTED,
+            timestamp=_now(),
+            reject_reason='Insufficient balance',
+        )
+        assert outcome.outcome_type == TradeOutcomeType.REJECTED
+        assert outcome.reject_reason == 'Insufficient balance'
+
+    def test_expired_outcome_valid(self) -> None:
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.EXPIRED,
+            timestamp=_now(),
+        )
+        assert outcome.outcome_type == TradeOutcomeType.EXPIRED
+
+    def test_canceled_outcome_valid(self) -> None:
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.CANCELED,
+            timestamp=_now(),
+            cancel_reason='User requested',
+        )
+        assert outcome.outcome_type == TradeOutcomeType.CANCELED
+        assert outcome.cancel_reason == 'User requested'
+
+    def test_canceled_outcome_without_reason_valid(self) -> None:
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.CANCELED,
+            timestamp=_now(),
+        )
+        assert outcome.cancel_reason is None
+
+    def test_frozen(self) -> None:
+        outcome = _ack_outcome()
+        with pytest.raises(AttributeError):
+            outcome.outcome_id = 'changed'  # type: ignore[misc]
+
+
+class TestTradeOutcomeIdValidation:
+
+    def test_empty_outcome_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='outcome_id must be a non-empty string'):
+            TradeOutcome(
+                outcome_id='',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.ACK,
+                timestamp=_now(),
+            )
+
+    def test_whitespace_outcome_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='outcome_id must be a non-empty string'):
+            TradeOutcome(
+                outcome_id='   ',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.ACK,
+                timestamp=_now(),
+            )
+
+    def test_empty_command_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='command_id must be a non-empty string'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='',
+                outcome_type=TradeOutcomeType.ACK,
+                timestamp=_now(),
+            )
+
+    def test_whitespace_command_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match='command_id must be a non-empty string'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='   ',
+                outcome_type=TradeOutcomeType.ACK,
+                timestamp=_now(),
+            )
+
+
+class TestTradeOutcomeTimestampValidation:
+
+    def test_naive_timestamp_rejected(self) -> None:
+        with pytest.raises(ValueError, match='timestamp must be timezone-aware'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.ACK,
+                timestamp=datetime.now(),
+            )
+
+
+class TestTradeOutcomeFillValidation:
+
+    def test_filled_missing_fill_size_rejected(self) -> None:
+        with pytest.raises(ValueError, match='fill_size required for fill outcomes'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.FILLED,
+                timestamp=_now(),
+                fill_price=Decimal('50000'),
+                fill_notional=Decimal('500'),
+                actual_fees=Decimal('0.5'),
+            )
+
+    def test_filled_missing_fill_price_rejected(self) -> None:
+        with pytest.raises(ValueError, match='fill_price required for fill outcomes'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.FILLED,
+                timestamp=_now(),
+                fill_size=Decimal('0.01'),
+                fill_notional=Decimal('500'),
+                actual_fees=Decimal('0.5'),
+            )
+
+    def test_filled_missing_fill_notional_rejected(self) -> None:
+        with pytest.raises(ValueError, match='fill_notional required for fill outcomes'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.FILLED,
+                timestamp=_now(),
+                fill_size=Decimal('0.01'),
+                fill_price=Decimal('50000'),
+                actual_fees=Decimal('0.5'),
+            )
+
+    def test_filled_missing_actual_fees_rejected(self) -> None:
+        with pytest.raises(ValueError, match='actual_fees required for fill outcomes'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.FILLED,
+                timestamp=_now(),
+                fill_size=Decimal('0.01'),
+                fill_price=Decimal('50000'),
+                fill_notional=Decimal('500'),
+            )
+
+    def test_partial_missing_fill_fields_rejected(self) -> None:
+        with pytest.raises(ValueError, match='fill_size required for fill outcomes'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.PARTIAL,
+                timestamp=_now(),
+            )
+
+    def test_fill_size_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match='fill_size must be positive'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.FILLED,
+                timestamp=_now(),
+                fill_size=Decimal('0'),
+                fill_price=Decimal('50000'),
+                fill_notional=Decimal('500'),
+                actual_fees=Decimal('0.5'),
+            )
+
+    def test_fill_size_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match='fill_size must be positive'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.FILLED,
+                timestamp=_now(),
+                fill_size=Decimal('-0.01'),
+                fill_price=Decimal('50000'),
+                fill_notional=Decimal('500'),
+                actual_fees=Decimal('0.5'),
+            )
+
+    def test_fill_size_nan_rejected(self) -> None:
+        with pytest.raises(ValueError, match='fill_size must be a finite Decimal'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.FILLED,
+                timestamp=_now(),
+                fill_size=Decimal('NaN'),
+                fill_price=Decimal('50000'),
+                fill_notional=Decimal('500'),
+                actual_fees=Decimal('0.5'),
+            )
+
+    def test_fill_price_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match='fill_price must be positive'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.FILLED,
+                timestamp=_now(),
+                fill_size=Decimal('0.01'),
+                fill_price=Decimal('0'),
+                fill_notional=Decimal('500'),
+                actual_fees=Decimal('0.5'),
+            )
+
+    def test_fill_notional_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match='fill_notional must be positive'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.FILLED,
+                timestamp=_now(),
+                fill_size=Decimal('0.01'),
+                fill_price=Decimal('50000'),
+                fill_notional=Decimal('0'),
+                actual_fees=Decimal('0.5'),
+            )
+
+    def test_actual_fees_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match='actual_fees must be non-negative'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.FILLED,
+                timestamp=_now(),
+                fill_size=Decimal('0.01'),
+                fill_price=Decimal('50000'),
+                fill_notional=Decimal('500'),
+                actual_fees=Decimal('-0.5'),
+            )
+
+    def test_actual_fees_zero_valid(self) -> None:
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.FILLED,
+            timestamp=_now(),
+            fill_size=Decimal('0.01'),
+            fill_price=Decimal('50000'),
+            fill_notional=Decimal('500'),
+            actual_fees=Decimal('0'),
+        )
+        assert outcome.actual_fees == Decimal('0')
+
+
+class TestTradeOutcomeRejectValidation:
+
+    def test_rejected_missing_reason_rejected(self) -> None:
+        with pytest.raises(ValueError, match='reject_reason required for REJECTED'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.REJECTED,
+                timestamp=_now(),
+            )
+
+    def test_rejected_empty_reason_rejected(self) -> None:
+        with pytest.raises(ValueError, match='reject_reason required for REJECTED'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.REJECTED,
+                timestamp=_now(),
+                reject_reason='',
+            )
+
+    def test_rejected_whitespace_reason_rejected(self) -> None:
+        with pytest.raises(ValueError, match='reject_reason required for REJECTED'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.REJECTED,
+                timestamp=_now(),
+                reject_reason='   ',
+            )
+
+
+class TestTradeOutcomeRemainingSizeValidation:
+
+    def test_remaining_size_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match='remaining_size must be non-negative'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.ACK,
+                timestamp=_now(),
+                remaining_size=Decimal('-0.01'),
+            )
+
+    def test_remaining_size_nan_rejected(self) -> None:
+        with pytest.raises(ValueError, match='remaining_size must be a finite Decimal'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.ACK,
+                timestamp=_now(),
+                remaining_size=Decimal('NaN'),
+            )
+
+    def test_remaining_size_zero_valid(self) -> None:
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.ACK,
+            timestamp=_now(),
+            remaining_size=Decimal('0'),
+        )
+        assert outcome.remaining_size == Decimal('0')

--- a/tests/test_trade_outcome.py
+++ b/tests/test_trade_outcome.py
@@ -150,6 +150,15 @@ class TestTradeOutcomeIdValidation:
 
 
 class TestTradeOutcomeTimestampValidation:
+    def test_non_datetime_timestamp_rejected(self) -> None:
+        with pytest.raises(ValueError, match='timestamp must be a datetime instance'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.ACK,
+                timestamp='2024-01-01T00:00:00Z',  # type: ignore[arg-type]
+            )
+
     def test_naive_timestamp_rejected(self) -> None:
         with pytest.raises(ValueError, match='timestamp must be timezone-aware'):
             TradeOutcome(

--- a/tests/test_trade_outcome_type.py
+++ b/tests/test_trade_outcome_type.py
@@ -1,0 +1,38 @@
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+
+
+def test_enum_has_six_members() -> None:
+    assert len(TradeOutcomeType) == 6
+
+
+def test_enum_values() -> None:
+    assert TradeOutcomeType.ACK.value == 'ACK'
+    assert TradeOutcomeType.PARTIAL.value == 'PARTIAL'
+    assert TradeOutcomeType.FILLED.value == 'FILLED'
+    assert TradeOutcomeType.REJECTED.value == 'REJECTED'
+    assert TradeOutcomeType.EXPIRED.value == 'EXPIRED'
+    assert TradeOutcomeType.CANCELED.value == 'CANCELED'
+
+
+def test_is_terminal_for_terminal_outcomes() -> None:
+    assert TradeOutcomeType.FILLED.is_terminal is True
+    assert TradeOutcomeType.REJECTED.is_terminal is True
+    assert TradeOutcomeType.EXPIRED.is_terminal is True
+    assert TradeOutcomeType.CANCELED.is_terminal is True
+
+
+def test_is_terminal_for_non_terminal_outcomes() -> None:
+    assert TradeOutcomeType.ACK.is_terminal is False
+    assert TradeOutcomeType.PARTIAL.is_terminal is False
+
+
+def test_is_fill_for_fill_outcomes() -> None:
+    assert TradeOutcomeType.PARTIAL.is_fill is True
+    assert TradeOutcomeType.FILLED.is_fill is True
+
+
+def test_is_fill_for_non_fill_outcomes() -> None:
+    assert TradeOutcomeType.ACK.is_fill is False
+    assert TradeOutcomeType.REJECTED.is_fill is False
+    assert TradeOutcomeType.EXPIRED.is_fill is False
+    assert TradeOutcomeType.CANCELED.is_fill is False


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Phase 4.2 Praxis Connector inbound trade outcome processing (from RFC-3001 Manager Sub-System). Adds `TradeOutcomeType` enum (ACK, PARTIAL, FILLED, REJECTED, EXPIRED, CANCELED) for outcome classification. Adds frozen `TradeOutcome` dataclass with outcome-type-specific validation (fill outcomes require `fill_size`, `fill_price`, `fill_notional`, `actual_fees`). Adds `InboundConnector` protocol for receiving outcomes from Trading sub-system. Adds frozen `OrderContext` dataclass bridging outcome processing with order metadata (side, trade_id, estimated_fees). Adds frozen `ProcessResult` dataclass for outcome processing results. Extends `CapitalController.order_fill()` with `actual_fees` parameter and fee reconciliation against `fee_reserve` (surplus adds, deficit draws). Adds `OutcomeProcessor` routing outcomes to Capital Controller lifecycle methods (ACK → order_ack, FILL → order_fill, REJECT → order_reject, CANCEL/EXPIRED → order_cancel). Adds position growth with VWAP entry price calculation on entry fills. Adds position reduction with `pending_exit` clearing on exit fills, removing closed positions from state. Adds 126 new tests (638 total). Bumps to v0.16.0.

## Checklist

- [ ] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (638 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable