### PR TITLE
feat: Phase 7.1 - Manifest loading and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.18.0 on 30th of March, 2026
+
+- Add [`manifest.py`](nexus/infrastructure/manifest.py) with frozen `StrategySpec` dataclass (strategy_id, file, predictor_fn_ids, capital_pct) and frozen `Manifest` dataclass (capital_pool, strategies)
+- Add `load_manifest()` to parse YAML manifest files with `allocated_capital` ceiling validation
+- Add `_validate_strategy_files()` to verify strategy .py files exist and have valid Python syntax via `importlib`
+- Add `pyyaml>=6.0` runtime dependency for YAML manifest parsing
+- Add mypy override for yaml module missing type stubs
+- Add 52 tests covering StrategySpec validation, Manifest invariants, load_manifest parsing, and file validation (708 total)
+
 ## v0.17.0 on 28th of March, 2026
 
 - Add `StateStore` dependency to `OutcomeProcessor` for WAL persistence of risk events

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -1,0 +1,114 @@
+'''Manifest loading and validation for strategy configuration.
+
+Provides frozen dataclasses for manifest structure and a loader
+that parses YAML and validates all constraints including file
+existence and importability.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+__all__ = ['Manifest', 'StrategySpec']
+
+_ZERO = Decimal('0')
+_ONE_HUNDRED = Decimal('100')
+
+
+@dataclass(frozen=True)
+class StrategySpec:
+    '''Immutable specification for a single strategy.
+
+    Args:
+        strategy_id: Unique identifier for this strategy.
+        file: Path to the Python strategy implementation.
+        predictor_fn_ids: Predictor IDs this strategy depends on (from Limen).
+        capital_pct: Capital allocation percentage for this strategy.
+    '''
+
+    strategy_id: str
+    file: str
+    predictor_fn_ids: tuple[str, ...]
+    capital_pct: Decimal
+
+    def __post_init__(self) -> None:
+        '''Validate strategy specification invariants.'''
+
+        if not isinstance(self.strategy_id, str) or not self.strategy_id.strip():
+            msg = 'StrategySpec.strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.file, str) or not self.file.strip():
+            msg = 'StrategySpec.file must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.predictor_fn_ids, tuple) or not self.predictor_fn_ids:
+            msg = 'StrategySpec.predictor_fn_ids must be a non-empty tuple'
+            raise ValueError(msg)
+
+        for predictor_id in self.predictor_fn_ids:
+            if not isinstance(predictor_id, str) or not predictor_id.strip():
+                msg = 'StrategySpec.predictor_fn_ids must contain non-empty strings'
+                raise ValueError(msg)
+
+        if (
+            not isinstance(self.capital_pct, Decimal)
+            or not self.capital_pct.is_finite()
+        ):
+            msg = 'StrategySpec.capital_pct must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.capital_pct <= _ZERO or self.capital_pct > _ONE_HUNDRED:
+            msg = 'StrategySpec.capital_pct must be in (0, 100]'
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class Manifest:
+    '''Immutable manifest for a Manager instance.
+
+    Args:
+        capital_pool: Total capital in quote asset for this instance.
+        strategies: Strategy specifications for this instance.
+    '''
+
+    capital_pool: Decimal
+    strategies: tuple[StrategySpec, ...]
+
+    def __post_init__(self) -> None:
+        '''Validate manifest invariants.'''
+
+        if (
+            not isinstance(self.capital_pool, Decimal)
+            or not self.capital_pool.is_finite()
+        ):
+            msg = 'Manifest.capital_pool must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.capital_pool <= _ZERO:
+            msg = 'Manifest.capital_pool must be positive'
+            raise ValueError(msg)
+
+        if not isinstance(self.strategies, tuple) or not self.strategies:
+            msg = 'Manifest.strategies must be a non-empty tuple'
+            raise ValueError(msg)
+
+        seen_ids: set[str] = set()
+        total_pct = _ZERO
+
+        for spec in self.strategies:
+            if not isinstance(spec, StrategySpec):
+                msg = 'Manifest.strategies must contain StrategySpec instances'
+                raise ValueError(msg)
+
+            if spec.strategy_id in seen_ids:
+                msg = f'Manifest.strategies contains duplicate strategy_id: {spec.strategy_id!r}'
+                raise ValueError(msg)
+
+            seen_ids.add(spec.strategy_id)
+            total_pct += spec.capital_pct
+
+        if total_pct > _ONE_HUNDRED:
+            msg = f'Manifest.strategies capital_pct sum {total_pct} exceeds 100'
+            raise ValueError(msg)

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -7,10 +7,15 @@ existence and importability.
 
 from __future__ import annotations
 
+import importlib.util
 from dataclasses import dataclass
 from decimal import Decimal
+from pathlib import Path
+from typing import Any
 
-__all__ = ['Manifest', 'StrategySpec']
+import yaml
+
+__all__ = ['Manifest', 'StrategySpec', 'load_manifest']
 
 _ZERO = Decimal('0')
 _ONE_HUNDRED = Decimal('100')
@@ -112,3 +117,129 @@ class Manifest:
         if total_pct > _ONE_HUNDRED:
             msg = f'Manifest.strategies capital_pct sum {total_pct} exceeds 100'
             raise ValueError(msg)
+
+
+def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
+    '''Load and validate a manifest from a YAML file.
+
+    Args:
+        path: Path to the YAML manifest file.
+        allocated_capital: Hard ceiling for capital_pool validation.
+
+    Returns:
+        Validated Manifest instance.
+
+    Raises:
+        ValueError: If manifest is invalid or capital_pool exceeds allocated_capital.
+        FileNotFoundError: If manifest file does not exist.
+    '''
+
+    if not path.exists():
+        msg = f'Manifest file not found: {path}'
+        raise FileNotFoundError(msg)
+
+    with path.open() as f:
+        data: dict[str, Any] = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        msg = 'Manifest must be a YAML mapping'
+        raise ValueError(msg)
+
+    raw_capital_pool = data.get('capital_pool')
+    if raw_capital_pool is None:
+        msg = 'Manifest missing required field: capital_pool'
+        raise ValueError(msg)
+
+    capital_pool = Decimal(str(raw_capital_pool))
+
+    if capital_pool > allocated_capital:
+        msg = (
+            f'Manifest capital_pool {capital_pool} exceeds '
+            f'allocated_capital {allocated_capital}'
+        )
+        raise ValueError(msg)
+
+    raw_strategies = data.get('strategies')
+    if not isinstance(raw_strategies, list) or not raw_strategies:
+        msg = 'Manifest missing or empty strategies list'
+        raise ValueError(msg)
+
+    specs: list[StrategySpec] = []
+
+    for raw_spec in raw_strategies:
+        if not isinstance(raw_spec, dict):
+            msg = 'Each strategy must be a YAML mapping'
+            raise ValueError(msg)
+
+        strategy_id = raw_spec.get('id')
+        if strategy_id is None:
+            msg = 'Strategy missing required field: id'
+            raise ValueError(msg)
+
+        file = raw_spec.get('file')
+        if file is None:
+            msg = f'Strategy {strategy_id!r} missing required field: file'
+            raise ValueError(msg)
+
+        raw_predictor_fn_ids = raw_spec.get('predictor_fn_ids')
+        if not isinstance(raw_predictor_fn_ids, list) or not raw_predictor_fn_ids:
+            msg = f'Strategy {strategy_id!r} missing or empty predictor_fn_ids'
+            raise ValueError(msg)
+
+        predictor_fn_ids = tuple(raw_predictor_fn_ids)
+
+        raw_capital_pct = raw_spec.get('capital_pct')
+        if raw_capital_pct is None:
+            msg = f'Strategy {strategy_id!r} missing required field: capital_pct'
+            raise ValueError(msg)
+
+        capital_pct = Decimal(str(raw_capital_pct))
+
+        specs.append(
+            StrategySpec(
+                strategy_id=strategy_id,
+                file=file,
+                predictor_fn_ids=predictor_fn_ids,
+                capital_pct=capital_pct,
+            )
+        )
+
+    manifest = Manifest(capital_pool=capital_pool, strategies=tuple(specs))
+
+    _validate_strategy_files(manifest, path.parent)
+
+    return manifest
+
+
+def _validate_strategy_files(manifest: Manifest, base_path: Path) -> None:
+    '''Validate all strategy files exist and are valid Python.
+
+    Args:
+        manifest: Manifest with strategies to validate.
+        base_path: Base path for resolving relative file paths.
+
+    Raises:
+        ValueError: If any strategy file is missing or has syntax errors.
+    '''
+
+    for spec in manifest.strategies:
+        file_path = base_path / spec.file
+
+        if not file_path.exists():
+            msg = f'Strategy {spec.strategy_id!r} file not found: {file_path}'
+            raise ValueError(msg)
+
+        try:
+            spec_obj = importlib.util.spec_from_file_location(
+                spec.strategy_id,
+                file_path,
+            )
+            if spec_obj is None or spec_obj.loader is None:
+                msg = f'Strategy {spec.strategy_id!r} file cannot be loaded: {file_path}'
+                raise ValueError(msg)
+
+            module = importlib.util.module_from_spec(spec_obj)
+            spec_obj.loader.exec_module(module)
+        except SyntaxError as e:
+            msg = f'Strategy {spec.strategy_id!r} file has syntax error: {file_path}: {e}'
+            raise ValueError(msg) from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.10"
-dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0"]
+dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0", "pyyaml>=6.0"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,10 @@ no_implicit_optional = true
 module = ["msgpack", "msgpack.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["yaml", "yaml.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.17.0"
+version = "0.18.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import tempfile
 from decimal import Decimal
+from pathlib import Path
 
 import pytest
 
-from nexus.infrastructure.manifest import Manifest, StrategySpec
+from nexus.infrastructure.manifest import Manifest, StrategySpec, load_manifest
 
 
 class TestStrategySpec:
@@ -427,3 +429,319 @@ class TestManifest:
         )
 
         assert len(manifest.strategies) == 1
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    '''Write YAML content to a file.'''
+
+    path.write_text(content)
+
+
+def _write_strategy_file(base: Path, rel_path: str, content: str = '') -> None:
+    '''Create a strategy .py file.'''
+
+    file_path = base / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content or '# Strategy file\n')
+
+
+class TestLoadManifest:
+    '''Tests for load_manifest function.'''
+
+    def test_valid_manifest_loads(self) -> None:
+        '''Valid YAML manifest loads successfully.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            path = tmp_path / 'manifest.yaml'
+
+            _write_strategy_file(tmp_path, 'strategies/momentum.py')
+            _write_strategy_file(tmp_path, 'strategies/mean_rev.py')
+
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: momentum
+    file: strategies/momentum.py
+    predictor_fn_ids:
+      - alpha_v1
+    capital_pct: 60
+  - id: mean_rev
+    file: strategies/mean_rev.py
+    predictor_fn_ids:
+      - sensor_vol
+    capital_pct: 40
+''',
+            )
+
+            manifest = load_manifest(path, Decimal('20000'))
+
+            assert manifest.capital_pool == Decimal('10000')
+            assert len(manifest.strategies) == 2
+            assert manifest.strategies[0].strategy_id == 'momentum'
+            assert manifest.strategies[1].strategy_id == 'mean_rev'
+
+    def test_file_not_found_raises(self) -> None:
+        '''Missing manifest file raises FileNotFoundError.'''
+
+        with pytest.raises(FileNotFoundError, match='Manifest file not found'):
+            load_manifest(Path('/nonexistent/manifest.yaml'), Decimal('10000'))
+
+    def test_capital_pool_exceeds_allocated_raises(self) -> None:
+        '''capital_pool > allocated_capital raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 15000
+strategies:
+  - id: test
+    file: test.py
+    predictor_fn_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='exceeds allocated_capital'):
+                load_manifest(path, Decimal('10000'))
+
+    def test_missing_capital_pool_raises(self) -> None:
+        '''Missing capital_pool raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+strategies:
+  - id: test
+    file: test.py
+    predictor_fn_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing required field: capital_pool'):
+                load_manifest(path, Decimal('10000'))
+
+    def test_missing_strategies_raises(self) -> None:
+        '''Missing strategies raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(path, 'capital_pool: 10000\n')
+
+            with pytest.raises(ValueError, match='missing or empty strategies'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_empty_strategies_raises(self) -> None:
+        '''Empty strategies list raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies: []
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing or empty strategies'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_missing_id_raises(self) -> None:
+        '''Strategy missing id raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - file: test.py
+    predictor_fn_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing required field: id'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_missing_file_raises(self) -> None:
+        '''Strategy missing file raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: test
+    predictor_fn_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing required field: file'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_missing_predictor_fn_ids_raises(self) -> None:
+        '''Strategy missing predictor_fn_ids raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: test
+    file: test.py
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing or empty predictor_fn_ids'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_missing_capital_pct_raises(self) -> None:
+        '''Strategy missing capital_pct raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: test
+    file: test.py
+    predictor_fn_ids: [pred1]
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing required field: capital_pct'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_malformed_yaml_raises(self) -> None:
+        '''Malformed YAML raises yaml.YAMLError.'''
+
+        import yaml
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(path, 'capital_pool: [unclosed')
+
+            with pytest.raises(yaml.YAMLError):
+                load_manifest(path, Decimal('20000'))
+
+    def test_non_mapping_yaml_raises(self) -> None:
+        '''Non-mapping YAML raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(path, '- item1\n- item2\n')
+
+            with pytest.raises(ValueError, match='must be a YAML mapping'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_duplicate_strategy_id_raises(self) -> None:
+        '''Duplicate strategy_id raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: same
+    file: test1.py
+    predictor_fn_ids: [pred1]
+    capital_pct: 50
+  - id: same
+    file: test2.py
+    predictor_fn_ids: [pred2]
+    capital_pct: 50
+''',
+            )
+
+            with pytest.raises(ValueError, match='duplicate strategy_id'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_capital_pct_sum_over_100_raises(self) -> None:
+        '''capital_pct sum > 100 raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: a
+    file: a.py
+    predictor_fn_ids: [pred1]
+    capital_pct: 60
+  - id: b
+    file: b.py
+    predictor_fn_ids: [pred2]
+    capital_pct: 50
+''',
+            )
+
+            with pytest.raises(ValueError, match='exceeds 100'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_file_not_found_raises(self) -> None:
+        '''Missing strategy .py file raises ValueError with path.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            path = tmp_path / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: missing_file
+    file: nonexistent/strategy.py
+    predictor_fn_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match=r"file not found.*nonexistent/strategy\.py"):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_file_syntax_error_raises(self) -> None:
+        '''Invalid Python syntax in strategy file raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            path = tmp_path / 'manifest.yaml'
+
+            strategy_file = tmp_path / 'bad_syntax.py'
+            strategy_file.write_text('def broken(\n')
+
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: bad_syntax
+    file: bad_syntax.py
+    predictor_fn_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match=r'syntax error.*bad_syntax\.py'):
+                load_manifest(path, Decimal('20000'))

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,429 @@
+'''Tests for manifest loading and validation.'''
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from nexus.infrastructure.manifest import Manifest, StrategySpec
+
+
+class TestStrategySpec:
+    '''Tests for StrategySpec dataclass.'''
+
+    def test_valid_strategy_spec(self) -> None:
+        '''Valid StrategySpec creates successfully.'''
+
+        spec = StrategySpec(
+            strategy_id='momentum_v1',
+            file='strategies/momentum.py',
+            predictor_fn_ids=('cohort_alpha_v3', 'sensor_volatility'),
+            capital_pct=Decimal('25'),
+        )
+
+        assert spec.strategy_id == 'momentum_v1'
+        assert spec.file == 'strategies/momentum.py'
+        assert spec.predictor_fn_ids == ('cohort_alpha_v3', 'sensor_volatility')
+        assert spec.capital_pct == Decimal('25')
+
+    def test_strategy_spec_is_frozen(self) -> None:
+        '''StrategySpec is immutable.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            predictor_fn_ids=('pred1',),
+            capital_pct=Decimal('10'),
+        )
+
+        with pytest.raises(AttributeError):
+            spec.strategy_id = 'changed'  # type: ignore[misc]
+
+    def test_empty_strategy_id_raises(self) -> None:
+        '''Empty strategy_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategy_id must be a non-empty string'):
+            StrategySpec(
+                strategy_id='',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_whitespace_strategy_id_raises(self) -> None:
+        '''Whitespace-only strategy_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategy_id must be a non-empty string'):
+            StrategySpec(
+                strategy_id='   ',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_empty_file_raises(self) -> None:
+        '''Empty file raises ValueError.'''
+
+        with pytest.raises(ValueError, match='file must be a non-empty string'):
+            StrategySpec(
+                strategy_id='test',
+                file='',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_whitespace_file_raises(self) -> None:
+        '''Whitespace-only file raises ValueError.'''
+
+        with pytest.raises(ValueError, match='file must be a non-empty string'):
+            StrategySpec(
+                strategy_id='test',
+                file='  ',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_empty_predictor_fn_ids_raises(self) -> None:
+        '''Empty predictor_fn_ids raises ValueError.'''
+
+        with pytest.raises(ValueError, match='predictor_fn_ids must be a non-empty tuple'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=(),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_predictor_fn_ids_not_tuple_raises(self) -> None:
+        '''Non-tuple predictor_fn_ids raises ValueError.'''
+
+        with pytest.raises(ValueError, match='predictor_fn_ids must be a non-empty tuple'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=['pred1'],  # type: ignore[arg-type]
+                capital_pct=Decimal('10'),
+            )
+
+    def test_predictor_fn_ids_with_empty_string_raises(self) -> None:
+        '''predictor_fn_ids containing empty string raises ValueError.'''
+
+        with pytest.raises(ValueError, match='predictor_fn_ids must contain non-empty strings'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1', ''),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_predictor_fn_ids_with_whitespace_raises(self) -> None:
+        '''predictor_fn_ids containing whitespace-only string raises ValueError.'''
+
+        with pytest.raises(ValueError, match='predictor_fn_ids must contain non-empty strings'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1', '   '),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_predictor_fn_ids_with_non_string_raises(self) -> None:
+        '''predictor_fn_ids containing non-string raises ValueError.'''
+
+        with pytest.raises(ValueError, match='predictor_fn_ids must contain non-empty strings'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1', 123),  # type: ignore[arg-type]
+                capital_pct=Decimal('10'),
+            )
+
+    def test_non_decimal_capital_pct_raises(self) -> None:
+        '''Non-Decimal capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=25,  # type: ignore[arg-type]
+            )
+
+    def test_infinite_capital_pct_raises(self) -> None:
+        '''Infinite capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('inf'),
+            )
+
+    def test_nan_capital_pct_raises(self) -> None:
+        '''NaN capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('nan'),
+            )
+
+    def test_zero_capital_pct_raises(self) -> None:
+        '''Zero capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be in'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('0'),
+            )
+
+    def test_negative_capital_pct_raises(self) -> None:
+        '''Negative capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be in'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('-5'),
+            )
+
+    def test_capital_pct_over_100_raises(self) -> None:
+        '''capital_pct > 100 raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be in'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('101'),
+            )
+
+    def test_capital_pct_exactly_100_allowed(self) -> None:
+        '''capital_pct of exactly 100 is allowed.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            predictor_fn_ids=('pred1',),
+            capital_pct=Decimal('100'),
+        )
+
+        assert spec.capital_pct == Decimal('100')
+
+    def test_capital_pct_fractional_allowed(self) -> None:
+        '''Fractional capital_pct is allowed.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            predictor_fn_ids=('pred1',),
+            capital_pct=Decimal('12.5'),
+        )
+
+        assert spec.capital_pct == Decimal('12.5')
+
+    def test_single_predictor_fn_allowed(self) -> None:
+        '''Single predictor_fn in tuple is allowed.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            predictor_fn_ids=('single_pred',),
+            capital_pct=Decimal('50'),
+        )
+
+        assert spec.predictor_fn_ids == ('single_pred',)
+
+    def test_multiple_predictor_fn_ids_allowed(self) -> None:
+        '''Multiple predictor_fn_ids are allowed.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            predictor_fn_ids=('pred1', 'pred2', 'pred3'),
+            capital_pct=Decimal('50'),
+        )
+
+        assert spec.predictor_fn_ids == ('pred1', 'pred2', 'pred3')
+
+
+def _make_spec(
+    strategy_id: str = 'test',
+    capital_pct: Decimal = Decimal('50'),
+) -> StrategySpec:
+    '''Create a valid StrategySpec for testing.'''
+
+    return StrategySpec(
+        strategy_id=strategy_id,
+        file='test.py',
+        predictor_fn_ids=('pred1',),
+        capital_pct=capital_pct,
+    )
+
+
+class TestManifest:
+    '''Tests for Manifest dataclass.'''
+
+    def test_valid_manifest(self) -> None:
+        '''Valid Manifest creates successfully.'''
+
+        spec1 = _make_spec('strategy_a', Decimal('60'))
+        spec2 = _make_spec('strategy_b', Decimal('40'))
+
+        manifest = Manifest(
+            capital_pool=Decimal('10000'),
+            strategies=(spec1, spec2),
+        )
+
+        assert manifest.capital_pool == Decimal('10000')
+        assert manifest.strategies == (spec1, spec2)
+
+    def test_manifest_is_frozen(self) -> None:
+        '''Manifest is immutable.'''
+
+        manifest = Manifest(
+            capital_pool=Decimal('10000'),
+            strategies=(_make_spec(),),
+        )
+
+        with pytest.raises(AttributeError):
+            manifest.capital_pool = Decimal('5000')  # type: ignore[misc]
+
+    def test_non_decimal_capital_pool_raises(self) -> None:
+        '''Non-Decimal capital_pool raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
+            Manifest(
+                capital_pool=10000,  # type: ignore[arg-type]
+                strategies=(_make_spec(),),
+            )
+
+    def test_infinite_capital_pool_raises(self) -> None:
+        '''Infinite capital_pool raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
+            Manifest(
+                capital_pool=Decimal('inf'),
+                strategies=(_make_spec(),),
+            )
+
+    def test_nan_capital_pool_raises(self) -> None:
+        '''NaN capital_pool raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
+            Manifest(
+                capital_pool=Decimal('nan'),
+                strategies=(_make_spec(),),
+            )
+
+    def test_zero_capital_pool_raises(self) -> None:
+        '''Zero capital_pool raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pool must be positive'):
+            Manifest(
+                capital_pool=Decimal('0'),
+                strategies=(_make_spec(),),
+            )
+
+    def test_negative_capital_pool_raises(self) -> None:
+        '''Negative capital_pool raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pool must be positive'):
+            Manifest(
+                capital_pool=Decimal('-1000'),
+                strategies=(_make_spec(),),
+            )
+
+    def test_empty_strategies_raises(self) -> None:
+        '''Empty strategies raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategies must be a non-empty tuple'):
+            Manifest(
+                capital_pool=Decimal('10000'),
+                strategies=(),
+            )
+
+    def test_strategies_not_tuple_raises(self) -> None:
+        '''Non-tuple strategies raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategies must be a non-empty tuple'):
+            Manifest(
+                capital_pool=Decimal('10000'),
+                strategies=[_make_spec()],  # type: ignore[arg-type]
+            )
+
+    def test_strategies_with_non_spec_raises(self) -> None:
+        '''Strategies containing non-StrategySpec raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategies must contain StrategySpec'):
+            Manifest(
+                capital_pool=Decimal('10000'),
+                strategies=(_make_spec(), 'not a spec'),  # type: ignore[arg-type]
+            )
+
+    def test_duplicate_strategy_id_raises(self) -> None:
+        '''Duplicate strategy_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='duplicate strategy_id'):
+            Manifest(
+                capital_pool=Decimal('10000'),
+                strategies=(
+                    _make_spec('same_id', Decimal('50')),
+                    _make_spec('same_id', Decimal('50')),
+                ),
+            )
+
+    def test_capital_pct_sum_over_100_raises(self) -> None:
+        '''capital_pct sum > 100 raises ValueError.'''
+
+        with pytest.raises(ValueError, match=r'capital_pct sum .* exceeds 100'):
+            Manifest(
+                capital_pool=Decimal('10000'),
+                strategies=(
+                    _make_spec('a', Decimal('60')),
+                    _make_spec('b', Decimal('50')),
+                ),
+            )
+
+    def test_capital_pct_sum_exactly_100_allowed(self) -> None:
+        '''capital_pct sum of exactly 100 is allowed.'''
+
+        manifest = Manifest(
+            capital_pool=Decimal('10000'),
+            strategies=(
+                _make_spec('a', Decimal('60')),
+                _make_spec('b', Decimal('40')),
+            ),
+        )
+
+        assert manifest.capital_pool == Decimal('10000')
+
+    def test_capital_pct_sum_under_100_allowed(self) -> None:
+        '''capital_pct sum under 100 is allowed.'''
+
+        manifest = Manifest(
+            capital_pool=Decimal('10000'),
+            strategies=(
+                _make_spec('a', Decimal('30')),
+                _make_spec('b', Decimal('20')),
+            ),
+        )
+
+        assert manifest.capital_pool == Decimal('10000')
+
+    def test_single_strategy_allowed(self) -> None:
+        '''Single strategy in manifest is allowed.'''
+
+        manifest = Manifest(
+            capital_pool=Decimal('10000'),
+            strategies=(_make_spec('only_one', Decimal('100')),),
+        )
+
+        assert len(manifest.strategies) == 1


### PR DESCRIPTION
## Summary

- Add frozen `StrategySpec` dataclass (strategy_id, file, predictor_fn_ids, capital_pct)
- Add frozen `Manifest` dataclass (capital_pool, strategies tuple)
- Add `load_manifest()` to parse YAML manifests with `allocated_capital` ceiling validation
- Add `_validate_strategy_files()` to verify .py files exist and have valid Python syntax
- Add `pyyaml>=6.0` runtime dependency

## Test plan

- [x] 21 tests for StrategySpec validation (empty fields, invalid types, bounds)
- [x] 15 tests for Manifest invariants (duplicate IDs, capital_pct sum)
- [x] 16 tests for load_manifest (YAML parsing, file validation, syntax errors)
- [x] Ruff lint: pass
- [x] Mypy strict: pass
- [x] 708 tests passing

Closes #16 (RFC-3001 Phase 7.1)