### PR TITLE
feat: Phase 7.2 - Strategy class instantiation with on_load/on_save lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,3 +178,10 @@
 - Add `_validate_strategy_files()` to verify strategy .py files exist and have valid Python syntax via `ast.parse()`
 - Add `pyyaml>=6.0` runtime dependency and mypy override for yaml module
 - Add 58 tests covering StrategySpec, Manifest, load_manifest parsing, and file validation (714 total)
+
+## v0.19.0 on 31st of March, 2026
+
+- Add [`base.py`](nexus/strategy/base.py) with `Strategy` ABC defining `on_save() → bytes` and `on_load(bytes) → None` lifecycle hooks for state persistence
+- Add [`loader.py`](nexus/strategy/loader.py) with `load_strategy_class()` for dynamic import from .py files and `instantiate_strategy()` for creating Strategy instances from manifest specs
+- Add path traversal prevention and ABC inheritance validation in strategy loader
+- Add 27 tests covering Strategy ABC, on_save/on_load lifecycle, and dynamic loading (742 total)

--- a/nexus/strategy/__init__.py
+++ b/nexus/strategy/__init__.py
@@ -1,0 +1,6 @@
+'''Strategy layer for user-defined trading logic.'''
+
+from nexus.strategy.base import Strategy
+from nexus.strategy.loader import instantiate_strategy, load_strategy_class
+
+__all__ = ['Strategy', 'instantiate_strategy', 'load_strategy_class']

--- a/nexus/strategy/base.py
+++ b/nexus/strategy/base.py
@@ -1,0 +1,57 @@
+'''Abstract base class for trading strategies.
+
+Defines the contract that all concrete strategies must implement,
+including state persistence lifecycle hooks.
+'''
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class Strategy(ABC):
+    '''Abstract base class for trading strategies.
+
+    Concrete strategies inherit from this class and implement
+    the required lifecycle methods for state persistence.
+
+    Args:
+        strategy_id: Unique identifier for this strategy instance.
+    '''
+
+    _strategy_id: str
+
+    def __init__(self, strategy_id: str) -> None:
+        if not isinstance(strategy_id, str) or not strategy_id.strip():
+            msg = 'strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        self._strategy_id = strategy_id
+
+    @property
+    def strategy_id(self) -> str:
+        '''Unique identifier for this strategy instance.'''
+
+        return self._strategy_id
+
+    @abstractmethod
+    def on_save(self) -> bytes:
+        '''Serialize strategy state for persistence.
+
+        Called by Strategy Runner for periodic checkpoints and shutdown.
+        The strategy author decides what state to persist.
+
+        Returns:
+            Serialized state as bytes.
+        '''
+
+    @abstractmethod
+    def on_load(self, data: bytes) -> None:
+        '''Restore strategy state from persisted bytes.
+
+        Called by Strategy Runner on startup and crash recovery.
+        The data parameter contains bytes previously returned by on_save().
+
+        Args:
+            data: Serialized state from a prior on_save() call.
+        '''

--- a/nexus/strategy/base.py
+++ b/nexus/strategy/base.py
@@ -22,11 +22,17 @@ class Strategy(ABC):
     _strategy_id: str
 
     def __init__(self, strategy_id: str) -> None:
-        if not isinstance(strategy_id, str) or not strategy_id.strip():
+        if not isinstance(strategy_id, str):
             msg = 'strategy_id must be a non-empty string'
             raise ValueError(msg)
 
-        self._strategy_id = strategy_id
+        normalized = strategy_id.strip()
+
+        if not normalized:
+            msg = 'strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        self._strategy_id = normalized
 
     @property
     def strategy_id(self) -> str:

--- a/nexus/strategy/loader.py
+++ b/nexus/strategy/loader.py
@@ -34,6 +34,9 @@ def instantiate_strategy(spec: StrategySpec, base_path: Path) -> Strategy:
 def load_strategy_class(file_path: Path, base_path: Path) -> type[Strategy]:
     '''Load a Strategy class from a Python file.
 
+    The file must define a class named ``Strategy`` that inherits from
+    the Strategy ABC.
+
     Args:
         file_path: Relative path to the strategy .py file.
         base_path: Base directory for resolving the file path.
@@ -47,6 +50,10 @@ def load_strategy_class(file_path: Path, base_path: Path) -> type[Strategy]:
 
     if file_path.is_absolute():
         msg = f'Strategy file path must be relative: {file_path}'
+        raise ValueError(msg)
+
+    if file_path.suffix != '.py':
+        msg = f'Strategy file must be a .py file: {file_path}'
         raise ValueError(msg)
 
     base_resolved = base_path.resolve()
@@ -96,6 +103,11 @@ def _load_module(path: Path) -> ModuleType:
         raise ValueError(msg)
 
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+
+    try:
+        spec.loader.exec_module(module)
+    except Exception as e:
+        msg = f'Failed to execute strategy module: {path}'
+        raise ValueError(msg) from e
 
     return module

--- a/nexus/strategy/loader.py
+++ b/nexus/strategy/loader.py
@@ -28,7 +28,11 @@ def instantiate_strategy(spec: StrategySpec, base_path: Path) -> Strategy:
 
     strategy_class = load_strategy_class(Path(spec.file), base_path)
 
-    return strategy_class(spec.strategy_id)
+    try:
+        return strategy_class(spec.strategy_id)
+    except Exception as e:
+        msg = f'Failed to instantiate strategy {spec.strategy_id!r}'
+        raise ValueError(msg) from e
 
 
 def load_strategy_class(file_path: Path, base_path: Path) -> type[Strategy]:

--- a/nexus/strategy/loader.py
+++ b/nexus/strategy/loader.py
@@ -1,0 +1,101 @@
+'''Strategy loading and instantiation from manifest specifications.'''
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+from nexus.infrastructure.manifest import StrategySpec
+from nexus.strategy.base import Strategy
+
+__all__ = ['instantiate_strategy', 'load_strategy_class']
+
+
+def instantiate_strategy(spec: StrategySpec, base_path: Path) -> Strategy:
+    '''Load and instantiate a Strategy from a manifest specification.
+
+    Args:
+        spec: Strategy specification from manifest.
+        base_path: Base directory for resolving the strategy file path.
+
+    Returns:
+        Instantiated Strategy with strategy_id from spec.
+
+    Raises:
+        ValueError: If loading or instantiation fails.
+    '''
+
+    strategy_class = load_strategy_class(Path(spec.file), base_path)
+
+    return strategy_class(spec.strategy_id)
+
+
+def load_strategy_class(file_path: Path, base_path: Path) -> type[Strategy]:
+    '''Load a Strategy class from a Python file.
+
+    Args:
+        file_path: Relative path to the strategy .py file.
+        base_path: Base directory for resolving the file path.
+
+    Returns:
+        The Strategy subclass defined in the file.
+
+    Raises:
+        ValueError: If path escapes base, file missing, or invalid Strategy.
+    '''
+
+    if file_path.is_absolute():
+        msg = f'Strategy file path must be relative: {file_path}'
+        raise ValueError(msg)
+
+    base_resolved = base_path.resolve()
+    full_path = (base_resolved / file_path).resolve()
+
+    try:
+        full_path.relative_to(base_resolved)
+    except ValueError as e:
+        msg = f'Strategy file escapes base path: {full_path}'
+        raise ValueError(msg) from e
+
+    if not full_path.is_file():
+        msg = f'Strategy file not found: {full_path}'
+        raise ValueError(msg)
+
+    module = _load_module(full_path)
+
+    if not hasattr(module, 'Strategy'):
+        msg = f'Strategy file missing Strategy class: {full_path}'
+        raise ValueError(msg)
+
+    strategy_class = module.Strategy
+
+    if not isinstance(strategy_class, type):
+        msg = f'Strategy attribute is not a class: {full_path}'
+        raise ValueError(msg)
+
+    if not issubclass(strategy_class, Strategy):
+        msg = f'Strategy class does not inherit from Strategy ABC: {full_path}'
+        raise ValueError(msg)
+
+    if strategy_class is Strategy:
+        msg = f'Strategy file exports the ABC, not a concrete subclass: {full_path}'
+        raise ValueError(msg)
+
+    return strategy_class
+
+
+def _load_module(path: Path) -> ModuleType:
+    '''Load a Python module from a file path.'''
+
+    module_name = path.stem
+    spec = importlib.util.spec_from_file_location(module_name, path)
+
+    if spec is None or spec.loader is None:
+        msg = f'Failed to load module spec: {path}'
+        raise ValueError(msg)
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.18.0"
+version = "0.19.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_strategy_base.py
+++ b/tests/test_strategy_base.py
@@ -1,0 +1,144 @@
+'''Tests for Strategy abstract base class.'''
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.strategy import Strategy
+
+
+class ConcreteStrategy(Strategy):
+    '''Valid concrete strategy for testing.'''
+
+    def __init__(self, strategy_id: str) -> None:
+        super().__init__(strategy_id)
+        self._state: bytes = b''
+
+    def on_save(self) -> bytes:
+        return self._state
+
+    def on_load(self, data: bytes) -> None:
+        self._state = data
+
+
+class TestStrategyABC:
+    '''Tests for Strategy abstract base class.'''
+
+    def test_cannot_instantiate_abc_directly(self) -> None:
+        '''Strategy ABC cannot be instantiated directly.'''
+
+        with pytest.raises(TypeError, match='abstract'):
+            Strategy('test')  # type: ignore[abstract]
+
+    def test_concrete_strategy_instantiates(self) -> None:
+        '''Concrete strategy with all methods instantiates successfully.'''
+
+        strategy = ConcreteStrategy('momentum_v1')
+
+        assert strategy.strategy_id == 'momentum_v1'
+
+    def test_strategy_id_property_returns_id(self) -> None:
+        '''strategy_id property returns the id passed at construction.'''
+
+        strategy = ConcreteStrategy('momentum_btc')
+
+        assert strategy.strategy_id == 'momentum_btc'
+
+    def test_empty_strategy_id_raises(self) -> None:
+        '''Empty strategy_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='non-empty string'):
+            ConcreteStrategy('')
+
+    def test_whitespace_strategy_id_raises(self) -> None:
+        '''Whitespace-only strategy_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='non-empty string'):
+            ConcreteStrategy('   ')
+
+    def test_non_string_strategy_id_raises(self) -> None:
+        '''Non-string strategy_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='non-empty string'):
+            ConcreteStrategy(123)  # type: ignore[arg-type]
+
+
+class TestOnSaveOnLoad:
+    '''Tests for on_save/on_load lifecycle.'''
+
+    def test_on_save_returns_bytes(self) -> None:
+        '''on_save returns bytes.'''
+
+        strategy = ConcreteStrategy('test')
+        strategy._state = b'test state'
+
+        result = strategy.on_save()
+
+        assert result == b'test state'
+        assert isinstance(result, bytes)
+
+    def test_on_load_restores_state(self) -> None:
+        '''on_load restores state from bytes.'''
+
+        strategy = ConcreteStrategy('test')
+
+        strategy.on_load(b'restored state')
+
+        assert strategy._state == b'restored state'
+
+    def test_on_save_on_load_round_trip(self) -> None:
+        '''on_save followed by on_load preserves state.'''
+
+        strategy1 = ConcreteStrategy('test')
+        strategy1._state = b'important data'
+
+        saved = strategy1.on_save()
+
+        strategy2 = ConcreteStrategy('test')
+        strategy2.on_load(saved)
+
+        assert strategy2._state == strategy1._state
+
+    def test_on_save_on_load_empty_bytes(self) -> None:
+        '''on_save/on_load handle empty bytes.'''
+
+        strategy = ConcreteStrategy('test')
+        strategy._state = b''
+
+        saved = strategy.on_save()
+
+        assert saved == b''
+
+        strategy.on_load(b'')
+
+        assert strategy._state == b''
+
+
+class MissingOnSaveStrategy(Strategy):
+    '''Strategy missing on_save implementation.'''
+
+    def on_load(self, data: bytes) -> None:
+        pass
+
+
+class MissingOnLoadStrategy(Strategy):
+    '''Strategy missing on_load implementation.'''
+
+    def on_save(self) -> bytes:
+        return b''
+
+
+class TestMissingMethods:
+    '''Tests for strategies missing required methods.'''
+
+    def test_missing_on_save_raises(self) -> None:
+        '''Strategy missing on_save cannot be instantiated.'''
+
+        with pytest.raises(TypeError, match='abstract'):
+            MissingOnSaveStrategy('test')  # type: ignore[abstract]
+
+    def test_missing_on_load_raises(self) -> None:
+        '''Strategy missing on_load cannot be instantiated.'''
+
+        with pytest.raises(TypeError, match='abstract'):
+            MissingOnLoadStrategy('test')  # type: ignore[abstract]

--- a/tests/test_strategy_base.py
+++ b/tests/test_strategy_base.py
@@ -56,6 +56,13 @@ class TestStrategyABC:
         with pytest.raises(ValueError, match='non-empty string'):
             ConcreteStrategy('   ')
 
+    def test_strategy_id_normalized(self) -> None:
+        '''strategy_id is stripped of leading/trailing whitespace.'''
+
+        strategy = ConcreteStrategy('  momentum_v1  ')
+
+        assert strategy.strategy_id == 'momentum_v1'
+
     def test_non_string_strategy_id_raises(self) -> None:
         '''Non-string strategy_id raises ValueError.'''
 

--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -1,0 +1,265 @@
+'''Tests for strategy loader.'''
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from decimal import Decimal
+
+from nexus.infrastructure.manifest import StrategySpec
+from nexus.strategy import Strategy
+from nexus.strategy.loader import instantiate_strategy, load_strategy_class
+
+
+def _write_strategy_file(base: Path, rel_path: str, content: str) -> None:
+    '''Create a strategy .py file.'''
+
+    file_path = base / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content, encoding='utf-8')
+
+
+VALID_STRATEGY = '''
+from nexus.strategy import Strategy
+
+class Strategy(Strategy):
+    def on_save(self) -> bytes:
+        return b''
+
+    def on_load(self, data: bytes) -> None:
+        pass
+'''
+
+MISSING_ON_SAVE = '''
+from nexus.strategy import Strategy as BaseStrategy
+
+class Strategy(BaseStrategy):
+    def on_load(self, data: bytes) -> None:
+        pass
+'''
+
+MISSING_STRATEGY_CLASS = '''
+class SomeOtherClass:
+    pass
+'''
+
+NOT_A_CLASS = '''
+Strategy = "not a class"
+'''
+
+EXPORTS_ABC = '''
+from nexus.strategy import Strategy
+'''
+
+NOT_SUBCLASS = '''
+class Strategy:
+    def on_save(self) -> bytes:
+        return b''
+
+    def on_load(self, data: bytes) -> None:
+        pass
+'''
+
+
+class TestLoadStrategyClass:
+    '''Tests for load_strategy_class function.'''
+
+    def test_loads_valid_strategy(self) -> None:
+        '''Valid strategy file loads successfully.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'strategies/momentum.py', VALID_STRATEGY)
+
+            strategy_class = load_strategy_class(
+                Path('strategies/momentum.py'),
+                tmp_path,
+            )
+
+            assert issubclass(strategy_class, Strategy)
+            assert strategy_class is not Strategy
+
+    def test_instantiate_loaded_class(self) -> None:
+        '''Loaded strategy class can be instantiated.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'strategies/momentum.py', VALID_STRATEGY)
+
+            strategy_class = load_strategy_class(
+                Path('strategies/momentum.py'),
+                tmp_path,
+            )
+
+            instance = strategy_class('test_id')
+
+            assert instance.strategy_id == 'test_id'
+            assert instance.on_save() == b''
+
+    def test_absolute_path_raises(self) -> None:
+        '''Absolute file path raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            with pytest.raises(ValueError, match='must be relative'):
+                load_strategy_class(Path('/absolute/path.py'), tmp_path)
+
+    def test_path_traversal_raises(self) -> None:
+        '''Path traversal attempt raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'strategies/momentum.py', VALID_STRATEGY)
+
+            with pytest.raises(ValueError, match='escapes base path'):
+                load_strategy_class(Path('../outside.py'), tmp_path)
+
+    def test_file_not_found_raises(self) -> None:
+        '''Missing file raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            with pytest.raises(ValueError, match='not found'):
+                load_strategy_class(Path('missing.py'), tmp_path)
+
+    def test_missing_strategy_class_raises(self) -> None:
+        '''File without Strategy class raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'bad.py', MISSING_STRATEGY_CLASS)
+
+            with pytest.raises(ValueError, match='missing Strategy class'):
+                load_strategy_class(Path('bad.py'), tmp_path)
+
+    def test_strategy_not_a_class_raises(self) -> None:
+        '''Strategy attribute that is not a class raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'bad.py', NOT_A_CLASS)
+
+            with pytest.raises(ValueError, match='not a class'):
+                load_strategy_class(Path('bad.py'), tmp_path)
+
+    def test_strategy_not_subclass_raises(self) -> None:
+        '''Strategy class not inheriting ABC raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'bad.py', NOT_SUBCLASS)
+
+            with pytest.raises(ValueError, match='does not inherit'):
+                load_strategy_class(Path('bad.py'), tmp_path)
+
+    def test_exports_abc_raises(self) -> None:
+        '''File that exports the ABC itself raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'bad.py', EXPORTS_ABC)
+
+            with pytest.raises(ValueError, match='exports the ABC'):
+                load_strategy_class(Path('bad.py'), tmp_path)
+
+    def test_missing_abstract_method_raises_on_instantiate(self) -> None:
+        '''Strategy missing abstract method raises TypeError on instantiation.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'bad.py', MISSING_ON_SAVE)
+
+            strategy_class = load_strategy_class(Path('bad.py'), tmp_path)
+
+            with pytest.raises(TypeError, match='abstract'):
+                strategy_class('test')  # type: ignore[abstract]
+
+    def test_nested_path_loads(self) -> None:
+        '''Nested directory path loads successfully.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(
+                tmp_path,
+                'strategies/btc/momentum_v2.py',
+                VALID_STRATEGY,
+            )
+
+            strategy_class = load_strategy_class(
+                Path('strategies/btc/momentum_v2.py'),
+                tmp_path,
+            )
+
+            assert issubclass(strategy_class, Strategy)
+
+
+def _make_spec(
+    strategy_id: str = 'test_strategy',
+    file: str = 'strategies/momentum.py',
+) -> StrategySpec:
+    '''Create a StrategySpec for testing.'''
+
+    return StrategySpec(
+        strategy_id=strategy_id,
+        file=file,
+        permutation_ids=('pred1',),
+        capital_pct=Decimal('50'),
+    )
+
+
+class TestInstantiateStrategy:
+    '''Tests for instantiate_strategy function.'''
+
+    def test_instantiates_from_spec(self) -> None:
+        '''instantiate_strategy returns working Strategy instance.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'strategies/momentum.py', VALID_STRATEGY)
+
+            spec = _make_spec('momentum_v1', 'strategies/momentum.py')
+            strategy = instantiate_strategy(spec, tmp_path)
+
+            assert isinstance(strategy, Strategy)
+            assert strategy.strategy_id == 'momentum_v1'
+
+    def test_strategy_id_matches_spec(self) -> None:
+        '''Instantiated strategy has strategy_id from spec.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'my_strategy.py', VALID_STRATEGY)
+
+            spec = _make_spec('custom_id_123', 'my_strategy.py')
+            strategy = instantiate_strategy(spec, tmp_path)
+
+            assert strategy.strategy_id == 'custom_id_123'
+
+    def test_on_save_on_load_work(self) -> None:
+        '''Instantiated strategy has working on_save/on_load.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'strat.py', VALID_STRATEGY)
+
+            spec = _make_spec(file='strat.py')
+            strategy = instantiate_strategy(spec, tmp_path)
+
+            assert strategy.on_save() == b''
+            strategy.on_load(b'data')
+
+    def test_invalid_file_raises(self) -> None:
+        '''instantiate_strategy with missing file raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            spec = _make_spec(file='missing.py')
+
+            with pytest.raises(ValueError, match='not found'):
+                instantiate_strategy(spec, tmp_path)

--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -63,6 +63,10 @@ class Strategy:
         pass
 '''
 
+RUNTIME_ERROR = '''
+import nonexistent_module
+'''
+
 
 class TestLoadStrategyClass:
     '''Tests for load_strategy_class function.'''
@@ -196,6 +200,25 @@ class TestLoadStrategyClass:
             )
 
             assert issubclass(strategy_class, Strategy)
+
+    def test_non_py_suffix_raises(self) -> None:
+        '''Non-.py file suffix raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            with pytest.raises(ValueError, match=r'must be a \.py file'):
+                load_strategy_class(Path('strategy.txt'), tmp_path)
+
+    def test_runtime_error_raises_valueerror(self) -> None:
+        '''Runtime error in strategy module raises ValueError.'''
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _write_strategy_file(tmp_path, 'bad.py', RUNTIME_ERROR)
+
+            with pytest.raises(ValueError, match='Failed to execute'):
+                load_strategy_class(Path('bad.py'), tmp_path)
 
 
 def _make_spec(

--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import tempfile
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
-
-from decimal import Decimal
 
 from nexus.infrastructure.manifest import StrategySpec
 from nexus.strategy import Strategy


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Strategy class instantiation with on_load/on_save lifecycle (phase 7.2). Adds `Strategy` ABC in `nexus/strategy/base.py` defining `on_save() → bytes` and `on_load(bytes) → None` lifecycle hooks for state persistence. Adds `load_strategy_class()` in `nexus/strategy/loader.py` for dynamic import from .py files with path traversal prevention and ABC inheritance validation. Adds `instantiate_strategy()` to create Strategy instances from manifest specs. Wires `nexus/strategy/__init__.py` public API exports. Adds 27 new tests (12 base, 15 loader). Bumps to v0.19.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (742 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable