### PR TITLE
feat: Phase 7.1 - Manifest loading and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add [`manifest.py`](nexus/infrastructure/manifest.py) with frozen `StrategySpec` dataclass (strategy_id, file, permutation_ids, capital_pct) and frozen `Manifest` dataclass (capital_pool, strategies)
 - Add `load_manifest()` to parse YAML manifest files with `allocated_capital` ceiling validation
-- Add `_validate_strategy_files()` to verify strategy .py files exist and have valid Python syntax via `importlib`
+- Add `_validate_strategy_files()` to verify strategy .py files exist and have valid Python syntax via `ast.parse()`
 - Add `pyyaml>=6.0` runtime dependency and mypy override for yaml module
 - Add 52 tests covering StrategySpec, Manifest, load_manifest parsing, and file validation (708 total)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,5 @@
 # Changelog
 
-## v0.18.0 on 31st of March, 2026
-
-- Add [`manifest.py`](nexus/infrastructure/manifest.py) with frozen `StrategySpec` dataclass (strategy_id, file, permutation_ids, capital_pct) and frozen `Manifest` dataclass (capital_pool, strategies)
-- Add `load_manifest()` to parse YAML manifest files with `allocated_capital` ceiling validation
-- Add `_validate_strategy_files()` to verify strategy .py files exist and have valid Python syntax via `ast.parse()`
-- Add `pyyaml>=6.0` runtime dependency and mypy override for yaml module
-- Add 52 tests covering StrategySpec, Manifest, load_manifest parsing, and file validation (708 total)
-
-## v0.17.0 on 28th of March, 2026
-
-- Add `StateStore` dependency to `OutcomeProcessor` for WAL persistence of risk events
-- Compute realized P&L in `_reduce_position` using side-aware formula: `side_multiplier × (fill_price - entry_price) × fill_size` where `side_multiplier` is `-1` for shorts
-- Add `_update_strategy_risk_state()` to update per-strategy `strategy_realized_pnl`, `rolling_loss_24h/7d/30d`, and `high_water_mark`
-- Update instance-level `cumulative_realized_pnl` triggering `recompute_drawdown_metrics()` on exit fills
-- Persist `StrategyEvent` to WAL via `StateStore.append_event()` on every exit fill
-- Add 7 tests covering risk metrics recalculation, strategy isolation, and WAL persistence (652 total)
-
-## v0.16.0 on 27th of March, 2026
-
-- Add [`trade_outcome_type.py`](nexus/infrastructure/praxis_connector/trade_outcome_type.py) with `TradeOutcomeType` enum (ACK, PARTIAL, FILLED, REJECTED, EXPIRED, CANCELED)
-- Add [`trade_outcome.py`](nexus/infrastructure/praxis_connector/trade_outcome.py) with frozen `TradeOutcome` dataclass and outcome-type-specific validation (fill outcomes require `actual_fees`)
-- Add [`inbound_connector.py`](nexus/infrastructure/praxis_connector/inbound_connector.py) with `InboundConnector` protocol for receiving outcomes from Trading sub-system
-- Add [`order_context.py`](nexus/infrastructure/praxis_connector/order_context.py) with frozen `OrderContext` dataclass bridging outcome processing with order metadata (side, trade_id, estimated_fees)
-- Add [`process_result.py`](nexus/infrastructure/praxis_connector/process_result.py) with frozen `ProcessResult` dataclass for outcome processing results
-- Extend `CapitalController.order_fill()` with `actual_fees` parameter and fee reconciliation against `fee_reserve`
-- Add [`outcome_processor.py`](nexus/infrastructure/praxis_connector/outcome_processor.py) with `OutcomeProcessor` routing outcomes to Capital Controller lifecycle methods
-- Add position growth with VWAP entry price calculation on entry fills
-- Add position reduction with `pending_exit` clearing on exit fills, removing closed positions from state
-- Add 126 tests covering TradeOutcome validation, OutcomeProcessor routing, position growth/reduction, and fee reconciliation (638 total)
-
-## v0.15.0 on 25th of March, 2026
-
-- Add [`stp_mode.py`](nexus/core/stp_mode.py) with `STPMode` enum (CANCEL_MAKER, CANCEL_TAKER, CANCEL_BOTH) for self-trade prevention
-- Add `stp_mode` field to `InstanceConfig` with default `CANCEL_TAKER` and validation
-- Add [`trade_command_type.py`](nexus/infrastructure/praxis_connector/trade_command_type.py) with `TradeCommandType` enum (NEW_ORDER, AMEND_ORDER, CANCEL_ORDER)
-- Add [`trade_command.py`](nexus/infrastructure/praxis_connector/trade_command.py) with frozen `TradeCommand` dataclass and command-type-specific validation
-- Add [`translate.py`](nexus/infrastructure/praxis_connector/translate.py) with `translate_to_trade_command()` mapping ValidationAction to TradeCommand
-- Add [`outbound_connector.py`](nexus/infrastructure/praxis_connector/outbound_connector.py) with `OutboundConnector` protocol for Trading sub-system dispatch
-- Enforce `translate_to_trade_command` guards for allowed decision and non-empty `command_id`
-- Enforce `TradeCommand` rejection of `side`/`size` for `AMEND_ORDER`/`CANCEL_ORDER` command types
-- Enforce robust `expires_at` computation in tests using `timedelta` instead of `minute` replacement
-- Add 45 tests covering STPMode, TradeCommandType, TradeCommand validation, and translation for all action types (558 total)
-
 ## v0.1.0 on 16th of March, 2026
 
 - Add CI pipeline mirroring Praxis: Ruff, Mypy strict, pytest, CodeQL workflows
@@ -178,3 +135,46 @@
 - Add reference-source identity to price contracts via `PriceCheckSnapshot.reference_price_source` and `PriceStageLimits.reference_price_source` with non-empty validation
 - Fix deviation-stage behavior to deny deterministically when reference source is missing or mismatched (`PRICE_SYSTEM_DATA_UNAVAILABLE`/`PRICE_SNAPSHOT_INVALID`)
 - Add and expand tests for 3.4 config validation, source-aware deviation paths, consequence routing (stale => platform-critical, spread/deviation => strategy-warning), and full-suite stability (512 passing tests)
+
+## v0.15.0 on 25th of March, 2026
+
+- Add [`stp_mode.py`](nexus/core/stp_mode.py) with `STPMode` enum (CANCEL_MAKER, CANCEL_TAKER, CANCEL_BOTH) for self-trade prevention
+- Add `stp_mode` field to `InstanceConfig` with default `CANCEL_TAKER` and validation
+- Add [`trade_command_type.py`](nexus/infrastructure/praxis_connector/trade_command_type.py) with `TradeCommandType` enum (NEW_ORDER, AMEND_ORDER, CANCEL_ORDER)
+- Add [`trade_command.py`](nexus/infrastructure/praxis_connector/trade_command.py) with frozen `TradeCommand` dataclass and command-type-specific validation
+- Add [`translate.py`](nexus/infrastructure/praxis_connector/translate.py) with `translate_to_trade_command()` mapping ValidationAction to TradeCommand
+- Add [`outbound_connector.py`](nexus/infrastructure/praxis_connector/outbound_connector.py) with `OutboundConnector` protocol for Trading sub-system dispatch
+- Enforce `translate_to_trade_command` guards for allowed decision and non-empty `command_id`
+- Enforce `TradeCommand` rejection of `side`/`size` for `AMEND_ORDER`/`CANCEL_ORDER` command types
+- Enforce robust `expires_at` computation in tests using `timedelta` instead of `minute` replacement
+- Add 45 tests covering STPMode, TradeCommandType, TradeCommand validation, and translation for all action types (558 total)
+
+## v0.16.0 on 27th of March, 2026
+
+- Add [`trade_outcome_type.py`](nexus/infrastructure/praxis_connector/trade_outcome_type.py) with `TradeOutcomeType` enum (ACK, PARTIAL, FILLED, REJECTED, EXPIRED, CANCELED)
+- Add [`trade_outcome.py`](nexus/infrastructure/praxis_connector/trade_outcome.py) with frozen `TradeOutcome` dataclass and outcome-type-specific validation (fill outcomes require `actual_fees`)
+- Add [`inbound_connector.py`](nexus/infrastructure/praxis_connector/inbound_connector.py) with `InboundConnector` protocol for receiving outcomes from Trading sub-system
+- Add [`order_context.py`](nexus/infrastructure/praxis_connector/order_context.py) with frozen `OrderContext` dataclass bridging outcome processing with order metadata (side, trade_id, estimated_fees)
+- Add [`process_result.py`](nexus/infrastructure/praxis_connector/process_result.py) with frozen `ProcessResult` dataclass for outcome processing results
+- Extend `CapitalController.order_fill()` with `actual_fees` parameter and fee reconciliation against `fee_reserve`
+- Add [`outcome_processor.py`](nexus/infrastructure/praxis_connector/outcome_processor.py) with `OutcomeProcessor` routing outcomes to Capital Controller lifecycle methods
+- Add position growth with VWAP entry price calculation on entry fills
+- Add position reduction with `pending_exit` clearing on exit fills, removing closed positions from state
+- Add 126 tests covering TradeOutcome validation, OutcomeProcessor routing, position growth/reduction, and fee reconciliation (638 total)
+
+## v0.17.0 on 28th of March, 2026
+
+- Add `StateStore` dependency to `OutcomeProcessor` for WAL persistence of risk events
+- Compute realized P&L in `_reduce_position` using side-aware formula: `side_multiplier × (fill_price - entry_price) × fill_size` where `side_multiplier` is `-1` for shorts
+- Add `_update_strategy_risk_state()` to update per-strategy `strategy_realized_pnl`, `rolling_loss_24h/7d/30d`, and `high_water_mark`
+- Update instance-level `cumulative_realized_pnl` triggering `recompute_drawdown_metrics()` on exit fills
+- Persist `StrategyEvent` to WAL via `StateStore.append_event()` on every exit fill
+- Add 7 tests covering risk metrics recalculation, strategy isolation, and WAL persistence (652 total)
+
+## v0.18.0 on 31st of March, 2026
+
+- Add [`manifest.py`](nexus/infrastructure/manifest.py) with frozen `StrategySpec` dataclass (strategy_id, file, permutation_ids, capital_pct) and frozen `Manifest` dataclass (capital_pool, strategies)
+- Add `load_manifest()` to parse YAML manifest files with `allocated_capital` ceiling validation
+- Add `_validate_strategy_files()` to verify strategy .py files exist and have valid Python syntax via `ast.parse()`
+- Add `pyyaml>=6.0` runtime dependency and mypy override for yaml module
+- Add 58 tests covering StrategySpec, Manifest, load_manifest parsing, and file validation (714 total)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.18.0 on 31st of March, 2026
+
+- Add [`manifest.py`](nexus/infrastructure/manifest.py) with frozen `StrategySpec` dataclass (strategy_id, file, permutation_ids, capital_pct) and frozen `Manifest` dataclass (capital_pool, strategies)
+- Add `load_manifest()` to parse YAML manifest files with `allocated_capital` ceiling validation
+- Add `_validate_strategy_files()` to verify strategy .py files exist and have valid Python syntax via `importlib`
+- Add `pyyaml>=6.0` runtime dependency and mypy override for yaml module
+- Add 52 tests covering StrategySpec, Manifest, load_manifest parsing, and file validation (708 total)
+
 ## v0.17.0 on 28th of March, 2026
 
 - Add `StateStore` dependency to `OutcomeProcessor` for WAL persistence of risk events

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -2,7 +2,7 @@
 
 Provides frozen dataclasses for manifest structure and a loader
 that parses YAML and validates all constraints including file
-existence and valid Python syntax.
+existence and Python syntax.
 '''
 
 from __future__ import annotations

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -27,7 +27,7 @@ class StrategySpec:
 
     Args:
         strategy_id: Unique identifier for this strategy.
-        file: Path to the Python strategy implementation.
+        file: Relative path string to the Python strategy implementation.
         permutation_ids: Limen permutation IDs for Trainer/Cohort signal sources.
         capital_pct: Capital allocation percentage for this strategy.
     '''
@@ -156,6 +156,10 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
     except InvalidOperation as e:
         msg = f'Manifest capital_pool is not a valid number: {raw_capital_pool!r}'
         raise ValueError(msg) from e
+
+    if not capital_pool.is_finite() or capital_pool <= _ZERO:
+        msg = f'Manifest capital_pool must be a finite positive number: {capital_pool}'
+        raise ValueError(msg)
 
     if capital_pool > allocated_capital:
         msg = (

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -139,8 +139,8 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
         msg = f'Manifest file not found: {path}'
         raise FileNotFoundError(msg)
 
-    with path.open() as f:
-        data: dict[str, Any] = yaml.safe_load(f)
+    with path.open(encoding='utf-8') as f:
+        data: Any = yaml.safe_load(f)
 
     if not isinstance(data, dict):
         msg = 'Manifest must be a YAML mapping'
@@ -264,7 +264,7 @@ def _validate_strategy_files(manifest: Manifest, base_path: Path) -> None:
             raise ValueError(msg)
 
         try:
-            ast.parse(file_path.read_text())
+            ast.parse(file_path.read_text(encoding='utf-8'))
         except SyntaxError as e:
             msg = f'Strategy {spec.strategy_id!r} file has syntax error: {file_path}: {e}'
             raise ValueError(msg) from e

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -28,7 +28,7 @@ class StrategySpec:
     Args:
         strategy_id: Unique identifier for this strategy.
         file: Path to the Python strategy implementation.
-        permutation_ids: Permutation IDs to subscribe to (input to Limen).
+        permutation_ids: Limen permutation IDs for Trainer/Cohort signal sources.
         capital_pct: Capital allocation percentage for this strategy.
     '''
 

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -7,10 +7,15 @@ existence and importability.
 
 from __future__ import annotations
 
+import importlib.util
 from dataclasses import dataclass
 from decimal import Decimal
+from pathlib import Path
+from typing import Any
 
-__all__ = ['Manifest', 'StrategySpec']
+import yaml
+
+__all__ = ['Manifest', 'StrategySpec', 'load_manifest']
 
 _ZERO = Decimal('0')
 _ONE_HUNDRED = Decimal('100')
@@ -23,13 +28,13 @@ class StrategySpec:
     Args:
         strategy_id: Unique identifier for this strategy.
         file: Path to the Python strategy implementation.
-        predictor_fn_ids: Predictor IDs this strategy depends on (from Limen).
+        permutation_ids: Permutation IDs to subscribe to (input to Limen).
         capital_pct: Capital allocation percentage for this strategy.
     '''
 
     strategy_id: str
     file: str
-    predictor_fn_ids: tuple[str, ...]
+    permutation_ids: tuple[str, ...]
     capital_pct: Decimal
 
     def __post_init__(self) -> None:
@@ -43,13 +48,13 @@ class StrategySpec:
             msg = 'StrategySpec.file must be a non-empty string'
             raise ValueError(msg)
 
-        if not isinstance(self.predictor_fn_ids, tuple) or not self.predictor_fn_ids:
-            msg = 'StrategySpec.predictor_fn_ids must be a non-empty tuple'
+        if not isinstance(self.permutation_ids, tuple) or not self.permutation_ids:
+            msg = 'StrategySpec.permutation_ids must be a non-empty tuple'
             raise ValueError(msg)
 
-        for predictor_id in self.predictor_fn_ids:
-            if not isinstance(predictor_id, str) or not predictor_id.strip():
-                msg = 'StrategySpec.predictor_fn_ids must contain non-empty strings'
+        for perm_id in self.permutation_ids:
+            if not isinstance(perm_id, str) or not perm_id.strip():
+                msg = 'StrategySpec.permutation_ids must contain non-empty strings'
                 raise ValueError(msg)
 
         if (
@@ -112,3 +117,129 @@ class Manifest:
         if total_pct > _ONE_HUNDRED:
             msg = f'Manifest.strategies capital_pct sum {total_pct} exceeds 100'
             raise ValueError(msg)
+
+
+def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
+    '''Load and validate a manifest from a YAML file.
+
+    Args:
+        path: Path to the YAML manifest file.
+        allocated_capital: Hard ceiling for capital_pool validation.
+
+    Returns:
+        Validated Manifest instance.
+
+    Raises:
+        ValueError: If manifest is invalid or capital_pool exceeds allocated_capital.
+        FileNotFoundError: If manifest file does not exist.
+    '''
+
+    if not path.exists():
+        msg = f'Manifest file not found: {path}'
+        raise FileNotFoundError(msg)
+
+    with path.open() as f:
+        data: dict[str, Any] = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        msg = 'Manifest must be a YAML mapping'
+        raise ValueError(msg)
+
+    raw_capital_pool = data.get('capital_pool')
+    if raw_capital_pool is None:
+        msg = 'Manifest missing required field: capital_pool'
+        raise ValueError(msg)
+
+    capital_pool = Decimal(str(raw_capital_pool))
+
+    if capital_pool > allocated_capital:
+        msg = (
+            f'Manifest capital_pool {capital_pool} exceeds '
+            f'allocated_capital {allocated_capital}'
+        )
+        raise ValueError(msg)
+
+    raw_strategies = data.get('strategies')
+    if not isinstance(raw_strategies, list) or not raw_strategies:
+        msg = 'Manifest missing or empty strategies list'
+        raise ValueError(msg)
+
+    specs: list[StrategySpec] = []
+
+    for raw_spec in raw_strategies:
+        if not isinstance(raw_spec, dict):
+            msg = 'Each strategy must be a YAML mapping'
+            raise ValueError(msg)
+
+        strategy_id = raw_spec.get('id')
+        if strategy_id is None:
+            msg = 'Strategy missing required field: id'
+            raise ValueError(msg)
+
+        file = raw_spec.get('file')
+        if file is None:
+            msg = f'Strategy {strategy_id!r} missing required field: file'
+            raise ValueError(msg)
+
+        raw_permutation_ids = raw_spec.get('permutation_ids')
+        if not isinstance(raw_permutation_ids, list) or not raw_permutation_ids:
+            msg = f'Strategy {strategy_id!r} missing or empty permutation_ids'
+            raise ValueError(msg)
+
+        permutation_ids = tuple(raw_permutation_ids)
+
+        raw_capital_pct = raw_spec.get('capital_pct')
+        if raw_capital_pct is None:
+            msg = f'Strategy {strategy_id!r} missing required field: capital_pct'
+            raise ValueError(msg)
+
+        capital_pct = Decimal(str(raw_capital_pct))
+
+        specs.append(
+            StrategySpec(
+                strategy_id=strategy_id,
+                file=file,
+                permutation_ids=permutation_ids,
+                capital_pct=capital_pct,
+            )
+        )
+
+    manifest = Manifest(capital_pool=capital_pool, strategies=tuple(specs))
+
+    _validate_strategy_files(manifest, path.parent)
+
+    return manifest
+
+
+def _validate_strategy_files(manifest: Manifest, base_path: Path) -> None:
+    '''Validate all strategy files exist and are valid Python.
+
+    Args:
+        manifest: Manifest with strategies to validate.
+        base_path: Base path for resolving relative file paths.
+
+    Raises:
+        ValueError: If any strategy file is missing or has syntax errors.
+    '''
+
+    for spec in manifest.strategies:
+        file_path = base_path / spec.file
+
+        if not file_path.exists():
+            msg = f'Strategy {spec.strategy_id!r} file not found: {file_path}'
+            raise ValueError(msg)
+
+        try:
+            spec_obj = importlib.util.spec_from_file_location(
+                spec.strategy_id,
+                file_path,
+            )
+            if spec_obj is None or spec_obj.loader is None:
+                msg = f'Strategy {spec.strategy_id!r} file cannot be loaded: {file_path}'
+                raise ValueError(msg)
+
+            module = importlib.util.module_from_spec(spec_obj)
+            spec_obj.loader.exec_module(module)
+        except SyntaxError as e:
+            msg = f'Strategy {spec.strategy_id!r} file has syntax error: {file_path}: {e}'
+            raise ValueError(msg) from e

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -1,0 +1,114 @@
+'''Manifest loading and validation for strategy configuration.
+
+Provides frozen dataclasses for manifest structure and a loader
+that parses YAML and validates all constraints including file
+existence and importability.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+__all__ = ['Manifest', 'StrategySpec']
+
+_ZERO = Decimal('0')
+_ONE_HUNDRED = Decimal('100')
+
+
+@dataclass(frozen=True)
+class StrategySpec:
+    '''Immutable specification for a single strategy.
+
+    Args:
+        strategy_id: Unique identifier for this strategy.
+        file: Path to the Python strategy implementation.
+        predictor_fn_ids: Predictor IDs this strategy depends on (from Limen).
+        capital_pct: Capital allocation percentage for this strategy.
+    '''
+
+    strategy_id: str
+    file: str
+    predictor_fn_ids: tuple[str, ...]
+    capital_pct: Decimal
+
+    def __post_init__(self) -> None:
+        '''Validate strategy specification invariants.'''
+
+        if not isinstance(self.strategy_id, str) or not self.strategy_id.strip():
+            msg = 'StrategySpec.strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.file, str) or not self.file.strip():
+            msg = 'StrategySpec.file must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.predictor_fn_ids, tuple) or not self.predictor_fn_ids:
+            msg = 'StrategySpec.predictor_fn_ids must be a non-empty tuple'
+            raise ValueError(msg)
+
+        for predictor_id in self.predictor_fn_ids:
+            if not isinstance(predictor_id, str) or not predictor_id.strip():
+                msg = 'StrategySpec.predictor_fn_ids must contain non-empty strings'
+                raise ValueError(msg)
+
+        if (
+            not isinstance(self.capital_pct, Decimal)
+            or not self.capital_pct.is_finite()
+        ):
+            msg = 'StrategySpec.capital_pct must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.capital_pct <= _ZERO or self.capital_pct > _ONE_HUNDRED:
+            msg = 'StrategySpec.capital_pct must be in (0, 100]'
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class Manifest:
+    '''Immutable manifest for a Manager instance.
+
+    Args:
+        capital_pool: Total capital in quote asset for this instance.
+        strategies: Strategy specifications for this instance.
+    '''
+
+    capital_pool: Decimal
+    strategies: tuple[StrategySpec, ...]
+
+    def __post_init__(self) -> None:
+        '''Validate manifest invariants.'''
+
+        if (
+            not isinstance(self.capital_pool, Decimal)
+            or not self.capital_pool.is_finite()
+        ):
+            msg = 'Manifest.capital_pool must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.capital_pool <= _ZERO:
+            msg = 'Manifest.capital_pool must be positive'
+            raise ValueError(msg)
+
+        if not isinstance(self.strategies, tuple) or not self.strategies:
+            msg = 'Manifest.strategies must be a non-empty tuple'
+            raise ValueError(msg)
+
+        seen_ids: set[str] = set()
+        total_pct = _ZERO
+
+        for spec in self.strategies:
+            if not isinstance(spec, StrategySpec):
+                msg = 'Manifest.strategies must contain StrategySpec instances'
+                raise ValueError(msg)
+
+            if spec.strategy_id in seen_ids:
+                msg = f'Manifest.strategies contains duplicate strategy_id: {spec.strategy_id!r}'
+                raise ValueError(msg)
+
+            seen_ids.add(spec.strategy_id)
+            total_pct += spec.capital_pct
+
+        if total_pct > _ONE_HUNDRED:
+            msg = f'Manifest.strategies capital_pct sum {total_pct} exceeds 100'
+            raise ValueError(msg)

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -7,9 +7,9 @@ existence and importability.
 
 from __future__ import annotations
 
-import importlib.util
+import ast
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
@@ -132,6 +132,7 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
     Raises:
         ValueError: If manifest is invalid or capital_pool exceeds allocated_capital.
         FileNotFoundError: If manifest file does not exist.
+        yaml.YAMLError: If the file contains malformed YAML.
     '''
 
     if not path.exists():
@@ -150,7 +151,11 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
         msg = 'Manifest missing required field: capital_pool'
         raise ValueError(msg)
 
-    capital_pool = Decimal(str(raw_capital_pool))
+    try:
+        capital_pool = Decimal(str(raw_capital_pool))
+    except InvalidOperation as e:
+        msg = f'Manifest capital_pool is not a valid number: {raw_capital_pool!r}'
+        raise ValueError(msg) from e
 
     if capital_pool > allocated_capital:
         msg = (
@@ -193,7 +198,11 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
             msg = f'Strategy {strategy_id!r} missing required field: capital_pct'
             raise ValueError(msg)
 
-        capital_pct = Decimal(str(raw_capital_pct))
+        try:
+            capital_pct = Decimal(str(raw_capital_pct))
+        except InvalidOperation as e:
+            msg = f'Strategy {strategy_id!r} capital_pct is not a valid number: {raw_capital_pct!r}'
+            raise ValueError(msg) from e
 
         specs.append(
             StrategySpec(
@@ -219,27 +228,32 @@ def _validate_strategy_files(manifest: Manifest, base_path: Path) -> None:
         base_path: Base path for resolving relative file paths.
 
     Raises:
-        ValueError: If any strategy file is missing or has syntax errors.
+        ValueError: If any strategy file is missing, escapes base path, or has syntax errors.
     '''
 
-    for spec in manifest.strategies:
-        file_path = base_path / spec.file
+    base_resolved = base_path.resolve()
 
-        if not file_path.exists():
+    for spec in manifest.strategies:
+        raw_path = Path(spec.file)
+
+        if raw_path.is_absolute():
+            msg = f'Strategy {spec.strategy_id!r} file must be relative: {raw_path}'
+            raise ValueError(msg)
+
+        file_path = (base_resolved / raw_path).resolve()
+
+        try:
+            file_path.relative_to(base_resolved)
+        except ValueError as e:
+            msg = f'Strategy {spec.strategy_id!r} file escapes base path: {file_path}'
+            raise ValueError(msg) from e
+
+        if not file_path.is_file():
             msg = f'Strategy {spec.strategy_id!r} file not found: {file_path}'
             raise ValueError(msg)
 
         try:
-            spec_obj = importlib.util.spec_from_file_location(
-                spec.strategy_id,
-                file_path,
-            )
-            if spec_obj is None or spec_obj.loader is None:
-                msg = f'Strategy {spec.strategy_id!r} file cannot be loaded: {file_path}'
-                raise ValueError(msg)
-
-            module = importlib.util.module_from_spec(spec_obj)
-            spec_obj.loader.exec_module(module)
+            ast.parse(file_path.read_text())
         except SyntaxError as e:
             msg = f'Strategy {spec.strategy_id!r} file has syntax error: {file_path}: {e}'
             raise ValueError(msg) from e

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -44,8 +44,8 @@ class StrategySpec:
             msg = 'StrategySpec.strategy_id must be a non-empty string'
             raise ValueError(msg)
 
-        if not isinstance(self.file, str) or not self.file.strip():
-            msg = 'StrategySpec.file must be a non-empty string'
+        if not isinstance(self.file, str) or not self.file.strip() or self.file != self.file.strip():
+            msg = 'StrategySpec.file must be a non-empty string without surrounding whitespace'
             raise ValueError(msg)
 
         if not isinstance(self.permutation_ids, tuple) or not self.permutation_ids:

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -161,6 +161,13 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
         msg = f'Manifest capital_pool must be a finite positive number: {capital_pool}'
         raise ValueError(msg)
 
+    if (
+        not isinstance(allocated_capital, Decimal)
+        or not allocated_capital.is_finite()
+    ):
+        msg = 'allocated_capital must be a finite Decimal'
+        raise ValueError(msg)
+
     if capital_pool > allocated_capital:
         msg = (
             f'Manifest capital_pool {capital_pool} exceeds '

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -2,7 +2,7 @@
 
 Provides frozen dataclasses for manifest structure and a loader
 that parses YAML and validates all constraints including file
-existence and importability.
+existence and valid Python syntax.
 '''
 
 from __future__ import annotations
@@ -135,7 +135,7 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
         yaml.YAMLError: If the file contains malformed YAML.
     '''
 
-    if not path.exists():
+    if not path.is_file():
         msg = f'Manifest file not found: {path}'
         raise FileNotFoundError(msg)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.10"
-dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0"]
+dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0", "pyyaml>=6.0"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,10 @@ no_implicit_optional = true
 module = ["msgpack", "msgpack.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["yaml", "yaml.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.17.0"
+version = "0.18.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -445,7 +445,7 @@ class TestManifest:
 def _write_yaml(path: Path, content: str) -> None:
     '''Write YAML content to a file.'''
 
-    path.write_text(content)
+    path.write_text(content, encoding='utf-8')
 
 
 def _write_strategy_file(base: Path, rel_path: str, content: str = '') -> None:
@@ -453,7 +453,7 @@ def _write_strategy_file(base: Path, rel_path: str, content: str = '') -> None:
 
     file_path = base / rel_path
     file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(content or '# Strategy file\n')
+    file_path.write_text(content or '# Strategy file\n', encoding='utf-8')
 
 
 class TestLoadManifest:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import tempfile
 from decimal import Decimal
+from pathlib import Path
 
 import pytest
 
-from nexus.infrastructure.manifest import Manifest, StrategySpec
+from nexus.infrastructure.manifest import Manifest, StrategySpec, load_manifest
 
 
 class TestStrategySpec:
@@ -18,13 +20,13 @@ class TestStrategySpec:
         spec = StrategySpec(
             strategy_id='momentum_v1',
             file='strategies/momentum.py',
-            predictor_fn_ids=('cohort_alpha_v3', 'sensor_volatility'),
+            permutation_ids=('cohort_alpha_v3', 'sensor_volatility'),
             capital_pct=Decimal('25'),
         )
 
         assert spec.strategy_id == 'momentum_v1'
         assert spec.file == 'strategies/momentum.py'
-        assert spec.predictor_fn_ids == ('cohort_alpha_v3', 'sensor_volatility')
+        assert spec.permutation_ids == ('cohort_alpha_v3', 'sensor_volatility')
         assert spec.capital_pct == Decimal('25')
 
     def test_strategy_spec_is_frozen(self) -> None:
@@ -33,7 +35,7 @@ class TestStrategySpec:
         spec = StrategySpec(
             strategy_id='test',
             file='test.py',
-            predictor_fn_ids=('pred1',),
+            permutation_ids=('pred1',),
             capital_pct=Decimal('10'),
         )
 
@@ -47,7 +49,7 @@ class TestStrategySpec:
             StrategySpec(
                 strategy_id='',
                 file='test.py',
-                predictor_fn_ids=('pred1',),
+                permutation_ids=('pred1',),
                 capital_pct=Decimal('10'),
             )
 
@@ -58,7 +60,7 @@ class TestStrategySpec:
             StrategySpec(
                 strategy_id='   ',
                 file='test.py',
-                predictor_fn_ids=('pred1',),
+                permutation_ids=('pred1',),
                 capital_pct=Decimal('10'),
             )
 
@@ -69,7 +71,7 @@ class TestStrategySpec:
             StrategySpec(
                 strategy_id='test',
                 file='',
-                predictor_fn_ids=('pred1',),
+                permutation_ids=('pred1',),
                 capital_pct=Decimal('10'),
             )
 
@@ -80,62 +82,62 @@ class TestStrategySpec:
             StrategySpec(
                 strategy_id='test',
                 file='  ',
-                predictor_fn_ids=('pred1',),
+                permutation_ids=('pred1',),
                 capital_pct=Decimal('10'),
             )
 
-    def test_empty_predictor_fn_ids_raises(self) -> None:
-        '''Empty predictor_fn_ids raises ValueError.'''
+    def test_empty_permutation_ids_raises(self) -> None:
+        '''Empty permutation_ids raises ValueError.'''
 
-        with pytest.raises(ValueError, match='predictor_fn_ids must be a non-empty tuple'):
+        with pytest.raises(ValueError, match='permutation_ids must be a non-empty tuple'):
             StrategySpec(
                 strategy_id='test',
                 file='test.py',
-                predictor_fn_ids=(),
+                permutation_ids=(),
                 capital_pct=Decimal('10'),
             )
 
-    def test_predictor_fn_ids_not_tuple_raises(self) -> None:
-        '''Non-tuple predictor_fn_ids raises ValueError.'''
+    def test_permutation_ids_not_tuple_raises(self) -> None:
+        '''Non-tuple permutation_ids raises ValueError.'''
 
-        with pytest.raises(ValueError, match='predictor_fn_ids must be a non-empty tuple'):
+        with pytest.raises(ValueError, match='permutation_ids must be a non-empty tuple'):
             StrategySpec(
                 strategy_id='test',
                 file='test.py',
-                predictor_fn_ids=['pred1'],  # type: ignore[arg-type]
+                permutation_ids=['pred1'],  # type: ignore[arg-type]
                 capital_pct=Decimal('10'),
             )
 
-    def test_predictor_fn_ids_with_empty_string_raises(self) -> None:
-        '''predictor_fn_ids containing empty string raises ValueError.'''
+    def test_permutation_ids_with_empty_string_raises(self) -> None:
+        '''permutation_ids containing empty string raises ValueError.'''
 
-        with pytest.raises(ValueError, match='predictor_fn_ids must contain non-empty strings'):
+        with pytest.raises(ValueError, match='permutation_ids must contain non-empty strings'):
             StrategySpec(
                 strategy_id='test',
                 file='test.py',
-                predictor_fn_ids=('pred1', ''),
+                permutation_ids=('pred1', ''),
                 capital_pct=Decimal('10'),
             )
 
-    def test_predictor_fn_ids_with_whitespace_raises(self) -> None:
-        '''predictor_fn_ids containing whitespace-only string raises ValueError.'''
+    def test_permutation_ids_with_whitespace_raises(self) -> None:
+        '''permutation_ids containing whitespace-only string raises ValueError.'''
 
-        with pytest.raises(ValueError, match='predictor_fn_ids must contain non-empty strings'):
+        with pytest.raises(ValueError, match='permutation_ids must contain non-empty strings'):
             StrategySpec(
                 strategy_id='test',
                 file='test.py',
-                predictor_fn_ids=('pred1', '   '),
+                permutation_ids=('pred1', '   '),
                 capital_pct=Decimal('10'),
             )
 
-    def test_predictor_fn_ids_with_non_string_raises(self) -> None:
-        '''predictor_fn_ids containing non-string raises ValueError.'''
+    def test_permutation_ids_with_non_string_raises(self) -> None:
+        '''permutation_ids containing non-string raises ValueError.'''
 
-        with pytest.raises(ValueError, match='predictor_fn_ids must contain non-empty strings'):
+        with pytest.raises(ValueError, match='permutation_ids must contain non-empty strings'):
             StrategySpec(
                 strategy_id='test',
                 file='test.py',
-                predictor_fn_ids=('pred1', 123),  # type: ignore[arg-type]
+                permutation_ids=('pred1', 123),  # type: ignore[arg-type]
                 capital_pct=Decimal('10'),
             )
 
@@ -146,7 +148,7 @@ class TestStrategySpec:
             StrategySpec(
                 strategy_id='test',
                 file='test.py',
-                predictor_fn_ids=('pred1',),
+                permutation_ids=('pred1',),
                 capital_pct=25,  # type: ignore[arg-type]
             )
 
@@ -157,7 +159,7 @@ class TestStrategySpec:
             StrategySpec(
                 strategy_id='test',
                 file='test.py',
-                predictor_fn_ids=('pred1',),
+                permutation_ids=('pred1',),
                 capital_pct=Decimal('inf'),
             )
 
@@ -168,7 +170,7 @@ class TestStrategySpec:
             StrategySpec(
                 strategy_id='test',
                 file='test.py',
-                predictor_fn_ids=('pred1',),
+                permutation_ids=('pred1',),
                 capital_pct=Decimal('nan'),
             )
 
@@ -179,7 +181,7 @@ class TestStrategySpec:
             StrategySpec(
                 strategy_id='test',
                 file='test.py',
-                predictor_fn_ids=('pred1',),
+                permutation_ids=('pred1',),
                 capital_pct=Decimal('0'),
             )
 
@@ -190,7 +192,7 @@ class TestStrategySpec:
             StrategySpec(
                 strategy_id='test',
                 file='test.py',
-                predictor_fn_ids=('pred1',),
+                permutation_ids=('pred1',),
                 capital_pct=Decimal('-5'),
             )
 
@@ -201,7 +203,7 @@ class TestStrategySpec:
             StrategySpec(
                 strategy_id='test',
                 file='test.py',
-                predictor_fn_ids=('pred1',),
+                permutation_ids=('pred1',),
                 capital_pct=Decimal('101'),
             )
 
@@ -211,7 +213,7 @@ class TestStrategySpec:
         spec = StrategySpec(
             strategy_id='test',
             file='test.py',
-            predictor_fn_ids=('pred1',),
+            permutation_ids=('pred1',),
             capital_pct=Decimal('100'),
         )
 
@@ -223,7 +225,7 @@ class TestStrategySpec:
         spec = StrategySpec(
             strategy_id='test',
             file='test.py',
-            predictor_fn_ids=('pred1',),
+            permutation_ids=('pred1',),
             capital_pct=Decimal('12.5'),
         )
 
@@ -235,23 +237,23 @@ class TestStrategySpec:
         spec = StrategySpec(
             strategy_id='test',
             file='test.py',
-            predictor_fn_ids=('single_pred',),
+            permutation_ids=('single_pred',),
             capital_pct=Decimal('50'),
         )
 
-        assert spec.predictor_fn_ids == ('single_pred',)
+        assert spec.permutation_ids == ('single_pred',)
 
-    def test_multiple_predictor_fn_ids_allowed(self) -> None:
-        '''Multiple predictor_fn_ids are allowed.'''
+    def test_multiple_permutation_ids_allowed(self) -> None:
+        '''Multiple permutation_ids are allowed.'''
 
         spec = StrategySpec(
             strategy_id='test',
             file='test.py',
-            predictor_fn_ids=('pred1', 'pred2', 'pred3'),
+            permutation_ids=('pred1', 'pred2', 'pred3'),
             capital_pct=Decimal('50'),
         )
 
-        assert spec.predictor_fn_ids == ('pred1', 'pred2', 'pred3')
+        assert spec.permutation_ids == ('pred1', 'pred2', 'pred3')
 
 
 def _make_spec(
@@ -263,7 +265,7 @@ def _make_spec(
     return StrategySpec(
         strategy_id=strategy_id,
         file='test.py',
-        predictor_fn_ids=('pred1',),
+        permutation_ids=('pred1',),
         capital_pct=capital_pct,
     )
 
@@ -427,3 +429,319 @@ class TestManifest:
         )
 
         assert len(manifest.strategies) == 1
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    '''Write YAML content to a file.'''
+
+    path.write_text(content)
+
+
+def _write_strategy_file(base: Path, rel_path: str, content: str = '') -> None:
+    '''Create a strategy .py file.'''
+
+    file_path = base / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content or '# Strategy file\n')
+
+
+class TestLoadManifest:
+    '''Tests for load_manifest function.'''
+
+    def test_valid_manifest_loads(self) -> None:
+        '''Valid YAML manifest loads successfully.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            path = tmp_path / 'manifest.yaml'
+
+            _write_strategy_file(tmp_path, 'strategies/momentum.py')
+            _write_strategy_file(tmp_path, 'strategies/mean_rev.py')
+
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: momentum
+    file: strategies/momentum.py
+    permutation_ids:
+      - alpha_v1
+    capital_pct: 60
+  - id: mean_rev
+    file: strategies/mean_rev.py
+    permutation_ids:
+      - sensor_vol
+    capital_pct: 40
+''',
+            )
+
+            manifest = load_manifest(path, Decimal('20000'))
+
+            assert manifest.capital_pool == Decimal('10000')
+            assert len(manifest.strategies) == 2
+            assert manifest.strategies[0].strategy_id == 'momentum'
+            assert manifest.strategies[1].strategy_id == 'mean_rev'
+
+    def test_file_not_found_raises(self) -> None:
+        '''Missing manifest file raises FileNotFoundError.'''
+
+        with pytest.raises(FileNotFoundError, match='Manifest file not found'):
+            load_manifest(Path('/nonexistent/manifest.yaml'), Decimal('10000'))
+
+    def test_capital_pool_exceeds_allocated_raises(self) -> None:
+        '''capital_pool > allocated_capital raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 15000
+strategies:
+  - id: test
+    file: test.py
+    permutation_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='exceeds allocated_capital'):
+                load_manifest(path, Decimal('10000'))
+
+    def test_missing_capital_pool_raises(self) -> None:
+        '''Missing capital_pool raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+strategies:
+  - id: test
+    file: test.py
+    permutation_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing required field: capital_pool'):
+                load_manifest(path, Decimal('10000'))
+
+    def test_missing_strategies_raises(self) -> None:
+        '''Missing strategies raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(path, 'capital_pool: 10000\n')
+
+            with pytest.raises(ValueError, match='missing or empty strategies'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_empty_strategies_raises(self) -> None:
+        '''Empty strategies list raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies: []
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing or empty strategies'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_missing_id_raises(self) -> None:
+        '''Strategy missing id raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - file: test.py
+    permutation_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing required field: id'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_missing_file_raises(self) -> None:
+        '''Strategy missing file raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: test
+    permutation_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing required field: file'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_missing_permutation_ids_raises(self) -> None:
+        '''Strategy missing permutation_ids raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: test
+    file: test.py
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing or empty permutation_ids'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_missing_capital_pct_raises(self) -> None:
+        '''Strategy missing capital_pct raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: test
+    file: test.py
+    permutation_ids: [pred1]
+''',
+            )
+
+            with pytest.raises(ValueError, match='missing required field: capital_pct'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_malformed_yaml_raises(self) -> None:
+        '''Malformed YAML raises yaml.YAMLError.'''
+
+        import yaml
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(path, 'capital_pool: [unclosed')
+
+            with pytest.raises(yaml.YAMLError):
+                load_manifest(path, Decimal('20000'))
+
+    def test_non_mapping_yaml_raises(self) -> None:
+        '''Non-mapping YAML raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(path, '- item1\n- item2\n')
+
+            with pytest.raises(ValueError, match='must be a YAML mapping'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_duplicate_strategy_id_raises(self) -> None:
+        '''Duplicate strategy_id raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: same
+    file: test1.py
+    permutation_ids: [pred1]
+    capital_pct: 50
+  - id: same
+    file: test2.py
+    permutation_ids: [pred2]
+    capital_pct: 50
+''',
+            )
+
+            with pytest.raises(ValueError, match='duplicate strategy_id'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_capital_pct_sum_over_100_raises(self) -> None:
+        '''capital_pct sum > 100 raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: a
+    file: a.py
+    permutation_ids: [pred1]
+    capital_pct: 60
+  - id: b
+    file: b.py
+    permutation_ids: [pred2]
+    capital_pct: 50
+''',
+            )
+
+            with pytest.raises(ValueError, match='exceeds 100'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_file_not_found_raises(self) -> None:
+        '''Missing strategy .py file raises ValueError with path.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            path = tmp_path / 'manifest.yaml'
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: missing_file
+    file: nonexistent/strategy.py
+    permutation_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match=r"file not found.*nonexistent/strategy\.py"):
+                load_manifest(path, Decimal('20000'))
+
+    def test_strategy_file_syntax_error_raises(self) -> None:
+        '''Invalid Python syntax in strategy file raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            path = tmp_path / 'manifest.yaml'
+
+            strategy_file = tmp_path / 'bad_syntax.py'
+            strategy_file.write_text('def broken(\n')
+
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: bad_syntax
+    file: bad_syntax.py
+    permutation_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match=r'syntax error.*bad_syntax\.py'):
+                load_manifest(path, Decimal('20000'))

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,429 @@
+'''Tests for manifest loading and validation.'''
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from nexus.infrastructure.manifest import Manifest, StrategySpec
+
+
+class TestStrategySpec:
+    '''Tests for StrategySpec dataclass.'''
+
+    def test_valid_strategy_spec(self) -> None:
+        '''Valid StrategySpec creates successfully.'''
+
+        spec = StrategySpec(
+            strategy_id='momentum_v1',
+            file='strategies/momentum.py',
+            predictor_fn_ids=('cohort_alpha_v3', 'sensor_volatility'),
+            capital_pct=Decimal('25'),
+        )
+
+        assert spec.strategy_id == 'momentum_v1'
+        assert spec.file == 'strategies/momentum.py'
+        assert spec.predictor_fn_ids == ('cohort_alpha_v3', 'sensor_volatility')
+        assert spec.capital_pct == Decimal('25')
+
+    def test_strategy_spec_is_frozen(self) -> None:
+        '''StrategySpec is immutable.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            predictor_fn_ids=('pred1',),
+            capital_pct=Decimal('10'),
+        )
+
+        with pytest.raises(AttributeError):
+            spec.strategy_id = 'changed'  # type: ignore[misc]
+
+    def test_empty_strategy_id_raises(self) -> None:
+        '''Empty strategy_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategy_id must be a non-empty string'):
+            StrategySpec(
+                strategy_id='',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_whitespace_strategy_id_raises(self) -> None:
+        '''Whitespace-only strategy_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategy_id must be a non-empty string'):
+            StrategySpec(
+                strategy_id='   ',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_empty_file_raises(self) -> None:
+        '''Empty file raises ValueError.'''
+
+        with pytest.raises(ValueError, match='file must be a non-empty string'):
+            StrategySpec(
+                strategy_id='test',
+                file='',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_whitespace_file_raises(self) -> None:
+        '''Whitespace-only file raises ValueError.'''
+
+        with pytest.raises(ValueError, match='file must be a non-empty string'):
+            StrategySpec(
+                strategy_id='test',
+                file='  ',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_empty_predictor_fn_ids_raises(self) -> None:
+        '''Empty predictor_fn_ids raises ValueError.'''
+
+        with pytest.raises(ValueError, match='predictor_fn_ids must be a non-empty tuple'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=(),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_predictor_fn_ids_not_tuple_raises(self) -> None:
+        '''Non-tuple predictor_fn_ids raises ValueError.'''
+
+        with pytest.raises(ValueError, match='predictor_fn_ids must be a non-empty tuple'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=['pred1'],  # type: ignore[arg-type]
+                capital_pct=Decimal('10'),
+            )
+
+    def test_predictor_fn_ids_with_empty_string_raises(self) -> None:
+        '''predictor_fn_ids containing empty string raises ValueError.'''
+
+        with pytest.raises(ValueError, match='predictor_fn_ids must contain non-empty strings'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1', ''),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_predictor_fn_ids_with_whitespace_raises(self) -> None:
+        '''predictor_fn_ids containing whitespace-only string raises ValueError.'''
+
+        with pytest.raises(ValueError, match='predictor_fn_ids must contain non-empty strings'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1', '   '),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_predictor_fn_ids_with_non_string_raises(self) -> None:
+        '''predictor_fn_ids containing non-string raises ValueError.'''
+
+        with pytest.raises(ValueError, match='predictor_fn_ids must contain non-empty strings'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1', 123),  # type: ignore[arg-type]
+                capital_pct=Decimal('10'),
+            )
+
+    def test_non_decimal_capital_pct_raises(self) -> None:
+        '''Non-Decimal capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=25,  # type: ignore[arg-type]
+            )
+
+    def test_infinite_capital_pct_raises(self) -> None:
+        '''Infinite capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('inf'),
+            )
+
+    def test_nan_capital_pct_raises(self) -> None:
+        '''NaN capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('nan'),
+            )
+
+    def test_zero_capital_pct_raises(self) -> None:
+        '''Zero capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be in'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('0'),
+            )
+
+    def test_negative_capital_pct_raises(self) -> None:
+        '''Negative capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be in'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('-5'),
+            )
+
+    def test_capital_pct_over_100_raises(self) -> None:
+        '''capital_pct > 100 raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be in'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                predictor_fn_ids=('pred1',),
+                capital_pct=Decimal('101'),
+            )
+
+    def test_capital_pct_exactly_100_allowed(self) -> None:
+        '''capital_pct of exactly 100 is allowed.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            predictor_fn_ids=('pred1',),
+            capital_pct=Decimal('100'),
+        )
+
+        assert spec.capital_pct == Decimal('100')
+
+    def test_capital_pct_fractional_allowed(self) -> None:
+        '''Fractional capital_pct is allowed.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            predictor_fn_ids=('pred1',),
+            capital_pct=Decimal('12.5'),
+        )
+
+        assert spec.capital_pct == Decimal('12.5')
+
+    def test_single_predictor_fn_allowed(self) -> None:
+        '''Single predictor_fn in tuple is allowed.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            predictor_fn_ids=('single_pred',),
+            capital_pct=Decimal('50'),
+        )
+
+        assert spec.predictor_fn_ids == ('single_pred',)
+
+    def test_multiple_predictor_fn_ids_allowed(self) -> None:
+        '''Multiple predictor_fn_ids are allowed.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            predictor_fn_ids=('pred1', 'pred2', 'pred3'),
+            capital_pct=Decimal('50'),
+        )
+
+        assert spec.predictor_fn_ids == ('pred1', 'pred2', 'pred3')
+
+
+def _make_spec(
+    strategy_id: str = 'test',
+    capital_pct: Decimal = Decimal('50'),
+) -> StrategySpec:
+    '''Create a valid StrategySpec for testing.'''
+
+    return StrategySpec(
+        strategy_id=strategy_id,
+        file='test.py',
+        predictor_fn_ids=('pred1',),
+        capital_pct=capital_pct,
+    )
+
+
+class TestManifest:
+    '''Tests for Manifest dataclass.'''
+
+    def test_valid_manifest(self) -> None:
+        '''Valid Manifest creates successfully.'''
+
+        spec1 = _make_spec('strategy_a', Decimal('60'))
+        spec2 = _make_spec('strategy_b', Decimal('40'))
+
+        manifest = Manifest(
+            capital_pool=Decimal('10000'),
+            strategies=(spec1, spec2),
+        )
+
+        assert manifest.capital_pool == Decimal('10000')
+        assert manifest.strategies == (spec1, spec2)
+
+    def test_manifest_is_frozen(self) -> None:
+        '''Manifest is immutable.'''
+
+        manifest = Manifest(
+            capital_pool=Decimal('10000'),
+            strategies=(_make_spec(),),
+        )
+
+        with pytest.raises(AttributeError):
+            manifest.capital_pool = Decimal('5000')  # type: ignore[misc]
+
+    def test_non_decimal_capital_pool_raises(self) -> None:
+        '''Non-Decimal capital_pool raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
+            Manifest(
+                capital_pool=10000,  # type: ignore[arg-type]
+                strategies=(_make_spec(),),
+            )
+
+    def test_infinite_capital_pool_raises(self) -> None:
+        '''Infinite capital_pool raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
+            Manifest(
+                capital_pool=Decimal('inf'),
+                strategies=(_make_spec(),),
+            )
+
+    def test_nan_capital_pool_raises(self) -> None:
+        '''NaN capital_pool raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
+            Manifest(
+                capital_pool=Decimal('nan'),
+                strategies=(_make_spec(),),
+            )
+
+    def test_zero_capital_pool_raises(self) -> None:
+        '''Zero capital_pool raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pool must be positive'):
+            Manifest(
+                capital_pool=Decimal('0'),
+                strategies=(_make_spec(),),
+            )
+
+    def test_negative_capital_pool_raises(self) -> None:
+        '''Negative capital_pool raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pool must be positive'):
+            Manifest(
+                capital_pool=Decimal('-1000'),
+                strategies=(_make_spec(),),
+            )
+
+    def test_empty_strategies_raises(self) -> None:
+        '''Empty strategies raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategies must be a non-empty tuple'):
+            Manifest(
+                capital_pool=Decimal('10000'),
+                strategies=(),
+            )
+
+    def test_strategies_not_tuple_raises(self) -> None:
+        '''Non-tuple strategies raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategies must be a non-empty tuple'):
+            Manifest(
+                capital_pool=Decimal('10000'),
+                strategies=[_make_spec()],  # type: ignore[arg-type]
+            )
+
+    def test_strategies_with_non_spec_raises(self) -> None:
+        '''Strategies containing non-StrategySpec raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategies must contain StrategySpec'):
+            Manifest(
+                capital_pool=Decimal('10000'),
+                strategies=(_make_spec(), 'not a spec'),  # type: ignore[arg-type]
+            )
+
+    def test_duplicate_strategy_id_raises(self) -> None:
+        '''Duplicate strategy_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='duplicate strategy_id'):
+            Manifest(
+                capital_pool=Decimal('10000'),
+                strategies=(
+                    _make_spec('same_id', Decimal('50')),
+                    _make_spec('same_id', Decimal('50')),
+                ),
+            )
+
+    def test_capital_pct_sum_over_100_raises(self) -> None:
+        '''capital_pct sum > 100 raises ValueError.'''
+
+        with pytest.raises(ValueError, match=r'capital_pct sum .* exceeds 100'):
+            Manifest(
+                capital_pool=Decimal('10000'),
+                strategies=(
+                    _make_spec('a', Decimal('60')),
+                    _make_spec('b', Decimal('50')),
+                ),
+            )
+
+    def test_capital_pct_sum_exactly_100_allowed(self) -> None:
+        '''capital_pct sum of exactly 100 is allowed.'''
+
+        manifest = Manifest(
+            capital_pool=Decimal('10000'),
+            strategies=(
+                _make_spec('a', Decimal('60')),
+                _make_spec('b', Decimal('40')),
+            ),
+        )
+
+        assert manifest.capital_pool == Decimal('10000')
+
+    def test_capital_pct_sum_under_100_allowed(self) -> None:
+        '''capital_pct sum under 100 is allowed.'''
+
+        manifest = Manifest(
+            capital_pool=Decimal('10000'),
+            strategies=(
+                _make_spec('a', Decimal('30')),
+                _make_spec('b', Decimal('20')),
+            ),
+        )
+
+        assert manifest.capital_pool == Decimal('10000')
+
+    def test_single_strategy_allowed(self) -> None:
+        '''Single strategy in manifest is allowed.'''
+
+        manifest = Manifest(
+            capital_pool=Decimal('10000'),
+            strategies=(_make_spec('only_one', Decimal('100')),),
+        )
+
+        assert len(manifest.strategies) == 1

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -231,8 +231,8 @@ class TestStrategySpec:
 
         assert spec.capital_pct == Decimal('12.5')
 
-    def test_single_predictor_fn_allowed(self) -> None:
-        '''Single predictor_fn in tuple is allowed.'''
+    def test_single_permutation_id_allowed(self) -> None:
+        '''Single permutation_id in tuple is allowed.'''
 
         spec = StrategySpec(
             strategy_id='test',
@@ -744,4 +744,120 @@ strategies:
             )
 
             with pytest.raises(ValueError, match=r'syntax error.*bad_syntax\.py'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_invalid_capital_pool_decimal_raises(self) -> None:
+        '''Non-numeric capital_pool raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            path = tmp_path / 'manifest.yaml'
+
+            _write_strategy_file(tmp_path, 'test.py')
+
+            _write_yaml(
+                path,
+                '''
+capital_pool: not_a_number
+strategies:
+  - id: test
+    file: test.py
+    permutation_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='capital_pool is not a valid number'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_invalid_capital_pct_decimal_raises(self) -> None:
+        '''Non-numeric capital_pct raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            path = tmp_path / 'manifest.yaml'
+
+            _write_strategy_file(tmp_path, 'test.py')
+
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: test
+    file: test.py
+    permutation_ids: [pred1]
+    capital_pct: invalid
+''',
+            )
+
+            with pytest.raises(ValueError, match='capital_pct is not a valid number'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_absolute_file_path_raises(self) -> None:
+        '''Absolute strategy file path raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            path = tmp_path / 'manifest.yaml'
+
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: absolute
+    file: /etc/passwd
+    permutation_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='file must be relative'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_path_traversal_raises(self) -> None:
+        '''Strategy file path escaping base raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            path = tmp_path / 'manifest.yaml'
+
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: escape
+    file: ../../../etc/passwd
+    permutation_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='escapes base path'):
+                load_manifest(path, Decimal('20000'))
+
+    def test_directory_instead_of_file_raises(self) -> None:
+        '''Directory path instead of file raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            path = tmp_path / 'manifest.yaml'
+
+            (tmp_path / 'a_directory').mkdir()
+
+            _write_yaml(
+                path,
+                '''
+capital_pool: 10000
+strategies:
+  - id: dir_not_file
+    file: a_directory
+    permutation_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='file not found'):
                 load_manifest(path, Decimal('20000'))

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -86,6 +86,17 @@ class TestStrategySpec:
                 capital_pct=Decimal('10'),
             )
 
+    def test_padded_whitespace_file_raises(self) -> None:
+        '''File with surrounding whitespace raises ValueError.'''
+
+        with pytest.raises(ValueError, match='file must be a non-empty string without surrounding whitespace'):
+            StrategySpec(
+                strategy_id='test',
+                file=' strategies/foo.py ',
+                permutation_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
     def test_empty_permutation_ids_raises(self) -> None:
         '''Empty permutation_ids raises ValueError.'''
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -509,6 +509,31 @@ strategies:
             with pytest.raises(ValueError, match='exceeds allocated_capital'):
                 load_manifest(path, Decimal('10000'))
 
+    def test_non_finite_allocated_capital_raises(self) -> None:
+        '''Non-finite allocated_capital raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'manifest.yaml'
+            strategy = Path(tmp) / 'test.py'
+            strategy.write_text('pass')
+            _write_yaml(
+                path,
+                '''
+capital_pool: 5000
+strategies:
+  - id: test
+    file: test.py
+    permutation_ids: [pred1]
+    capital_pct: 100
+''',
+            )
+
+            with pytest.raises(ValueError, match='allocated_capital must be a finite'):
+                load_manifest(path, Decimal('NaN'))
+
+            with pytest.raises(ValueError, match='allocated_capital must be a finite'):
+                load_manifest(path, Decimal('Infinity'))
+
     def test_missing_capital_pool_raises(self) -> None:
         '''Missing capital_pool raises ValueError.'''
 


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Manifest loading and validation for strategy configuration (phase 7.1). Adds frozen `StrategySpec` dataclass (strategy_id, file, permutation_ids, capital_pct) and frozen `Manifest` dataclass (capital_pool, strategies tuple). Adds `load_manifest()` to parse YAML manifest files with `allocated_capital` ceiling validation. Adds `_validate_strategy_files()` to verify strategy .py files exist and have valid Python syntax via `ast.parse()`. Adds `pyyaml>=6.0` runtime dependency and mypy override for yaml module. Adds 58 new tests (714 total). Bumps to v0.18.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (714 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable