### PR TITLE
feat: 7.4 serialized callback execution (StrategyExecutor + StrategyRunner)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,4 +200,4 @@
 
 - Add [`executor.py`](nexus/strategy/executor.py) with `StrategyExecutor` class wrapping Strategy instance with `threading.Lock` for serialized callback execution
 - Add [`runner.py`](nexus/strategy/runner.py) with `StrategyRunner` class orchestrating multiple executors by strategy_id
-- Add 27 tests covering executor delegation, runner routing, unknown strategy rejection, and concurrent dispatch serialization (804 total)
+- Add 29 tests covering executor delegation, runner routing, unknown strategy rejection, and concurrent dispatch serialization (806 total)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,3 +195,9 @@
 - Extend `Strategy` ABC with five event callbacks: `on_startup`, `on_signal`, `on_outcome`, `on_timer`, `on_shutdown`
 - Wire new types in [`nexus/strategy/__init__.py`](nexus/strategy/__init__.py) public API
 - Add 57 tests covering event dispatch types and Strategy callbacks (772 total)
+
+## v0.21.0 on 2nd of April, 2026
+
+- Add [`executor.py`](nexus/strategy/executor.py) with `StrategyExecutor` class wrapping Strategy instance with `threading.Lock` for serialized callback execution
+- Add [`runner.py`](nexus/strategy/runner.py) with `StrategyRunner` class orchestrating multiple executors by strategy_id
+- Add 27 tests covering executor delegation, runner routing, unknown strategy rejection, and concurrent dispatch serialization (804 total)

--- a/nexus/strategy/__init__.py
+++ b/nexus/strategy/__init__.py
@@ -3,6 +3,7 @@
 from nexus.strategy.action import Action, ActionType
 from nexus.strategy.base import Strategy
 from nexus.strategy.context import StrategyContext
+from nexus.strategy.executor import StrategyExecutor
 from nexus.strategy.loader import instantiate_strategy, load_strategy_class
 from nexus.strategy.params import StrategyParams
 from nexus.strategy.signal import Signal
@@ -13,6 +14,7 @@ __all__ = [
     'Signal',
     'Strategy',
     'StrategyContext',
+    'StrategyExecutor',
     'StrategyParams',
     'instantiate_strategy',
     'load_strategy_class',

--- a/nexus/strategy/__init__.py
+++ b/nexus/strategy/__init__.py
@@ -6,6 +6,7 @@ from nexus.strategy.context import StrategyContext
 from nexus.strategy.executor import StrategyExecutor
 from nexus.strategy.loader import instantiate_strategy, load_strategy_class
 from nexus.strategy.params import StrategyParams
+from nexus.strategy.runner import StrategyRunner
 from nexus.strategy.signal import Signal
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     'StrategyContext',
     'StrategyExecutor',
     'StrategyParams',
+    'StrategyRunner',
     'instantiate_strategy',
     'load_strategy_class',
 ]

--- a/nexus/strategy/executor.py
+++ b/nexus/strategy/executor.py
@@ -1,0 +1,134 @@
+'''Strategy executor for serialized callback execution.'''
+
+from __future__ import annotations
+
+import threading
+
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.strategy.action import Action
+from nexus.strategy.base import Strategy
+from nexus.strategy.context import StrategyContext
+from nexus.strategy.params import StrategyParams
+from nexus.strategy.signal import Signal
+
+
+class StrategyExecutor:
+    '''Wraps a Strategy instance to guarantee serialized callback execution.
+
+    All dispatch methods acquire a lock before delegating to the underlying
+    Strategy callback. This ensures only one callback executes at a time
+    per strategy instance.
+
+    Args:
+        strategy: Strategy instance to wrap.
+    '''
+
+    def __init__(self, strategy: Strategy) -> None:
+        if not isinstance(strategy, Strategy):
+            msg = 'strategy must be a Strategy instance'
+            raise ValueError(msg)
+
+        self._strategy = strategy
+        self._lock = threading.Lock()
+
+    @property
+    def strategy_id(self) -> str:
+        '''Unique identifier of the wrapped strategy.'''
+
+        return self._strategy.strategy_id
+
+    def dispatch_startup(
+        self,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Dispatch startup event to strategy under lock.
+
+        Args:
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions from strategy.
+        '''
+
+        with self._lock:
+            return self._strategy.on_startup(params, context)
+
+    def dispatch_signal(
+        self,
+        signal: Signal,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Dispatch signal event to strategy under lock.
+
+        Args:
+            signal: Signal from predictor function.
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions from strategy.
+        '''
+
+        with self._lock:
+            return self._strategy.on_signal(signal, params, context)
+
+    def dispatch_outcome(
+        self,
+        outcome: TradeOutcome,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Dispatch outcome event to strategy under lock.
+
+        Args:
+            outcome: Trade execution result.
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions from strategy.
+        '''
+
+        with self._lock:
+            return self._strategy.on_outcome(outcome, params, context)
+
+    def dispatch_timer(
+        self,
+        timer_id: str,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Dispatch timer event to strategy under lock.
+
+        Args:
+            timer_id: Identifier of the timer that fired.
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions from strategy.
+        '''
+
+        with self._lock:
+            return self._strategy.on_timer(timer_id, params, context)
+
+    def dispatch_shutdown(
+        self,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Dispatch shutdown event to strategy under lock.
+
+        Args:
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions from strategy.
+        '''
+
+        with self._lock:
+            return self._strategy.on_shutdown(params, context)

--- a/nexus/strategy/runner.py
+++ b/nexus/strategy/runner.py
@@ -25,20 +25,30 @@ class StrategyRunner:
             msg = 'executors must be a dict'
             raise ValueError(msg)
 
+        normalized: dict[str, StrategyExecutor] = {}
+
         for strategy_id, executor in executors.items():
             if not isinstance(strategy_id, str) or not strategy_id.strip():
                 msg = 'executor keys must be non-empty strings'
                 raise ValueError(msg)
 
+            key = strategy_id.strip()
+
             if not isinstance(executor, StrategyExecutor):
-                msg = f'executor for {strategy_id!r} must be a StrategyExecutor'
+                msg = f'executor for {key!r} must be a StrategyExecutor'
                 raise ValueError(msg)
 
-            if executor.strategy_id != strategy_id:
-                msg = f'executor strategy_id {executor.strategy_id!r} does not match key {strategy_id!r}'
+            if executor.strategy_id != key:
+                msg = f'executor strategy_id {executor.strategy_id!r} does not match key {key!r}'
                 raise ValueError(msg)
 
-        self._executors = dict(executors)
+            if key in normalized:
+                msg = f'duplicate strategy_id after normalization: {key!r}'
+                raise ValueError(msg)
+
+            normalized[key] = executor
+
+        self._executors = normalized
 
     def _get_executor(self, strategy_id: str) -> StrategyExecutor:
         '''Get executor for strategy_id or raise ValueError.'''

--- a/nexus/strategy/runner.py
+++ b/nexus/strategy/runner.py
@@ -1,0 +1,168 @@
+'''Strategy runner for orchestrating multiple strategy executors.'''
+
+from __future__ import annotations
+
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.strategy.action import Action
+from nexus.strategy.context import StrategyContext
+from nexus.strategy.executor import StrategyExecutor
+from nexus.strategy.params import StrategyParams
+from nexus.strategy.signal import Signal
+
+
+class StrategyRunner:
+    '''Orchestrates dispatch to multiple strategy executors.
+
+    Routes events to the appropriate StrategyExecutor by strategy_id.
+    Each executor guarantees serialized callback execution for its strategy.
+
+    Args:
+        executors: Mapping of strategy_id to StrategyExecutor.
+    '''
+
+    def __init__(self, executors: dict[str, StrategyExecutor]) -> None:
+        if not isinstance(executors, dict):
+            msg = 'executors must be a dict'
+            raise ValueError(msg)
+
+        for strategy_id, executor in executors.items():
+            if not isinstance(strategy_id, str) or not strategy_id.strip():
+                msg = 'executor keys must be non-empty strings'
+                raise ValueError(msg)
+
+            if not isinstance(executor, StrategyExecutor):
+                msg = f'executor for {strategy_id!r} must be a StrategyExecutor'
+                raise ValueError(msg)
+
+            if executor.strategy_id != strategy_id:
+                msg = f'executor strategy_id {executor.strategy_id!r} does not match key {strategy_id!r}'
+                raise ValueError(msg)
+
+        self._executors = dict(executors)
+
+    def _get_executor(self, strategy_id: str) -> StrategyExecutor:
+        '''Get executor for strategy_id or raise ValueError.'''
+
+        executor = self._executors.get(strategy_id)
+
+        if executor is None:
+            msg = f'unknown strategy_id: {strategy_id!r}'
+            raise ValueError(msg)
+
+        return executor
+
+    def dispatch_startup(
+        self,
+        strategy_id: str,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Dispatch startup event to strategy.
+
+        Args:
+            strategy_id: Target strategy identifier.
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions from strategy.
+
+        Raises:
+            ValueError: If strategy_id is unknown.
+        '''
+
+        return self._get_executor(strategy_id).dispatch_startup(params, context)
+
+    def dispatch_signal(
+        self,
+        strategy_id: str,
+        signal: Signal,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Dispatch signal event to strategy.
+
+        Args:
+            strategy_id: Target strategy identifier.
+            signal: Signal from predictor function.
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions from strategy.
+
+        Raises:
+            ValueError: If strategy_id is unknown.
+        '''
+
+        return self._get_executor(strategy_id).dispatch_signal(signal, params, context)
+
+    def dispatch_outcome(
+        self,
+        strategy_id: str,
+        outcome: TradeOutcome,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Dispatch outcome event to strategy.
+
+        Args:
+            strategy_id: Target strategy identifier.
+            outcome: Trade execution result.
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions from strategy.
+
+        Raises:
+            ValueError: If strategy_id is unknown.
+        '''
+
+        return self._get_executor(strategy_id).dispatch_outcome(outcome, params, context)
+
+    def dispatch_timer(
+        self,
+        strategy_id: str,
+        timer_id: str,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Dispatch timer event to strategy.
+
+        Args:
+            strategy_id: Target strategy identifier.
+            timer_id: Identifier of the timer that fired.
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions from strategy.
+
+        Raises:
+            ValueError: If strategy_id is unknown.
+        '''
+
+        return self._get_executor(strategy_id).dispatch_timer(timer_id, params, context)
+
+    def dispatch_shutdown(
+        self,
+        strategy_id: str,
+        params: StrategyParams,
+        context: StrategyContext,
+    ) -> list[Action]:
+        '''Dispatch shutdown event to strategy.
+
+        Args:
+            strategy_id: Target strategy identifier.
+            params: Strategy parameters from manifest.
+            context: Current strategy context.
+
+        Returns:
+            List of actions from strategy.
+
+        Raises:
+            ValueError: If strategy_id is unknown.
+        '''
+
+        return self._get_executor(strategy_id).dispatch_shutdown(params, context)

--- a/nexus/strategy/runner.py
+++ b/nexus/strategy/runner.py
@@ -53,10 +53,20 @@ class StrategyRunner:
     def _get_executor(self, strategy_id: str) -> StrategyExecutor:
         '''Get executor for strategy_id or raise ValueError.'''
 
-        executor = self._executors.get(strategy_id)
+        if not isinstance(strategy_id, str):
+            msg = f'strategy_id must be a string, got {type(strategy_id).__name__}'
+            raise ValueError(msg)
+
+        key = strategy_id.strip()
+
+        if not key:
+            msg = 'strategy_id must be a non-empty string'
+            raise ValueError(msg)
+
+        executor = self._executors.get(key)
 
         if executor is None:
-            msg = f'unknown strategy_id: {strategy_id!r}'
+            msg = f'unknown strategy_id: {key!r}'
             raise ValueError(msg)
 
         return executor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.20.0"
+version = "0.21.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_strategy_executor.py
+++ b/tests/test_strategy_executor.py
@@ -27,7 +27,7 @@ class StubStrategy(Strategy):
     def on_save(self) -> bytes:
         return b''
 
-    def on_load(self, data: bytes) -> None:
+    def on_load(self, _data: bytes) -> None:
         pass
 
     def on_startup(

--- a/tests/test_strategy_executor.py
+++ b/tests/test_strategy_executor.py
@@ -1,0 +1,251 @@
+'''Tests for StrategyExecutor.'''
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from nexus.core.domain.enums import OperationalMode
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+from nexus.strategy import Action, ActionType, Strategy, StrategyContext, StrategyParams
+from nexus.strategy.executor import StrategyExecutor
+from nexus.strategy.signal import Signal
+
+
+class StubStrategy(Strategy):
+
+    def __init__(self, strategy_id: str) -> None:
+        super().__init__(strategy_id)
+        self.calls: list[str] = []
+        self.delay: float = 0.0
+
+    def on_save(self) -> bytes:
+        return b''
+
+    def on_load(self, data: bytes) -> None:
+        pass
+
+    def on_startup(
+        self,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        if self.delay:
+            time.sleep(self.delay)
+        self.calls.append('on_startup')
+        return [Action(ActionType.ENTER)]
+
+    def on_signal(
+        self,
+        _signal: Signal,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        if self.delay:
+            time.sleep(self.delay)
+        self.calls.append('on_signal')
+        return [Action(ActionType.ENTER)]
+
+    def on_outcome(
+        self,
+        _outcome: TradeOutcome,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        if self.delay:
+            time.sleep(self.delay)
+        self.calls.append('on_outcome')
+        return [Action(ActionType.EXIT)]
+
+    def on_timer(
+        self,
+        _timer_id: str,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        if self.delay:
+            time.sleep(self.delay)
+        self.calls.append('on_timer')
+        return []
+
+    def on_shutdown(
+        self,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        if self.delay:
+            time.sleep(self.delay)
+        self.calls.append('on_shutdown')
+        return [Action(ActionType.ABORT)]
+
+
+def _make_params() -> StrategyParams:
+    return StrategyParams(raw={'key': 'value'})
+
+
+def _make_context() -> StrategyContext:
+    return StrategyContext(
+        positions=(),
+        capital_available=Decimal('1000'),
+        operational_mode=OperationalMode.ACTIVE,
+    )
+
+
+def _make_signal() -> Signal:
+    return Signal(
+        predictor_fn_id='pred1',
+        values={'score': 0.8},
+        timestamp=datetime.now(tz=timezone.utc),
+    )
+
+
+def _make_outcome() -> TradeOutcome:
+    return TradeOutcome(
+        outcome_id='out1',
+        command_id='cmd1',
+        outcome_type=TradeOutcomeType.ACK,
+        timestamp=datetime.now(tz=timezone.utc),
+    )
+
+
+class TestStrategyExecutorConstruction:
+
+    def test_requires_strategy_instance(self) -> None:
+        with pytest.raises(ValueError, match='must be a Strategy instance'):
+            StrategyExecutor('not a strategy')  # type: ignore[arg-type]
+
+    def test_strategy_id_exposed(self) -> None:
+        strategy = StubStrategy('test_strat')
+        executor = StrategyExecutor(strategy)
+
+        assert executor.strategy_id == 'test_strat'
+
+
+class TestStrategyExecutorDispatch:
+
+    def test_dispatch_startup_delegates(self) -> None:
+        strategy = StubStrategy('s1')
+        executor = StrategyExecutor(strategy)
+
+        actions = executor.dispatch_startup(_make_params(), _make_context())
+
+        assert strategy.calls == ['on_startup']
+        assert len(actions) == 1
+        assert actions[0].action_type == ActionType.ENTER
+
+    def test_dispatch_signal_delegates(self) -> None:
+        strategy = StubStrategy('s1')
+        executor = StrategyExecutor(strategy)
+
+        actions = executor.dispatch_signal(_make_signal(), _make_params(), _make_context())
+
+        assert strategy.calls == ['on_signal']
+        assert len(actions) == 1
+        assert actions[0].action_type == ActionType.ENTER
+
+    def test_dispatch_outcome_delegates(self) -> None:
+        strategy = StubStrategy('s1')
+        executor = StrategyExecutor(strategy)
+
+        actions = executor.dispatch_outcome(_make_outcome(), _make_params(), _make_context())
+
+        assert strategy.calls == ['on_outcome']
+        assert len(actions) == 1
+        assert actions[0].action_type == ActionType.EXIT
+
+    def test_dispatch_timer_delegates(self) -> None:
+        strategy = StubStrategy('s1')
+        executor = StrategyExecutor(strategy)
+
+        actions = executor.dispatch_timer('timer1', _make_params(), _make_context())
+
+        assert strategy.calls == ['on_timer']
+        assert actions == []
+
+    def test_dispatch_shutdown_delegates(self) -> None:
+        strategy = StubStrategy('s1')
+        executor = StrategyExecutor(strategy)
+
+        actions = executor.dispatch_shutdown(_make_params(), _make_context())
+
+        assert strategy.calls == ['on_shutdown']
+        assert len(actions) == 1
+        assert actions[0].action_type == ActionType.ABORT
+
+
+class TestStrategyExecutorConcurrency:
+
+    def test_concurrent_dispatch_serialized(self) -> None:
+        strategy = StubStrategy('s1')
+        strategy.delay = 0.05
+        executor = StrategyExecutor(strategy)
+
+        results: list[str] = []
+        errors: list[Exception] = []
+
+        def dispatch_startup() -> None:
+            try:
+                executor.dispatch_startup(_make_params(), _make_context())
+                results.append('startup_done')
+            except Exception as e:
+                errors.append(e)
+
+        def dispatch_signal() -> None:
+            try:
+                executor.dispatch_signal(_make_signal(), _make_params(), _make_context())
+                results.append('signal_done')
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=dispatch_startup)
+        t2 = threading.Thread(target=dispatch_signal)
+
+        t1.start()
+        time.sleep(0.01)
+        t2.start()
+
+        t1.join()
+        t2.join()
+
+        assert not errors
+        assert len(results) == 2
+        assert strategy.calls == ['on_startup', 'on_signal']
+
+    def test_multiple_concurrent_dispatches_all_complete(self) -> None:
+        strategy = StubStrategy('s1')
+        strategy.delay = 0.01
+        executor = StrategyExecutor(strategy)
+
+        errors: list[Exception] = []
+
+        def dispatch(method: str) -> None:
+            try:
+                if method == 'startup':
+                    executor.dispatch_startup(_make_params(), _make_context())
+                elif method == 'signal':
+                    executor.dispatch_signal(_make_signal(), _make_params(), _make_context())
+                elif method == 'timer':
+                    executor.dispatch_timer('t1', _make_params(), _make_context())
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=dispatch, args=('startup',)),
+            threading.Thread(target=dispatch, args=('signal',)),
+            threading.Thread(target=dispatch, args=('timer',)),
+        ]
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(strategy.calls) == 3
+        assert set(strategy.calls) == {'on_startup', 'on_signal', 'on_timer'}

--- a/tests/test_strategy_runner.py
+++ b/tests/test_strategy_runner.py
@@ -149,6 +149,13 @@ class TestStrategyRunnerConstruction:
         with pytest.raises(ValueError, match='does not match key'):
             StrategyRunner({'wrong_key': executor})
 
+    def test_duplicate_key_after_normalization_rejected(self) -> None:
+        strategy = StubStrategy('s1')
+        executor = StrategyExecutor(strategy)
+
+        with pytest.raises(ValueError, match='duplicate strategy_id'):
+            StrategyRunner({'s1': executor, ' s1 ': executor})
+
 
 class TestStrategyRunnerDispatch:
 

--- a/tests/test_strategy_runner.py
+++ b/tests/test_strategy_runner.py
@@ -211,6 +211,14 @@ class TestStrategyRunnerUnknownStrategy:
         with pytest.raises(ValueError, match='unknown strategy_id'):
             runner.dispatch_startup('unknown', _make_params(), _make_context())
 
+    def test_dispatch_with_whitespace_padded_id_normalizes(self) -> None:
+        runner, strategies = _make_runner_with_strategies('s1')
+
+        actions = runner.dispatch_startup(' s1 ', _make_params(), _make_context())
+
+        assert strategies['s1'].calls == ['on_startup']
+        assert len(actions) == 1
+
     def test_dispatch_signal_unknown_strategy_raises(self) -> None:
         runner, _ = _make_runner_with_strategies('s1')
 

--- a/tests/test_strategy_runner.py
+++ b/tests/test_strategy_runner.py
@@ -1,0 +1,243 @@
+'''Tests for StrategyRunner.'''
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from nexus.core.domain.enums import OperationalMode
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+from nexus.strategy import Action, ActionType, Strategy, StrategyContext, StrategyParams
+from nexus.strategy.executor import StrategyExecutor
+from nexus.strategy.runner import StrategyRunner
+from nexus.strategy.signal import Signal
+
+
+class StubStrategy(Strategy):
+
+    def __init__(self, strategy_id: str) -> None:
+        super().__init__(strategy_id)
+        self.calls: list[str] = []
+
+    def on_save(self) -> bytes:
+        return b''
+
+    def on_load(self, _data: bytes) -> None:
+        pass
+
+    def on_startup(
+        self,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        self.calls.append('on_startup')
+        return [Action(ActionType.ENTER)]
+
+    def on_signal(
+        self,
+        _signal: Signal,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        self.calls.append('on_signal')
+        return [Action(ActionType.ENTER)]
+
+    def on_outcome(
+        self,
+        _outcome: TradeOutcome,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        self.calls.append('on_outcome')
+        return [Action(ActionType.EXIT)]
+
+    def on_timer(
+        self,
+        _timer_id: str,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        self.calls.append('on_timer')
+        return []
+
+    def on_shutdown(
+        self,
+        _params: StrategyParams,
+        _context: StrategyContext,
+    ) -> list[Action]:
+        self.calls.append('on_shutdown')
+        return [Action(ActionType.ABORT)]
+
+
+def _make_params() -> StrategyParams:
+    return StrategyParams(raw={'key': 'value'})
+
+
+def _make_context() -> StrategyContext:
+    return StrategyContext(
+        positions=(),
+        capital_available=Decimal('1000'),
+        operational_mode=OperationalMode.ACTIVE,
+    )
+
+
+def _make_signal() -> Signal:
+    return Signal(
+        predictor_fn_id='pred1',
+        values={'score': 0.8},
+        timestamp=datetime.now(tz=timezone.utc),
+    )
+
+
+def _make_outcome() -> TradeOutcome:
+    return TradeOutcome(
+        outcome_id='out1',
+        command_id='cmd1',
+        outcome_type=TradeOutcomeType.ACK,
+        timestamp=datetime.now(tz=timezone.utc),
+    )
+
+
+def _make_runner_with_strategies(*strategy_ids: str) -> tuple[StrategyRunner, dict[str, StubStrategy]]:
+    strategies = {sid: StubStrategy(sid) for sid in strategy_ids}
+    executors = {sid: StrategyExecutor(strat) for sid, strat in strategies.items()}
+    runner = StrategyRunner(executors)
+    return runner, strategies
+
+
+class TestStrategyRunnerConstruction:
+
+    def test_valid_construction(self) -> None:
+        runner, _ = _make_runner_with_strategies('s1', 's2')
+
+        assert runner is not None
+
+    def test_empty_executors_allowed(self) -> None:
+        runner = StrategyRunner({})
+
+        assert runner is not None
+
+    def test_non_dict_executors_rejected(self) -> None:
+        with pytest.raises(ValueError, match='must be a dict'):
+            StrategyRunner([])  # type: ignore[arg-type]
+
+    def test_empty_strategy_id_key_rejected(self) -> None:
+        strategy = StubStrategy('s1')
+        executor = StrategyExecutor(strategy)
+
+        with pytest.raises(ValueError, match='non-empty strings'):
+            StrategyRunner({'': executor})
+
+    def test_whitespace_strategy_id_key_rejected(self) -> None:
+        strategy = StubStrategy('s1')
+        executor = StrategyExecutor(strategy)
+
+        with pytest.raises(ValueError, match='non-empty strings'):
+            StrategyRunner({'  ': executor})
+
+    def test_non_executor_value_rejected(self) -> None:
+        with pytest.raises(ValueError, match='must be a StrategyExecutor'):
+            StrategyRunner({'s1': 'not an executor'})  # type: ignore[dict-item]
+
+    def test_mismatched_strategy_id_rejected(self) -> None:
+        strategy = StubStrategy('actual_id')
+        executor = StrategyExecutor(strategy)
+
+        with pytest.raises(ValueError, match='does not match key'):
+            StrategyRunner({'wrong_key': executor})
+
+
+class TestStrategyRunnerDispatch:
+
+    def test_dispatch_startup_routes_to_executor(self) -> None:
+        runner, strategies = _make_runner_with_strategies('s1', 's2')
+
+        actions = runner.dispatch_startup('s1', _make_params(), _make_context())
+
+        assert strategies['s1'].calls == ['on_startup']
+        assert strategies['s2'].calls == []
+        assert len(actions) == 1
+        assert actions[0].action_type == ActionType.ENTER
+
+    def test_dispatch_signal_routes_to_executor(self) -> None:
+        runner, strategies = _make_runner_with_strategies('s1', 's2')
+
+        actions = runner.dispatch_signal('s2', _make_signal(), _make_params(), _make_context())
+
+        assert strategies['s1'].calls == []
+        assert strategies['s2'].calls == ['on_signal']
+        assert len(actions) == 1
+
+    def test_dispatch_outcome_routes_to_executor(self) -> None:
+        runner, strategies = _make_runner_with_strategies('s1')
+
+        actions = runner.dispatch_outcome('s1', _make_outcome(), _make_params(), _make_context())
+
+        assert strategies['s1'].calls == ['on_outcome']
+        assert actions[0].action_type == ActionType.EXIT
+
+    def test_dispatch_timer_routes_to_executor(self) -> None:
+        runner, strategies = _make_runner_with_strategies('s1')
+
+        actions = runner.dispatch_timer('s1', 'timer1', _make_params(), _make_context())
+
+        assert strategies['s1'].calls == ['on_timer']
+        assert actions == []
+
+    def test_dispatch_shutdown_routes_to_executor(self) -> None:
+        runner, strategies = _make_runner_with_strategies('s1')
+
+        actions = runner.dispatch_shutdown('s1', _make_params(), _make_context())
+
+        assert strategies['s1'].calls == ['on_shutdown']
+        assert actions[0].action_type == ActionType.ABORT
+
+
+class TestStrategyRunnerUnknownStrategy:
+
+    def test_dispatch_startup_unknown_strategy_raises(self) -> None:
+        runner, _ = _make_runner_with_strategies('s1')
+
+        with pytest.raises(ValueError, match='unknown strategy_id'):
+            runner.dispatch_startup('unknown', _make_params(), _make_context())
+
+    def test_dispatch_signal_unknown_strategy_raises(self) -> None:
+        runner, _ = _make_runner_with_strategies('s1')
+
+        with pytest.raises(ValueError, match='unknown strategy_id'):
+            runner.dispatch_signal('unknown', _make_signal(), _make_params(), _make_context())
+
+    def test_dispatch_outcome_unknown_strategy_raises(self) -> None:
+        runner, _ = _make_runner_with_strategies('s1')
+
+        with pytest.raises(ValueError, match='unknown strategy_id'):
+            runner.dispatch_outcome('unknown', _make_outcome(), _make_params(), _make_context())
+
+    def test_dispatch_timer_unknown_strategy_raises(self) -> None:
+        runner, _ = _make_runner_with_strategies('s1')
+
+        with pytest.raises(ValueError, match='unknown strategy_id'):
+            runner.dispatch_timer('unknown', 'timer1', _make_params(), _make_context())
+
+    def test_dispatch_shutdown_unknown_strategy_raises(self) -> None:
+        runner, _ = _make_runner_with_strategies('s1')
+
+        with pytest.raises(ValueError, match='unknown strategy_id'):
+            runner.dispatch_shutdown('unknown', _make_params(), _make_context())
+
+
+class TestStrategyRunnerMultipleStrategies:
+
+    def test_dispatch_to_multiple_strategies_independently(self) -> None:
+        runner, strategies = _make_runner_with_strategies('s1', 's2', 's3')
+
+        runner.dispatch_startup('s1', _make_params(), _make_context())
+        runner.dispatch_signal('s2', _make_signal(), _make_params(), _make_context())
+        runner.dispatch_shutdown('s3', _make_params(), _make_context())
+
+        assert strategies['s1'].calls == ['on_startup']
+        assert strategies['s2'].calls == ['on_signal']
+        assert strategies['s3'].calls == ['on_shutdown']


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Serialized callback execution for Strategy Runner (RFC-3001 phase 7.4). Adds `StrategyExecutor` class that wraps a Strategy instance with `threading.Lock` to guarantee one callback executes at a time per strategy. Adds `StrategyRunner` class that orchestrates multiple executors, routing events to the correct executor by strategy_id with key normalization and duplicate detection. Dispatch methods mirror Strategy ABC callbacks: `dispatch_startup`, `dispatch_signal`, `dispatch_outcome`, `dispatch_timer`, `dispatch_shutdown`. Adds 29 new tests (806 total passing). Bumps to v0.21.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (806 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable