### PR TITLE
feat: 7.3 event dispatch types and Strategy callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,3 +185,13 @@
 - Add [`loader.py`](nexus/strategy/loader.py) with `load_strategy_class()` for dynamic import from .py files and `instantiate_strategy()` for creating Strategy instances from manifest specs
 - Add path traversal prevention and ABC inheritance validation in strategy loader
 - Add 27 tests covering Strategy ABC, on_save/on_load lifecycle, and dynamic loading (742 total)
+
+## v0.20.0 on 1st of April, 2026
+
+- Add [`params.py`](nexus/strategy/params.py) with `StrategyParams` frozen dataclass wrapping manifest parameters
+- Add [`signal.py`](nexus/strategy/signal.py) with `Signal` frozen dataclass for predictor function output (predictor_fn_id, values dict, timestamp)
+- Add [`action.py`](nexus/strategy/action.py) with `ActionType` enum (ENTER, EXIT, MODIFY, ABORT) and `Action` frozen dataclass
+- Add [`context.py`](nexus/strategy/context.py) with `StrategyContext` frozen dataclass (positions, capital_available, operational_mode)
+- Extend `Strategy` ABC with five event callbacks: `on_startup`, `on_signal`, `on_outcome`, `on_timer`, `on_shutdown`
+- Wire new types in [`nexus/strategy/__init__.py`](nexus/strategy/__init__.py) public API
+- Add 57 tests covering event dispatch types and Strategy callbacks (772 total)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -50,3 +50,22 @@ Several lifecycle methods return `False` for failure paths (for example, missing
 - Keep soft-failure behavior for expected misses and add strict reason taxonomy.
 - Convert invariant-breach paths to hard-failure exceptions.
 - Standardize on explicit result types (`ok`, `reason_code`, `message`, `context`) instead of bare booleans.
+
+---
+
+## TD-004: All timestamps must be UTC
+
+**Origin**: 7.3 (event dispatch types)
+**Severity**: High
+**Modules**:
+- `nexus/strategy/signal.py`
+- `nexus/infrastructure/praxis_connector/trade_outcome.py`
+- `nexus/infrastructure/strategy_event.py`
+- `nexus/core/capital_controller/reservation.py`
+- `nexus/core/capital_controller/tracked_order.py`
+- `nexus/infrastructure/praxis_connector/trade_command.py`
+
+Current validation checks for tz-awareness (`tzinfo is not None`) but does not enforce UTC specifically. A timestamp with `tzinfo=+05:00` passes validation but violates the UTC-only convention.
+
+**When to fix**: ASAP
+**Migration**: Replace tz-awareness checks with explicit UTC checks (`timestamp.tzinfo == timezone.utc`).

--- a/nexus/strategy/__init__.py
+++ b/nexus/strategy/__init__.py
@@ -1,6 +1,19 @@
 '''Strategy layer for user-defined trading logic.'''
 
+from nexus.strategy.action import Action, ActionType
 from nexus.strategy.base import Strategy
+from nexus.strategy.context import StrategyContext
 from nexus.strategy.loader import instantiate_strategy, load_strategy_class
+from nexus.strategy.params import StrategyParams
+from nexus.strategy.signal import Signal
 
-__all__ = ['Strategy', 'instantiate_strategy', 'load_strategy_class']
+__all__ = [
+    'Action',
+    'ActionType',
+    'Signal',
+    'Strategy',
+    'StrategyContext',
+    'StrategyParams',
+    'instantiate_strategy',
+    'load_strategy_class',
+]

--- a/nexus/strategy/action.py
+++ b/nexus/strategy/action.py
@@ -1,0 +1,38 @@
+'''Action output from strategy callbacks.'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ActionType(Enum):
+    '''Type of action a strategy can request.
+
+    Args:
+        ENTER: Request to enter a new position.
+        EXIT: Request to exit an existing position.
+        MODIFY: Request to modify an existing position or order.
+        ABORT: Request to abort a pending action.
+    '''
+
+    ENTER = 'enter'
+    EXIT = 'exit'
+    MODIFY = 'modify'
+    ABORT = 'abort'
+
+
+@dataclass(frozen=True)
+class Action:
+    '''Action output from a strategy callback.
+
+    Args:
+        action_type: Type of action requested.
+    '''
+
+    action_type: ActionType
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.action_type, ActionType):
+            msg = 'action_type must be an ActionType'
+            raise ValueError(msg)

--- a/nexus/strategy/base.py
+++ b/nexus/strategy/base.py
@@ -58,6 +58,8 @@ class Strategy(ABC):
             Serialized state as bytes.
         '''
 
+        ...
+
     @abstractmethod
     def on_load(self, data: bytes) -> None:
         '''Restore strategy state from persisted bytes.
@@ -68,6 +70,8 @@ class Strategy(ABC):
         Args:
             data: Serialized state from a prior on_save() call.
         '''
+
+        ...
 
     @abstractmethod
     def on_startup(
@@ -87,6 +91,8 @@ class Strategy(ABC):
         Returns:
             List of actions to execute, or empty list for no action.
         '''
+
+        ...
 
     @abstractmethod
     def on_signal(
@@ -108,6 +114,8 @@ class Strategy(ABC):
             List of actions to execute, or empty list for no action.
         '''
 
+        ...
+
     @abstractmethod
     def on_outcome(
         self,
@@ -127,6 +135,8 @@ class Strategy(ABC):
         Returns:
             List of actions to execute, or empty list for no action.
         '''
+
+        ...
 
     @abstractmethod
     def on_timer(
@@ -148,6 +158,8 @@ class Strategy(ABC):
             List of actions to execute, or empty list for no action.
         '''
 
+        ...
+
     @abstractmethod
     def on_shutdown(
         self,
@@ -166,3 +178,5 @@ class Strategy(ABC):
         Returns:
             List of actions to execute, or empty list for no action.
         '''
+
+        ...

--- a/nexus/strategy/base.py
+++ b/nexus/strategy/base.py
@@ -1,19 +1,26 @@
 '''Abstract base class for trading strategies.
 
 Defines the contract that all concrete strategies must implement,
-including state persistence lifecycle hooks.
+including state persistence lifecycle hooks and event callbacks.
 '''
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.strategy.action import Action
+from nexus.strategy.context import StrategyContext
+from nexus.strategy.params import StrategyParams
+from nexus.strategy.signal import Signal
+
 
 class Strategy(ABC):
     '''Abstract base class for trading strategies.
 
     Concrete strategies inherit from this class and implement
-    the required lifecycle methods for state persistence.
+    the required lifecycle methods for state persistence and
+    event callbacks for signal processing and trade management.
 
     Args:
         strategy_id: Unique identifier for this strategy instance.
@@ -60,4 +67,102 @@ class Strategy(ABC):
 
         Args:
             data: Serialized state from a prior on_save() call.
+        '''
+
+    @abstractmethod
+    def on_startup(
+        self,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Handle strategy startup event.
+
+        Called once when the strategy is first activated. Use for
+        initial position setup or recovery actions.
+
+        Args:
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions to execute, or empty list for no action.
+        '''
+
+    @abstractmethod
+    def on_signal(
+        self,
+        signal: Signal,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Handle incoming signal from predictor function.
+
+        Called when a predictor function produces a signal for this strategy.
+
+        Args:
+            signal: Signal from predictor function.
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions to execute, or empty list for no action.
+        '''
+
+    @abstractmethod
+    def on_outcome(
+        self,
+        outcome: TradeOutcome,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Handle trade execution outcome.
+
+        Called when an execution result arrives for an action this strategy requested.
+
+        Args:
+            outcome: Trade execution result.
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions to execute, or empty list for no action.
+        '''
+
+    @abstractmethod
+    def on_timer(
+        self,
+        timer_id: str,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Handle timer expiration event.
+
+        Called when a registered timer fires.
+
+        Args:
+            timer_id: Identifier of the timer that fired.
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions to execute, or empty list for no action.
+        '''
+
+    @abstractmethod
+    def on_shutdown(
+        self,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Handle strategy shutdown event.
+
+        Called before the strategy is deactivated. Use for cleanup
+        or final position management.
+
+        Args:
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions to execute, or empty list for no action.
         '''

--- a/nexus/strategy/context.py
+++ b/nexus/strategy/context.py
@@ -1,0 +1,50 @@
+'''Strategy context for event callbacks.'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.position import Position
+
+_ZERO = Decimal(0)
+
+
+@dataclass(frozen=True)
+class StrategyContext:
+    '''Context provided to strategy event callbacks.
+
+    Args:
+        positions: Current open positions for this strategy.
+        capital_available: Capital available for new positions in quote asset.
+        operational_mode: Current operational state of the strategy.
+    '''
+
+    positions: tuple[Position, ...]
+    capital_available: Decimal
+    operational_mode: OperationalMode
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if not isinstance(self.positions, tuple):
+            msg = 'positions must be a tuple'
+            raise ValueError(msg)
+
+        for pos in self.positions:
+            if not isinstance(pos, Position):
+                msg = 'positions must contain only Position instances'
+                raise ValueError(msg)
+
+        if not isinstance(self.capital_available, Decimal):
+            msg = 'capital_available must be a Decimal'
+            raise ValueError(msg)
+
+        if not self.capital_available.is_finite() or self.capital_available < _ZERO:
+            msg = 'capital_available must be a finite non-negative value'
+            raise ValueError(msg)
+
+        if not isinstance(self.operational_mode, OperationalMode):
+            msg = 'operational_mode must be an OperationalMode'
+            raise ValueError(msg)

--- a/nexus/strategy/context.py
+++ b/nexus/strategy/context.py
@@ -15,6 +15,10 @@ _ZERO = Decimal(0)
 class StrategyContext:
     '''Context provided to strategy event callbacks.
 
+    NOTE: Position objects are mutable by design (size/unrealized_pnl change).
+    Strategies must not mutate positions; any mutations are unsupported and
+    ignored by the Strategy Runner.
+
     Args:
         positions: Current open positions for this strategy.
         capital_available: Capital available for new positions in quote asset.

--- a/nexus/strategy/params.py
+++ b/nexus/strategy/params.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 
@@ -11,18 +12,23 @@ class StrategyParams:
     '''Strategy parameters from manifest configuration.
 
     Wraps the raw params dict from the manifest, providing typed access
-    to user-defined strategy configuration.
+    to user-defined strategy configuration. The dict is defensively copied
+    and wrapped as immutable at construction.
 
     Args:
-        raw: Raw parameters dict from manifest.
+        raw: Raw parameters dict from manifest (stored as MappingProxyType).
     '''
 
-    raw: dict[str, Any]
+    raw: dict[str, Any] | MappingProxyType[str, Any]
 
     def __post_init__(self) -> None:
+        '''Validate and wrap raw dict as immutable.'''
+
         if not isinstance(self.raw, dict):
             msg = 'raw must be a dict'
             raise ValueError(msg)
+
+        object.__setattr__(self, 'raw', MappingProxyType(dict(self.raw)))
 
     def get(self, key: str, default: Any = None) -> Any:
         '''Get a parameter value by key.

--- a/nexus/strategy/params.py
+++ b/nexus/strategy/params.py
@@ -16,10 +16,10 @@ class StrategyParams:
     and wrapped as immutable at construction.
 
     Args:
-        raw: Raw parameters dict from manifest (stored as MappingProxyType).
+        raw: Raw parameters dict from manifest.
     '''
 
-    raw: dict[str, Any] | MappingProxyType[str, Any]
+    raw: dict[str, Any]
 
     def __post_init__(self) -> None:
         '''Validate and wrap raw dict as immutable.'''

--- a/nexus/strategy/params.py
+++ b/nexus/strategy/params.py
@@ -1,0 +1,38 @@
+'''Strategy parameters from manifest configuration.'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class StrategyParams:
+    '''Strategy parameters from manifest configuration.
+
+    Wraps the raw params dict from the manifest, providing typed access
+    to user-defined strategy configuration.
+
+    Args:
+        raw: Raw parameters dict from manifest.
+    '''
+
+    raw: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.raw, dict):
+            msg = 'raw must be a dict'
+            raise ValueError(msg)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        '''Get a parameter value by key.
+
+        Args:
+            key: Parameter name.
+            default: Value to return if key not found.
+
+        Returns:
+            Parameter value or default.
+        '''
+
+        return self.raw.get(key, default)

--- a/nexus/strategy/signal.py
+++ b/nexus/strategy/signal.py
@@ -16,9 +16,10 @@ class Signal:
 
     Args:
         predictor_fn_id: Identifier of the predictor function that produced this signal.
-        values: Signal values dict. Currently binary (CAN_ENTER=1, NO_PREDICTION=0).
-            Future: confidence scores, directional strength, multi-class signals.
-        timestamp: When the signal was generated.
+        values: Signal values dict. Keys must be strings. Numeric values (int, float,
+            Decimal) must be finite. Common patterns: binary flags (CAN_ENTER=1),
+            confidence scores, directional strength.
+        timestamp: When the signal was generated (must be timezone-aware).
     '''
 
     predictor_fn_id: str

--- a/nexus/strategy/signal.py
+++ b/nexus/strategy/signal.py
@@ -1,0 +1,59 @@
+'''Signal from predictor function.'''
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Signal:
+    '''Signal output from a predictor function.
+
+    Args:
+        predictor_fn_id: Identifier of the predictor function that produced this signal.
+        values: Signal values dict. Currently binary (CAN_ENTER=1, NO_PREDICTION=0).
+            Future: confidence scores, directional strength, multi-class signals.
+        timestamp: When the signal was generated.
+    '''
+
+    predictor_fn_id: str
+    values: dict[str, Any]
+    timestamp: datetime
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.predictor_fn_id, str) or not self.predictor_fn_id.strip():
+            msg = 'predictor_fn_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.values, dict):
+            msg = 'values must be a dict'
+            raise ValueError(msg)
+
+        for key, val in self.values.items():
+            if not isinstance(key, str):
+                msg = 'values keys must be strings'
+                raise ValueError(msg)
+
+            if isinstance(val, (int, float)) and not math.isfinite(val):
+                msg = f'values[{key!r}] must be finite'
+                raise ValueError(msg)
+
+        if not isinstance(self.timestamp, datetime):
+            msg = 'timestamp must be a datetime'
+            raise ValueError(msg)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        '''Get a signal value by key.
+
+        Args:
+            key: Signal key.
+            default: Value to return if key not found.
+
+        Returns:
+            Signal value or default.
+        '''
+
+        return self.values.get(key, default)

--- a/nexus/strategy/signal.py
+++ b/nexus/strategy/signal.py
@@ -16,14 +16,13 @@ class Signal:
 
     Args:
         predictor_fn_id: Identifier of the predictor function that produced this signal.
-        values: Signal values dict (stored as MappingProxyType). Currently binary
-            (CAN_ENTER=1, NO_PREDICTION=0). Future: confidence scores, directional
-            strength, multi-class signals.
+        values: Signal values dict. Currently binary (CAN_ENTER=1, NO_PREDICTION=0).
+            Future: confidence scores, directional strength, multi-class signals.
         timestamp: When the signal was generated.
     '''
 
     predictor_fn_id: str
-    values: dict[str, Any] | MappingProxyType[str, Any]
+    values: dict[str, Any]
     timestamp: datetime
 
     def __post_init__(self) -> None:

--- a/nexus/strategy/signal.py
+++ b/nexus/strategy/signal.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from datetime import datetime
+from decimal import Decimal
+from types import MappingProxyType
 from typing import Any
 
 
@@ -14,16 +16,19 @@ class Signal:
 
     Args:
         predictor_fn_id: Identifier of the predictor function that produced this signal.
-        values: Signal values dict. Currently binary (CAN_ENTER=1, NO_PREDICTION=0).
-            Future: confidence scores, directional strength, multi-class signals.
+        values: Signal values dict (stored as MappingProxyType). Currently binary
+            (CAN_ENTER=1, NO_PREDICTION=0). Future: confidence scores, directional
+            strength, multi-class signals.
         timestamp: When the signal was generated.
     '''
 
     predictor_fn_id: str
-    values: dict[str, Any]
+    values: dict[str, Any] | MappingProxyType[str, Any]
     timestamp: datetime
 
     def __post_init__(self) -> None:
+        '''Validate fields and wrap values as immutable.'''
+
         if not isinstance(self.predictor_fn_id, str) or not self.predictor_fn_id.strip():
             msg = 'predictor_fn_id must be a non-empty string'
             raise ValueError(msg)
@@ -41,9 +46,15 @@ class Signal:
                 msg = f'values[{key!r}] must be finite'
                 raise ValueError(msg)
 
+            if isinstance(val, Decimal) and not val.is_finite():
+                msg = f'values[{key!r}] must be finite'
+                raise ValueError(msg)
+
         if not isinstance(self.timestamp, datetime):
             msg = 'timestamp must be a datetime'
             raise ValueError(msg)
+
+        object.__setattr__(self, 'values', MappingProxyType(dict(self.values)))
 
     def get(self, key: str, default: Any = None) -> Any:
         '''Get a signal value by key.

--- a/nexus/strategy/signal.py
+++ b/nexus/strategy/signal.py
@@ -54,6 +54,13 @@ class Signal:
             msg = 'timestamp must be a datetime'
             raise ValueError(msg)
 
+        if (
+            self.timestamp.tzinfo is None
+            or self.timestamp.tzinfo.utcoffset(self.timestamp) is None
+        ):
+            msg = 'timestamp must be timezone-aware'
+            raise ValueError(msg)
+
         object.__setattr__(self, 'values', MappingProxyType(dict(self.values)))
 
     def get(self, key: str, default: Any = None) -> Any:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.19.0"
+version = "0.20.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_strategy_base.py
+++ b/tests/test_strategy_base.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from nexus.strategy import Strategy
+from nexus.strategy import Action, Strategy, StrategyContext, StrategyParams
+from nexus.strategy.signal import Signal
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 
 
 class ConcreteStrategy(Strategy):
@@ -19,6 +21,44 @@ class ConcreteStrategy(Strategy):
 
     def on_load(self, data: bytes) -> None:
         self._state = data
+
+    def on_startup(
+        self,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        return []
+
+    def on_signal(
+        self,
+        _signal: Signal,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        return []
+
+    def on_outcome(
+        self,
+        _outcome: TradeOutcome,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        return []
+
+    def on_timer(
+        self,
+        _timer_id: str,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        return []
+
+    def on_shutdown(
+        self,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        return []
 
 
 class TestStrategyABC:
@@ -135,6 +175,47 @@ class MissingOnLoadStrategy(Strategy):
         return b''
 
 
+class MissingOnStartupStrategy(Strategy):
+    '''Strategy missing on_startup implementation.'''
+
+    def on_save(self) -> bytes:
+        return b''
+
+    def on_load(self, _data: bytes) -> None:
+        pass
+
+    def on_signal(
+        self,
+        _signal: Signal,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        return []
+
+    def on_outcome(
+        self,
+        _outcome: TradeOutcome,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        return []
+
+    def on_timer(
+        self,
+        _timer_id: str,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        return []
+
+    def on_shutdown(
+        self,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        return []
+
+
 class TestMissingMethods:
     '''Tests for strategies missing required methods.'''
 
@@ -149,3 +230,118 @@ class TestMissingMethods:
 
         with pytest.raises(TypeError, match='abstract'):
             MissingOnLoadStrategy('test')  # type: ignore[abstract]
+
+    def test_missing_on_startup_raises(self) -> None:
+        '''Strategy missing on_startup cannot be instantiated.'''
+
+        with pytest.raises(TypeError, match='abstract'):
+            MissingOnStartupStrategy('test')  # type: ignore[abstract]
+
+
+class TestEventCallbacks:
+    '''Tests for event callback methods.'''
+
+    def test_callbacks_return_empty_list(self) -> None:
+        '''Callbacks can return empty list.'''
+
+        from datetime import datetime, timezone
+        from decimal import Decimal
+
+        from nexus.core.domain.enums import OperationalMode
+        from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+        from nexus.infrastructure.praxis_connector.trade_outcome_type import (
+            TradeOutcomeType,
+        )
+
+        strategy = ConcreteStrategy('test')
+        params = StrategyParams(raw={})
+        ctx = StrategyContext(
+            positions=(),
+            capital_available=Decimal('10000'),
+            operational_mode=OperationalMode.ACTIVE,
+        )
+        signal = Signal(
+            predictor_fn_id='pred1',
+            values={'CAN_ENTER': 1},
+            timestamp=datetime.now(timezone.utc),
+        )
+        outcome = TradeOutcome(
+            outcome_id='out1',
+            command_id='cmd1',
+            outcome_type=TradeOutcomeType.ACK,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        assert strategy.on_startup(params, ctx) == []
+        assert strategy.on_signal(signal, params, ctx) == []
+        assert strategy.on_outcome(outcome, params, ctx) == []
+        assert strategy.on_timer('timer1', params, ctx) == []
+        assert strategy.on_shutdown(params, ctx) == []
+
+    def test_callbacks_return_action_list(self) -> None:
+        '''Callbacks can return list of Actions.'''
+
+        from decimal import Decimal
+
+        from nexus.core.domain.enums import OperationalMode
+        from nexus.strategy import ActionType
+
+        class ActionReturningStrategy(Strategy):
+            '''Strategy that returns actions from callbacks.'''
+
+            def on_save(self) -> bytes:
+                return b''
+
+            def on_load(self, _data: bytes) -> None:
+                pass
+
+            def on_startup(
+                self,
+                _params: StrategyParams,
+                _context: StrategyContext,
+            ) -> list[Action]:
+                return [Action(action_type=ActionType.ENTER)]
+
+            def on_signal(
+                self,
+                _signal: Signal,
+                _params: StrategyParams,
+                _context: StrategyContext,
+            ) -> list[Action]:
+                return [Action(action_type=ActionType.ENTER)]
+
+            def on_outcome(
+                self,
+                _outcome: TradeOutcome,
+                _params: StrategyParams,
+                _context: StrategyContext,
+            ) -> list[Action]:
+                return [Action(action_type=ActionType.EXIT)]
+
+            def on_timer(
+                self,
+                _timer_id: str,
+                _params: StrategyParams,
+                _context: StrategyContext,
+            ) -> list[Action]:
+                return [Action(action_type=ActionType.MODIFY)]
+
+            def on_shutdown(
+                self,
+                _params: StrategyParams,
+                _context: StrategyContext,
+            ) -> list[Action]:
+                return [Action(action_type=ActionType.ABORT)]
+
+        strategy = ActionReturningStrategy('test')
+        params = StrategyParams(raw={})
+        ctx = StrategyContext(
+            positions=(),
+            capital_available=Decimal('10000'),
+            operational_mode=OperationalMode.ACTIVE,
+        )
+
+        result = strategy.on_startup(params, ctx)
+
+        assert len(result) == 1
+        assert result[0].action_type == ActionType.ENTER

--- a/tests/test_strategy_event_types.py
+++ b/tests/test_strategy_event_types.py
@@ -46,6 +46,19 @@ class TestStrategyParams:
 
         assert params.get('anything') is None
 
+    def test_raw_is_immutable(self) -> None:
+        '''raw dict is defensively copied and immutable.'''
+
+        original = {'key': 'value'}
+        params = StrategyParams(raw=original)
+
+        original['key'] = 'mutated'
+
+        assert params.raw['key'] == 'value'
+
+        with pytest.raises(TypeError):
+            params.raw['new'] = 'fail'  # type: ignore[index]
+
 
 class TestSignal:
     '''Tests for Signal dataclass.'''
@@ -127,6 +140,43 @@ class TestSignal:
                 values={'confidence': math.nan},
                 timestamp=datetime.now(timezone.utc),
             )
+
+    def test_decimal_nan_raises(self) -> None:
+        '''Decimal NaN raises ValueError.'''
+
+        with pytest.raises(ValueError, match='must be finite'):
+            Signal(
+                predictor_fn_id='test',
+                values={'confidence': Decimal('NaN')},
+                timestamp=datetime.now(timezone.utc),
+            )
+
+    def test_decimal_infinity_raises(self) -> None:
+        '''Decimal Infinity raises ValueError.'''
+
+        with pytest.raises(ValueError, match='must be finite'):
+            Signal(
+                predictor_fn_id='test',
+                values={'confidence': Decimal('Infinity')},
+                timestamp=datetime.now(timezone.utc),
+            )
+
+    def test_values_is_immutable(self) -> None:
+        '''values dict is defensively copied and immutable.'''
+
+        original = {'CAN_ENTER': 1}
+        signal = Signal(
+            predictor_fn_id='test',
+            values=original,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        original['CAN_ENTER'] = 999
+
+        assert signal.values['CAN_ENTER'] == 1
+
+        with pytest.raises(TypeError):
+            signal.values['new'] = 'fail'  # type: ignore[index]
 
     def test_non_string_key_raises(self) -> None:
         '''Non-string key in values raises ValueError.'''

--- a/tests/test_strategy_event_types.py
+++ b/tests/test_strategy_event_types.py
@@ -208,6 +208,18 @@ class TestSignal:
                 timestamp='not a datetime',  # type: ignore[arg-type]
             )
 
+    def test_naive_timestamp_raises(self) -> None:
+        '''Naive datetime raises ValueError.'''
+
+        from datetime import datetime as dt
+
+        with pytest.raises(ValueError, match='timezone-aware'):
+            Signal(
+                predictor_fn_id='test',
+                values={'CAN_ENTER': 1},
+                timestamp=dt.now(),
+            )
+
 
 class TestActionType:
     '''Tests for ActionType enum.'''

--- a/tests/test_strategy_event_types.py
+++ b/tests/test_strategy_event_types.py
@@ -1,0 +1,280 @@
+'''Tests for strategy event dispatch types.'''
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from nexus.core.domain.enums import OperationalMode, OrderSide
+from nexus.core.domain.position import Position
+from nexus.strategy import Action, ActionType, StrategyContext, StrategyParams
+from nexus.strategy.signal import Signal
+
+
+class TestStrategyParams:
+    '''Tests for StrategyParams dataclass.'''
+
+    def test_get_returns_value(self) -> None:
+        '''get() returns value for existing key.'''
+
+        params = StrategyParams(raw={'threshold': 0.5, 'window': 14})
+
+        assert params.get('threshold') == 0.5
+        assert params.get('window') == 14
+
+    def test_get_returns_default_for_missing_key(self) -> None:
+        '''get() returns default for missing key.'''
+
+        params = StrategyParams(raw={'threshold': 0.5})
+
+        assert params.get('missing') is None
+        assert params.get('missing', 100) == 100
+
+    def test_raw_must_be_dict(self) -> None:
+        '''raw must be a dict.'''
+
+        with pytest.raises(ValueError, match='must be a dict'):
+            StrategyParams(raw='not a dict')  # type: ignore[arg-type]
+
+    def test_empty_dict_valid(self) -> None:
+        '''Empty dict is valid.'''
+
+        params = StrategyParams(raw={})
+
+        assert params.get('anything') is None
+
+
+class TestSignal:
+    '''Tests for Signal dataclass.'''
+
+    def test_valid_signal(self) -> None:
+        '''Valid signal constructs successfully.'''
+
+        ts = datetime.now(timezone.utc)
+        signal = Signal(
+            predictor_fn_id='momentum_v1',
+            values={'CAN_ENTER': 1, 'confidence': 0.85},
+            timestamp=ts,
+        )
+
+        assert signal.predictor_fn_id == 'momentum_v1'
+        assert signal.values == {'CAN_ENTER': 1, 'confidence': 0.85}
+        assert signal.timestamp == ts
+
+    def test_get_returns_value(self) -> None:
+        '''get() returns value for existing key.'''
+
+        signal = Signal(
+            predictor_fn_id='test',
+            values={'CAN_ENTER': 1, 'confidence': 0.85},
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        assert signal.get('CAN_ENTER') == 1
+        assert signal.get('confidence') == 0.85
+
+    def test_get_returns_default_for_missing_key(self) -> None:
+        '''get() returns default for missing key.'''
+
+        signal = Signal(
+            predictor_fn_id='test',
+            values={'CAN_ENTER': 1},
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        assert signal.get('missing') is None
+        assert signal.get('missing', 0) == 0
+
+    def test_empty_predictor_fn_id_raises(self) -> None:
+        '''Empty predictor_fn_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='non-empty string'):
+            Signal(
+                predictor_fn_id='',
+                values={'CAN_ENTER': 1},
+                timestamp=datetime.now(timezone.utc),
+            )
+
+    def test_whitespace_predictor_fn_id_raises(self) -> None:
+        '''Whitespace-only predictor_fn_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='non-empty string'):
+            Signal(
+                predictor_fn_id='   ',
+                values={'CAN_ENTER': 1},
+                timestamp=datetime.now(timezone.utc),
+            )
+
+    def test_non_finite_value_raises(self) -> None:
+        '''Non-finite numeric value raises ValueError.'''
+
+        with pytest.raises(ValueError, match='must be finite'):
+            Signal(
+                predictor_fn_id='test',
+                values={'confidence': float('inf')},
+                timestamp=datetime.now(timezone.utc),
+            )
+
+    def test_nan_value_raises(self) -> None:
+        '''NaN value raises ValueError.'''
+
+        with pytest.raises(ValueError, match='must be finite'):
+            Signal(
+                predictor_fn_id='test',
+                values={'confidence': math.nan},
+                timestamp=datetime.now(timezone.utc),
+            )
+
+    def test_non_string_key_raises(self) -> None:
+        '''Non-string key in values raises ValueError.'''
+
+        with pytest.raises(ValueError, match='keys must be strings'):
+            Signal(
+                predictor_fn_id='test',
+                values={123: 1},  # type: ignore[dict-item]
+                timestamp=datetime.now(timezone.utc),
+            )
+
+    def test_values_must_be_dict(self) -> None:
+        '''values must be a dict.'''
+
+        with pytest.raises(ValueError, match='must be a dict'):
+            Signal(
+                predictor_fn_id='test',
+                values='not a dict',  # type: ignore[arg-type]
+                timestamp=datetime.now(timezone.utc),
+            )
+
+    def test_timestamp_must_be_datetime(self) -> None:
+        '''timestamp must be a datetime.'''
+
+        with pytest.raises(ValueError, match='must be a datetime'):
+            Signal(
+                predictor_fn_id='test',
+                values={'CAN_ENTER': 1},
+                timestamp='not a datetime',  # type: ignore[arg-type]
+            )
+
+
+class TestActionType:
+    '''Tests for ActionType enum.'''
+
+    def test_all_action_types_exist(self) -> None:
+        '''All expected action types exist.'''
+
+        assert ActionType.ENTER.value == 'enter'
+        assert ActionType.EXIT.value == 'exit'
+        assert ActionType.MODIFY.value == 'modify'
+        assert ActionType.ABORT.value == 'abort'
+
+
+class TestAction:
+    '''Tests for Action dataclass.'''
+
+    def test_action_with_each_type(self) -> None:
+        '''Action constructs with each ActionType.'''
+
+        for action_type in ActionType:
+            action = Action(action_type=action_type)
+
+            assert action.action_type == action_type
+
+    def test_action_type_must_be_actiontype(self) -> None:
+        '''action_type must be an ActionType.'''
+
+        with pytest.raises(ValueError, match='must be an ActionType'):
+            Action(action_type='enter')  # type: ignore[arg-type]
+
+
+class TestStrategyContext:
+    '''Tests for StrategyContext dataclass.'''
+
+    def _make_position(self) -> Position:
+        '''Create a valid position for testing.'''
+
+        return Position(
+            trade_id='trade_001',
+            strategy_id='momentum_v1',
+            symbol='BTC-USDT',
+            side=OrderSide.BUY,
+            size=Decimal('0.1'),
+            entry_price=Decimal('50000'),
+        )
+
+    def test_valid_context(self) -> None:
+        '''Valid context constructs successfully.'''
+
+        pos = self._make_position()
+        ctx = StrategyContext(
+            positions=(pos,),
+            capital_available=Decimal('10000'),
+            operational_mode=OperationalMode.ACTIVE,
+        )
+
+        assert ctx.positions == (pos,)
+        assert ctx.capital_available == Decimal('10000')
+        assert ctx.operational_mode == OperationalMode.ACTIVE
+
+    def test_empty_positions_valid(self) -> None:
+        '''Empty positions tuple is valid.'''
+
+        ctx = StrategyContext(
+            positions=(),
+            capital_available=Decimal('10000'),
+            operational_mode=OperationalMode.ACTIVE,
+        )
+
+        assert ctx.positions == ()
+
+    def test_positions_must_be_tuple(self) -> None:
+        '''positions must be a tuple.'''
+
+        with pytest.raises(ValueError, match='must be a tuple'):
+            StrategyContext(
+                positions=[],  # type: ignore[arg-type]
+                capital_available=Decimal('10000'),
+                operational_mode=OperationalMode.ACTIVE,
+            )
+
+    def test_positions_must_contain_position_instances(self) -> None:
+        '''positions must contain only Position instances.'''
+
+        with pytest.raises(ValueError, match='Position instances'):
+            StrategyContext(
+                positions=('not a position',),  # type: ignore[arg-type]
+                capital_available=Decimal('10000'),
+                operational_mode=OperationalMode.ACTIVE,
+            )
+
+    def test_capital_must_be_decimal(self) -> None:
+        '''capital_available must be a Decimal.'''
+
+        with pytest.raises(ValueError, match='must be a Decimal'):
+            StrategyContext(
+                positions=(),
+                capital_available=10000,  # type: ignore[arg-type]
+                operational_mode=OperationalMode.ACTIVE,
+            )
+
+    def test_capital_must_be_non_negative(self) -> None:
+        '''capital_available must be non-negative.'''
+
+        with pytest.raises(ValueError, match='non-negative'):
+            StrategyContext(
+                positions=(),
+                capital_available=Decimal('-100'),
+                operational_mode=OperationalMode.ACTIVE,
+            )
+
+    def test_operational_mode_must_be_enum(self) -> None:
+        '''operational_mode must be an OperationalMode.'''
+
+        with pytest.raises(ValueError, match='must be an OperationalMode'):
+            StrategyContext(
+                positions=(),
+                capital_available=Decimal('10000'),
+                operational_mode='ACTIVE',  # type: ignore[arg-type]
+            )

--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -22,14 +22,31 @@ def _write_strategy_file(base: Path, rel_path: str, content: str) -> None:
 
 
 VALID_STRATEGY = '''
-from nexus.strategy import Strategy
+from nexus.strategy import Action, Strategy, StrategyContext, StrategyParams
+from nexus.strategy.signal import Signal
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 
 class Strategy(Strategy):
     def on_save(self) -> bytes:
-        return b''
+        return b""
 
     def on_load(self, data: bytes) -> None:
         pass
+
+    def on_startup(self, params: StrategyParams, context: StrategyContext) -> list[Action]:
+        return []
+
+    def on_signal(self, signal: Signal, params: StrategyParams, context: StrategyContext) -> list[Action]:
+        return []
+
+    def on_outcome(self, outcome: TradeOutcome, params: StrategyParams, context: StrategyContext) -> list[Action]:
+        return []
+
+    def on_timer(self, timer_id: str, params: StrategyParams, context: StrategyContext) -> list[Action]:
+        return []
+
+    def on_shutdown(self, params: StrategyParams, context: StrategyContext) -> list[Action]:
+        return []
 '''
 
 MISSING_ON_SAVE = '''
@@ -180,7 +197,7 @@ class TestLoadStrategyClass:
             strategy_class = load_strategy_class(Path('bad.py'), tmp_path)
 
             with pytest.raises(TypeError, match='abstract'):
-                strategy_class('test')  # type: ignore[abstract]
+                strategy_class('test')
 
     def test_nested_path_loads(self) -> None:
         '''Nested directory path loads successfully.'''

--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -28,7 +28,7 @@ from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 
 class Strategy(Strategy):
     def on_save(self) -> bytes:
-        return b""
+        return b''
 
     def on_load(self, data: bytes) -> None:
         pass


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Event dispatch types and Strategy ABC callbacks (RFC-3001 phase 7.3). Adds `StrategyParams` frozen dataclass wrapping manifest parameters with `get()` accessor. Adds `Signal` frozen dataclass for predictor function output with `predictor_fn_id`, `values` dict, and `timestamp` with finite-value validation. Adds `ActionType` enum (ENTER, EXIT, MODIFY, ABORT) and `Action` frozen dataclass. Adds `StrategyContext` frozen dataclass composing `positions` tuple, `capital_available` Decimal, and `operational_mode`. Extends `Strategy` ABC with five event callbacks: `on_startup`, `on_signal`, `on_outcome`, `on_timer`, `on_shutdown` — all returning `list[Action]`. Wires new types in `nexus/strategy/__init__.py`. Adds 57 new tests (772 total passing). Bumps to v0.20.0.

## Checklist

- [ ] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (772 passing)
- [x] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable