### PR TITLE
feat: 9.2 shutdown sequencer — graceful termination orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,4 +227,4 @@
 - Add `InstanceConfig.shutdown_wait_timeout_seconds` and `shutdown_abort_timeout_seconds` for configurable shutdown timeouts
 - Add shutdown stubs: `_stop_signals` (TD-013), `_stop_timers` (TD-014), `_wait_terminal` (TD-016), `_deregister` (TD-012)
 - Fix import-in-method anti-pattern in [`sequencer.py`](nexus/startup/sequencer.py) by moving structlog to module level
-- Add 19 tests covering construction validation, dispatch shutdown, submit actions filtering, dispatch save, persist strategy state, final checkpoint, and full shutdown sequence (857 total)
+- Add 25 tests covering construction validation, dispatch shutdown, submit actions filtering, dispatch save, persist strategy state, final checkpoint, full shutdown sequence, executor/runner dispatch_save, and config timeout validation (863 total)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,3 +213,18 @@
 - Add runtime setup stubs: `_wire_predictor_fns` (TD-009), `_register_timers` (TD-010)
 - Add startup dispatch: `_determine_mode` stub (TD-011, always ACTIVE), `_dispatch_startup` calling strategies with context
 - Add 32 tests covering construction validation, state recovery, stubs, manifest loading, strategy instantiation, dispatch, and integration (838 total)
+
+## v0.23.0 on 3rd of April, 2026
+
+- Add [`shutdown_sequencer.py`](nexus/startup/shutdown_sequencer.py) with `ShutdownSequencer` orchestrating graceful termination: stop signals → stop timers → dispatch on_shutdown → submit actions → wait terminal → dispatch on_save → persist strategy state → final checkpoint → deregister
+- Add `_dispatch_shutdown()` building per-strategy context and collecting shutdown actions
+- Add `_submit_actions()` filtering EXIT/ABORT actions, skipping ENTER/MODIFY (TD-015 for Validator integration)
+- Add `_dispatch_save()` calling strategy on_save() and collecting state blobs
+- Add `_persist_strategy_state()` writing strategy state to individual `.bin` files with atomic tmp+rename pattern
+- Add `_final_checkpoint()` delegating to `StateStore.checkpoint()` for final snapshot + WAL truncation
+- Add `ShutdownError` exception to [`error.py`](nexus/startup/error.py)
+- Add `StrategyExecutor.dispatch_save()` and `StrategyRunner.dispatch_save()` for on_save lifecycle dispatch
+- Add `InstanceConfig.shutdown_wait_timeout_seconds` and `shutdown_abort_timeout_seconds` for configurable shutdown timeouts
+- Add shutdown stubs: `_stop_signals` (TD-013), `_stop_timers` (TD-014), `_wait_terminal` (TD-016), `_deregister` (TD-012)
+- Fix import-in-method anti-pattern in [`sequencer.py`](nexus/startup/sequencer.py) by moving structlog to module level
+- Add 19 tests covering construction validation, dispatch shutdown, submit actions filtering, dispatch save, persist strategy state, final checkpoint, and full shutdown sequence (857 total)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -173,3 +173,29 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 **When to fix**: When Praxis Connector integration is built.
 **Migration**: Extend `OutboundConnector` protocol with `register(account_id)` and `deregister(account_id)` methods. Implement in concrete connector. Remove this entry when done.
+
+---
+
+## TD-013: ShutdownSequencer._stop_signals is a stub
+
+**Origin**: 9.2.2 (shutdown sequence)
+**Severity**: High (signals continue during shutdown)
+**Module**: `nexus/startup/shutdown_sequencer.py`
+
+`_stop_signals()` logs a warning and does nothing. Without unsubscribing from predictor_fns, new signals can arrive and trigger strategy callbacks during shutdown, causing race conditions. Blocked by TD-009 — cannot stop what was never wired.
+
+**When to fix**: When predictor_fn subscription system is built (after TD-009).
+**Migration**: Implement signal unsubscription. Remove this entry when done.
+
+---
+
+## TD-014: ShutdownSequencer._stop_timers is a stub
+
+**Origin**: 9.2.2 (shutdown sequence)
+**Severity**: Medium (timers continue during shutdown)
+**Module**: `nexus/startup/shutdown_sequencer.py`
+
+`_stop_timers()` logs a warning and does nothing. Without cancelling timers, on_timer callbacks can fire during shutdown, causing race conditions. Blocked by TD-010 — cannot stop what was never registered.
+
+**When to fix**: When timer system is built (after TD-010).
+**Migration**: Implement timer cancellation. Remove this entry when done.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -212,3 +212,16 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 **When to fix**: When shutdown integration is built.
 **Migration**: Add validator and connector parameters to ShutdownSequencer. Validate filtered actions through pipeline, submit valid ones via connector. Remove this entry when done.
+
+---
+
+## TD-016: ShutdownSequencer._wait_terminal is a stub
+
+**Origin**: 9.2.5 (shutdown sequence)
+**Severity**: High (no graceful position closure)
+**Module**: `nexus/startup/shutdown_sequencer.py`
+
+`_wait_terminal()` logs a warning and returns immediately. Submitted EXIT commands are not tracked to completion. Shutdown proceeds without confirming positions are closed.
+
+**When to fix**: When TradeOutcome inbound integration is built.
+**Migration**: Subscribe/poll for TradeOutcome until all commands reach terminal state. Implement timeout with ABORT escalation. Remove this entry when done.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -199,3 +199,16 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 **When to fix**: When timer system is built (after TD-010).
 **Migration**: Implement timer cancellation. Remove this entry when done.
+
+---
+
+## TD-015: ShutdownSequencer._submit_actions lacks Validator/Connector
+
+**Origin**: 9.2.4 (shutdown sequence)
+**Severity**: High (shutdown EXIT actions not submitted)
+**Module**: `nexus/startup/shutdown_sequencer.py`
+
+`_submit_actions()` filters actions to EXIT/ABORT but cannot validate or submit them. No ValidationPipeline or OutboundConnector is wired in. EXIT actions from on_shutdown are logged but not executed.
+
+**When to fix**: When shutdown integration is built.
+**Migration**: Add validator and connector parameters to ShutdownSequencer. Validate filtered actions through pipeline, submit valid ones via connector. Remove this entry when done.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -160,3 +160,16 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 **When to fix**: When health monitoring is built.
 **Migration**: Implement health check and mode selection logic. Remove this entry when done.
+
+---
+
+## TD-012: OutboundConnector lacks register/deregister API
+
+**Origin**: 9.2 (shutdown sequence planning)
+**Severity**: Medium (no Trading sub-system lifecycle management)
+**Module**: `nexus/infrastructure/praxis_connector/outbound_connector.py`
+
+`OutboundConnector` protocol only defines `send_command()`. RFC-3001 specifies startup registration and shutdown deregistration with the Trading sub-system, but no API exists. Related to TD-005 (registration stub).
+
+**When to fix**: When Praxis Connector integration is built.
+**Migration**: Extend `OutboundConnector` protocol with `register(account_id)` and `deregister(account_id)` methods. Implement in concrete connector. Remove this entry when done.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -225,3 +225,16 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 **When to fix**: When TradeOutcome inbound integration is built.
 **Migration**: Subscribe/poll for TradeOutcome until all commands reach terminal state. Implement timeout with ABORT escalation. Remove this entry when done.
+
+---
+
+## TD-017: StrategySpec allows whitespace-padded strategy_id
+
+**Origin**: 9.2 review (manifest validation gap)
+**Severity**: Medium (potential collision after normalization)
+**Module**: `nexus/infrastructure/manifest.py`
+
+`StrategySpec.__post_init__` validates that `strategy_id.strip()` is non-empty but does not normalize or reject surrounding whitespace. This permits entries like `'s1'` and `' s1 '` to both pass validation as distinct strategies. Downstream code (StartupSequencer, ShutdownSequencer, StrategyRunner) uses `.strip()` on lookup, causing these entries to collide silently — actions and state get attributed to the wrong strategy.
+
+**When to fix**: Before multi-strategy deployments.
+**Migration**: Tighten `StrategySpec.__post_init__` to either (a) strip-and-store the normalized value, or (b) reject strategy_id with leading/trailing whitespace. Validate uniqueness after normalization. Remove this entry when done.

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -7,6 +7,7 @@ are added as their respective phases land.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from decimal import Decimal
@@ -222,6 +223,11 @@ class InstanceConfig:
             'shutdown_abort_timeout_seconds',
         ):
             value = getattr(self, field_name)
-            if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
-                msg = f'InstanceConfig.{field_name} must be a positive number'
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+                or value <= 0
+            ):
+                msg = f'InstanceConfig.{field_name} must be a finite positive number'
                 raise ValueError(msg)

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -222,6 +222,6 @@ class InstanceConfig:
             'shutdown_abort_timeout_seconds',
         ):
             value = getattr(self, field_name)
-            if not isinstance(value, (int, float)) or value <= 0:
+            if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
                 msg = f'InstanceConfig.{field_name} must be a positive number'
                 raise ValueError(msg)

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -49,6 +49,10 @@ class InstanceConfig:
             order. Defaults to ``CANCEL_TAKER``.
         capital_pct: Strategy capital-allocation percentages keyed by
             strategy_id.
+        shutdown_wait_timeout_seconds: Max seconds to wait for commands to
+            reach terminal state during shutdown. Defaults to 30.
+        shutdown_abort_timeout_seconds: Max seconds to wait after issuing
+            ABORT commands during shutdown. Defaults to 10.
     '''
 
     account_id: str
@@ -62,6 +66,8 @@ class InstanceConfig:
     reference_price_source: str | None = None
     stp_mode: STPMode = STPMode.CANCEL_TAKER
     capital_pct: Mapping[str, Decimal] = field(default_factory=dict)
+    shutdown_wait_timeout_seconds: float = 30.0
+    shutdown_abort_timeout_seconds: float = 10.0
 
     def __post_init__(self) -> None:
         '''Validate configuration invariants.'''
@@ -210,3 +216,12 @@ class InstanceConfig:
             'capital_pct',
             MappingProxyType(normalized_capital_pct),
         )
+
+        for field_name in (
+            'shutdown_wait_timeout_seconds',
+            'shutdown_abort_timeout_seconds',
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, (int, float)) or value <= 0:
+                msg = f'InstanceConfig.{field_name} must be a positive number'
+                raise ValueError(msg)

--- a/nexus/startup/__init__.py
+++ b/nexus/startup/__init__.py
@@ -1,8 +1,9 @@
-'''Startup orchestration for Manager instance.'''
+'''Startup and shutdown orchestration for Manager instance.'''
 
 from __future__ import annotations
 
+from nexus.startup.error import ShutdownError, StartupError
 from nexus.startup.sequencer import StartupSequencer
-from nexus.startup.error import StartupError
+from nexus.startup.shutdown_sequencer import ShutdownSequencer
 
-__all__ = ['StartupError', 'StartupSequencer']
+__all__ = ['ShutdownError', 'ShutdownSequencer', 'StartupError', 'StartupSequencer']

--- a/nexus/startup/error.py
+++ b/nexus/startup/error.py
@@ -1,8 +1,8 @@
-'''Startup error types.'''
+'''Startup and shutdown error types.'''
 
 from __future__ import annotations
 
-__all__ = ['StartupError']
+__all__ = ['ShutdownError', 'StartupError']
 
 
 class StartupError(Exception):
@@ -17,3 +17,17 @@ class StartupError(Exception):
         self.step = step
         self.reason = reason
         super().__init__(f'Startup failed at {step}: {reason}')
+
+
+class ShutdownError(Exception):
+    '''Raised when shutdown sequence fails critically.
+
+    Args:
+        step: Name of the step that failed.
+        reason: Description of the failure.
+    '''
+
+    def __init__(self, step: str, reason: str) -> None:
+        self.step = step
+        self.reason = reason
+        super().__init__(f'Shutdown failed at {step}: {reason}')

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -16,7 +16,10 @@ from nexus.strategy.params import StrategyParams
 from nexus.strategy.runner import StrategyRunner
 from nexus.startup.error import StartupError
 
+import structlog
+
 _HUNDRED = Decimal('100')
+_log = structlog.get_logger()
 
 __all__ = ['StartupSequencer']
 
@@ -114,8 +117,7 @@ class StartupSequencer:
         Stub: logs warning, does nothing. See TD-005.
         '''
 
-        import structlog
-        structlog.get_logger().warning('register_with_trading not implemented')
+        _log.warning('register_with_trading not implemented')
 
     def _reconcile_capital(self) -> None:
         '''Reconcile capital state against Trading positions.
@@ -123,8 +125,7 @@ class StartupSequencer:
         Stub: logs warning, does nothing. See TD-006.
         '''
 
-        import structlog
-        structlog.get_logger().warning('reconcile_capital not implemented')
+        _log.warning('reconcile_capital not implemented')
 
     def _load_manifest(self) -> None:
         '''Load and validate strategy manifest.'''
@@ -159,8 +160,7 @@ class StartupSequencer:
         Strategy state blob storage not implemented yet.
         '''
 
-        import structlog
-        structlog.get_logger().warning('restore_strategy_state not implemented')
+        _log.warning('restore_strategy_state not implemented')
 
     def _replay_strategy_events(self) -> None:
         '''Replay strategy events from WAL (actions discarded).
@@ -169,8 +169,7 @@ class StartupSequencer:
         Event replay to strategies not implemented yet.
         '''
 
-        import structlog
-        structlog.get_logger().warning('replay_strategy_events not implemented')
+        _log.warning('replay_strategy_events not implemented')
 
     def _wire_predictor_fns(self) -> None:
         '''Wire predictor_fn subscriptions.
@@ -179,8 +178,7 @@ class StartupSequencer:
         Predictor function wiring not implemented yet.
         '''
 
-        import structlog
-        structlog.get_logger().warning('wire_predictor_fns not implemented')
+        _log.warning('wire_predictor_fns not implemented')
 
     def _register_timers(self) -> None:
         '''Register strategy timers.
@@ -189,8 +187,7 @@ class StartupSequencer:
         Timer registration not implemented yet.
         '''
 
-        import structlog
-        structlog.get_logger().warning('register_timers not implemented')
+        _log.warning('register_timers not implemented')
 
     def _determine_mode(self) -> None:
         '''Determine operational mode based on health.
@@ -199,8 +196,7 @@ class StartupSequencer:
         Health check not implemented yet.
         '''
 
-        import structlog
-        structlog.get_logger().warning('determine_mode health check not implemented, defaulting to ACTIVE')
+        _log.warning('determine_mode health check not implemented, defaulting to ACTIVE')
         self._mode = OperationalMode.ACTIVE
 
     def _dispatch_startup(self) -> None:

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -5,18 +5,18 @@ from __future__ import annotations
 from decimal import Decimal
 from pathlib import Path
 
+import structlog
+
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
-from nexus.infrastructure.state_store import StateStore
 from nexus.infrastructure.manifest import Manifest, load_manifest
+from nexus.infrastructure.state_store import StateStore
+from nexus.startup.error import StartupError
 from nexus.strategy.context import StrategyContext
-from nexus.strategy.loader import instantiate_strategy
 from nexus.strategy.executor import StrategyExecutor
+from nexus.strategy.loader import instantiate_strategy
 from nexus.strategy.params import StrategyParams
 from nexus.strategy.runner import StrategyRunner
-from nexus.startup.error import StartupError
-
-import structlog
 
 _HUNDRED = Decimal('100')
 _log = structlog.get_logger()

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -77,6 +77,10 @@ class ShutdownSequencer:
     def shutdown(self) -> None:
         '''Execute the full shutdown sequence.'''
 
+        self._shutdown_actions.clear()
+        self._submitted_command_ids.clear()
+        self._save_blobs.clear()
+
         self._stop_signals()
         self._stop_timers()
         self._dispatch_shutdown()

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from decimal import Decimal
 from pathlib import Path
 
+import structlog
+
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.manifest import Manifest
 from nexus.infrastructure.state_store import StateStore
@@ -12,8 +14,6 @@ from nexus.strategy.action import Action, ActionType
 from nexus.strategy.context import StrategyContext
 from nexus.strategy.params import StrategyParams
 from nexus.strategy.runner import StrategyRunner
-
-import structlog
 
 __all__ = ['ShutdownSequencer']
 
@@ -212,7 +212,11 @@ class ShutdownSequencer:
         if not self._save_blobs:
             return
 
-        self._strategy_state_path.mkdir(parents=True, exist_ok=True)
+        try:
+            self._strategy_state_path.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            _log.exception('failed to create strategy_state directory')
+            return
 
         for strategy_id, blob in self._save_blobs.items():
             if not blob:

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -171,10 +171,18 @@ class ShutdownSequencer:
     def _wait_terminal(self) -> None:
         '''Wait for all submitted commands to reach terminal state.
 
-        Stub: logs warning, does nothing. Implemented in 9.2.5.
+        Stub: logs warning, returns immediately. No outcome tracking yet.
+        Future: poll/subscribe for TradeOutcome until all commands terminal.
+        On timeout: ABORT remaining commands, wait again with shorter timeout.
         '''
 
-        _log.warning('wait_terminal not implemented')
+        if not self._submitted_command_ids:
+            return
+
+        _log.warning(
+            'wait_terminal not implemented',
+            command_count=len(self._submitted_command_ids),
+        )
 
     def _dispatch_save(self) -> None:
         '''Dispatch on_save to all strategies.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from pathlib import Path
 
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.manifest import Manifest
 from nexus.infrastructure.state_store import StateStore
+from nexus.strategy.action import Action
+from nexus.strategy.context import StrategyContext
+from nexus.strategy.params import StrategyParams
 from nexus.strategy.runner import StrategyRunner
 
 import structlog
@@ -14,6 +18,7 @@ import structlog
 __all__ = ['ShutdownSequencer']
 
 _log = structlog.get_logger()
+_HUNDRED = Decimal('100')
 
 
 class ShutdownSequencer:
@@ -64,6 +69,7 @@ class ShutdownSequencer:
         self._state_store = state_store
         self._state = state
         self._strategy_state_path = strategy_state_path
+        self._shutdown_actions: dict[str, list[Action]] = {}
 
     def shutdown(self) -> None:
         '''Execute the full shutdown sequence.
@@ -101,10 +107,35 @@ class ShutdownSequencer:
     def _dispatch_shutdown(self) -> None:
         '''Dispatch on_shutdown to all strategies.
 
-        Stub: logs warning, does nothing. Implemented in 9.2.3.
+        Calls dispatch_shutdown on each strategy with context built from
+        current state. Collects returned actions keyed by strategy_id.
+        Strategy exceptions are logged and skipped — shutdown continues.
         '''
 
-        _log.warning('dispatch_shutdown not implemented')
+        for spec in self._manifest.strategies:
+            strategy_id = spec.strategy_id.strip()
+
+            positions = tuple(
+                pos for pos in self._state.positions.values()
+                if pos.strategy_id == strategy_id
+            )
+
+            capital_available = self._manifest.capital_pool * spec.capital_pct / _HUNDRED
+            mode = self._state.mode.mode
+
+            params = StrategyParams(raw={})
+            context = StrategyContext(
+                positions=positions,
+                capital_available=capital_available,
+                operational_mode=mode,
+            )
+
+            try:
+                actions = self._runner.dispatch_shutdown(strategy_id, params, context)
+                if actions:
+                    self._shutdown_actions[strategy_id] = actions
+            except Exception:  # noqa: BLE001 - intentional catch-all for strategy code
+                _log.exception('on_shutdown failed', strategy_id=strategy_id)
 
     def _submit_actions(self) -> None:
         '''Submit EXIT/ABORT/CANCEL actions through Validator.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.manifest import Manifest
 from nexus.infrastructure.state_store import StateStore
-from nexus.strategy.action import Action
+from nexus.strategy.action import Action, ActionType
 from nexus.strategy.context import StrategyContext
 from nexus.strategy.params import StrategyParams
 from nexus.strategy.runner import StrategyRunner
@@ -70,6 +70,7 @@ class ShutdownSequencer:
         self._state = state
         self._strategy_state_path = strategy_state_path
         self._shutdown_actions: dict[str, list[Action]] = {}
+        self._submitted_command_ids: list[str] = []
 
     def shutdown(self) -> None:
         '''Execute the full shutdown sequence.
@@ -138,12 +139,34 @@ class ShutdownSequencer:
                 _log.exception('on_shutdown failed', strategy_id=strategy_id)
 
     def _submit_actions(self) -> None:
-        '''Submit EXIT/ABORT/CANCEL actions through Validator.
+        '''Submit EXIT/ABORT actions through Validator.
 
-        Stub: logs warning, does nothing. Implemented in 9.2.4.
+        Filters actions returned by strategies from _dispatch_shutdown.
+        Only EXIT/ABORT are allowed during shutdown; ENTER/MODIFY skipped.
+        Validation and submission are stubs until Validator/Connector wired.
         '''
 
-        _log.warning('submit_actions not implemented')
+        allowed_types = (ActionType.EXIT, ActionType.ABORT)
+        filtered: list[tuple[str, Action]] = []
+
+        for strategy_id, actions in self._shutdown_actions.items():
+            for action in actions:
+                if action.action_type in allowed_types:
+                    filtered.append((strategy_id, action))
+                else:
+                    _log.info(
+                        'skipping non-shutdown action',
+                        strategy_id=strategy_id,
+                        action_type=action.action_type.value,
+                    )
+
+        if not filtered:
+            return
+
+        _log.warning(
+            'submit_actions validation/submission not implemented',
+            action_count=len(filtered),
+        )
 
     def _wait_terminal(self) -> None:
         '''Wait for all submitted commands to reach terminal state.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -231,10 +231,11 @@ class ShutdownSequencer:
     def _final_checkpoint(self) -> None:
         '''Save final snapshot and truncate WAL.
 
-        Stub: logs warning, does nothing. Implemented in 9.2.8.
+        Calls StateStore.checkpoint to persist current state
+        and truncate the WAL before exit.
         '''
 
-        _log.warning('final_checkpoint not implemented')
+        self._state_store.checkpoint(self._state)
 
     def _deregister(self) -> None:
         '''Deregister from Trading sub-system.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -74,11 +74,7 @@ class ShutdownSequencer:
         self._save_blobs: dict[str, bytes] = {}
 
     def shutdown(self) -> None:
-        '''Execute the full shutdown sequence.
-
-        Raises:
-            ShutdownError: If a critical step fails (state corruption).
-        '''
+        '''Execute the full shutdown sequence.'''
 
         self._stop_signals()
         self._stop_timers()
@@ -87,13 +83,16 @@ class ShutdownSequencer:
         self._wait_terminal()
         self._dispatch_save()
         self._persist_strategy_state()
-        self._final_checkpoint()
+        try:
+            self._final_checkpoint()
+        except Exception:  # noqa: BLE001 - checkpoint failure must not prevent deregister
+            _log.exception('final_checkpoint failed')
         self._deregister()
 
     def _stop_signals(self) -> None:
         '''Stop predictor_fn signal subscriptions.
 
-        Stub: logs warning, does nothing. See TD-009.
+        Stub: logs warning, does nothing. See TD-013.
         '''
 
         _log.warning('stop_signals not implemented')
@@ -101,7 +100,7 @@ class ShutdownSequencer:
     def _stop_timers(self) -> None:
         '''Cancel all registered strategy timers.
 
-        Stub: logs warning, does nothing. See TD-010.
+        Stub: logs warning, does nothing. See TD-014.
         '''
 
         _log.warning('stop_timers not implemented')
@@ -217,6 +216,10 @@ class ShutdownSequencer:
 
         for strategy_id, blob in self._save_blobs.items():
             if not blob:
+                continue
+
+            if '/' in strategy_id or '\\' in strategy_id:
+                _log.error('invalid strategy_id for persistence', strategy_id=strategy_id)
                 continue
 
             target = self._strategy_state_path / f'{strategy_id}.bin'

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -71,6 +71,7 @@ class ShutdownSequencer:
         self._strategy_state_path = strategy_state_path
         self._shutdown_actions: dict[str, list[Action]] = {}
         self._submitted_command_ids: list[str] = []
+        self._save_blobs: dict[str, bytes] = {}
 
     def shutdown(self) -> None:
         '''Execute the full shutdown sequence.
@@ -187,18 +188,45 @@ class ShutdownSequencer:
     def _dispatch_save(self) -> None:
         '''Dispatch on_save to all strategies.
 
-        Stub: logs warning, does nothing. Implemented in 9.2.6.
+        Calls dispatch_save on each strategy to serialize state.
+        Strategy exceptions are logged and skipped with empty bytes.
         '''
 
-        _log.warning('dispatch_save not implemented')
+        for spec in self._manifest.strategies:
+            strategy_id = spec.strategy_id.strip()
+
+            try:
+                blob = self._runner.dispatch_save(strategy_id)
+                self._save_blobs[strategy_id] = blob
+            except Exception:  # noqa: BLE001 - intentional catch-all for strategy code
+                _log.exception('on_save failed', strategy_id=strategy_id)
+                self._save_blobs[strategy_id] = b''
 
     def _persist_strategy_state(self) -> None:
         '''Persist strategy state blobs to disk.
 
-        Stub: logs warning, does nothing. Implemented in 9.2.7.
+        Creates strategy_state directory if needed. Writes each blob
+        to {strategy_id}.bin with atomic write (tmp + rename).
+        Write failures are logged but don't abort shutdown.
         '''
 
-        _log.warning('persist_strategy_state not implemented')
+        if not self._save_blobs:
+            return
+
+        self._strategy_state_path.mkdir(parents=True, exist_ok=True)
+
+        for strategy_id, blob in self._save_blobs.items():
+            if not blob:
+                continue
+
+            target = self._strategy_state_path / f'{strategy_id}.bin'
+            tmp = target.with_suffix('.tmp')
+
+            try:
+                tmp.write_bytes(blob)
+                tmp.replace(target)
+            except OSError:
+                _log.exception('persist_strategy_state failed', strategy_id=strategy_id)
 
     def _final_checkpoint(self) -> None:
         '''Save final snapshot and truncate WAL.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -152,6 +152,14 @@ class ShutdownSequencer:
 
         for strategy_id, actions in self._shutdown_actions.items():
             for action in actions:
+                if not isinstance(action, Action):
+                    _log.warning(
+                        'skipping invalid shutdown action',
+                        strategy_id=strategy_id,
+                        action_type=type(action).__name__,
+                    )
+                    continue
+
                 if action.action_type in allowed_types:
                     filtered.append((strategy_id, action))
                 else:

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from decimal import Decimal
 from pathlib import Path
 
@@ -230,8 +231,16 @@ class ShutdownSequencer:
             tmp = target.with_suffix('.tmp')
 
             try:
-                tmp.write_bytes(blob)
+                with tmp.open('wb') as f:
+                    f.write(blob)
+                    f.flush()
+                    os.fsync(f.fileno())
                 tmp.replace(target)
+                fd = os.open(str(self._strategy_state_path), os.O_RDONLY)
+                try:
+                    os.fsync(fd)
+                finally:
+                    os.close(fd)
             except OSError:
                 _log.exception('persist_strategy_state failed', strategy_id=strategy_id)
 

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -219,6 +219,7 @@ class ShutdownSequencer:
             _log.exception('failed to create strategy_state directory')
             return
 
+        wrote_any = False
         for strategy_id, blob in self._save_blobs.items():
             if not blob:
                 continue
@@ -236,13 +237,19 @@ class ShutdownSequencer:
                     f.flush()
                     os.fsync(f.fileno())
                 tmp.replace(target)
+                wrote_any = True
+            except OSError:
+                _log.exception('persist_strategy_state failed', strategy_id=strategy_id)
+
+        if wrote_any:
+            try:
                 fd = os.open(str(self._strategy_state_path), os.O_RDONLY)
                 try:
                     os.fsync(fd)
                 finally:
                     os.close(fd)
             except OSError:
-                _log.exception('persist_strategy_state failed', strategy_id=strategy_id)
+                _log.exception('failed to fsync strategy_state directory')
 
     def _final_checkpoint(self) -> None:
         '''Save final snapshot and truncate WAL.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -1,0 +1,155 @@
+'''Shutdown sequencer for Manager instance graceful termination.'''
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nexus.core.domain.instance_state import InstanceState
+from nexus.infrastructure.manifest import Manifest
+from nexus.infrastructure.state_store import StateStore
+from nexus.strategy.runner import StrategyRunner
+
+import structlog
+
+__all__ = ['ShutdownSequencer']
+
+_log = structlog.get_logger()
+
+
+class ShutdownSequencer:
+    '''Orchestrates the shutdown sequence for a Manager instance.
+
+    Executes steps in order: stop signals → stop timers → dispatch on_shutdown →
+    submit actions through Validator → wait for terminal outcomes → dispatch on_save →
+    persist strategy state → final checkpoint → deregister.
+
+    Args:
+        runner: StrategyRunner with active strategy executors.
+        manifest: Loaded strategy manifest.
+        state_store: Persistence facade for checkpointing.
+        state: Current instance state.
+        strategy_state_path: Directory for strategy state blobs.
+    '''
+
+    def __init__(
+        self,
+        runner: StrategyRunner,
+        manifest: Manifest,
+        state_store: StateStore,
+        state: InstanceState,
+        strategy_state_path: Path,
+    ) -> None:
+        if not isinstance(runner, StrategyRunner):
+            msg = 'runner must be a StrategyRunner instance'
+            raise ValueError(msg)
+
+        if not isinstance(manifest, Manifest):
+            msg = 'manifest must be a Manifest instance'
+            raise ValueError(msg)
+
+        if not isinstance(state_store, StateStore):
+            msg = 'state_store must be a StateStore instance'
+            raise ValueError(msg)
+
+        if not isinstance(state, InstanceState):
+            msg = 'state must be an InstanceState instance'
+            raise ValueError(msg)
+
+        if not isinstance(strategy_state_path, Path):
+            msg = 'strategy_state_path must be a Path'
+            raise ValueError(msg)
+
+        self._runner = runner
+        self._manifest = manifest
+        self._state_store = state_store
+        self._state = state
+        self._strategy_state_path = strategy_state_path
+
+    def shutdown(self) -> None:
+        '''Execute the full shutdown sequence.
+
+        Raises:
+            ShutdownError: If a critical step fails (state corruption).
+        '''
+
+        self._stop_signals()
+        self._stop_timers()
+        self._dispatch_shutdown()
+        self._submit_actions()
+        self._wait_terminal()
+        self._dispatch_save()
+        self._persist_strategy_state()
+        self._final_checkpoint()
+        self._deregister()
+
+    def _stop_signals(self) -> None:
+        '''Stop predictor_fn signal subscriptions.
+
+        Stub: logs warning, does nothing. See TD-009.
+        '''
+
+        _log.warning('stop_signals not implemented')
+
+    def _stop_timers(self) -> None:
+        '''Cancel all registered strategy timers.
+
+        Stub: logs warning, does nothing. See TD-010.
+        '''
+
+        _log.warning('stop_timers not implemented')
+
+    def _dispatch_shutdown(self) -> None:
+        '''Dispatch on_shutdown to all strategies.
+
+        Stub: logs warning, does nothing. Implemented in 9.2.3.
+        '''
+
+        _log.warning('dispatch_shutdown not implemented')
+
+    def _submit_actions(self) -> None:
+        '''Submit EXIT/ABORT/CANCEL actions through Validator.
+
+        Stub: logs warning, does nothing. Implemented in 9.2.4.
+        '''
+
+        _log.warning('submit_actions not implemented')
+
+    def _wait_terminal(self) -> None:
+        '''Wait for all submitted commands to reach terminal state.
+
+        Stub: logs warning, does nothing. Implemented in 9.2.5.
+        '''
+
+        _log.warning('wait_terminal not implemented')
+
+    def _dispatch_save(self) -> None:
+        '''Dispatch on_save to all strategies.
+
+        Stub: logs warning, does nothing. Implemented in 9.2.6.
+        '''
+
+        _log.warning('dispatch_save not implemented')
+
+    def _persist_strategy_state(self) -> None:
+        '''Persist strategy state blobs to disk.
+
+        Stub: logs warning, does nothing. Implemented in 9.2.7.
+        '''
+
+        _log.warning('persist_strategy_state not implemented')
+
+    def _final_checkpoint(self) -> None:
+        '''Save final snapshot and truncate WAL.
+
+        Stub: logs warning, does nothing. Implemented in 9.2.8.
+        '''
+
+        _log.warning('final_checkpoint not implemented')
+
+    def _deregister(self) -> None:
+        '''Deregister from Trading sub-system.
+
+        Stub: logs warning, does nothing. See TD-012.
+        '''
+
+        _log.warning('deregister not implemented')

--- a/nexus/strategy/executor.py
+++ b/nexus/strategy/executor.py
@@ -132,3 +132,13 @@ class StrategyExecutor:
 
         with self._lock:
             return self._strategy.on_shutdown(params, context)
+
+    def dispatch_save(self) -> bytes:
+        '''Dispatch save event to strategy under lock.
+
+        Returns:
+            Serialized strategy state bytes.
+        '''
+
+        with self._lock:
+            return self._strategy.on_save()

--- a/nexus/strategy/runner.py
+++ b/nexus/strategy/runner.py
@@ -186,3 +186,18 @@ class StrategyRunner:
         '''
 
         return self._get_executor(strategy_id).dispatch_shutdown(params, context)
+
+    def dispatch_save(self, strategy_id: str) -> bytes:
+        '''Dispatch save event to strategy.
+
+        Args:
+            strategy_id: Target strategy identifier.
+
+        Returns:
+            Serialized strategy state bytes.
+
+        Raises:
+            ValueError: If strategy_id is unknown.
+        '''
+
+        return self._get_executor(strategy_id).dispatch_save()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.22.0"
+version = "0.23.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -519,7 +519,7 @@ def test_capital_pct_total_above_100_rejected() -> None:
 def test_shutdown_wait_timeout_bool_rejected() -> None:
     '''Verify bool shutdown_wait_timeout_seconds raises ValueError.'''
 
-    with pytest.raises(ValueError, match='shutdown_wait_timeout_seconds must be a positive'):
+    with pytest.raises(ValueError, match='shutdown_wait_timeout_seconds must be a finite positive'):
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
@@ -531,7 +531,7 @@ def test_shutdown_wait_timeout_bool_rejected() -> None:
 def test_shutdown_abort_timeout_bool_rejected() -> None:
     '''Verify bool shutdown_abort_timeout_seconds raises ValueError.'''
 
-    with pytest.raises(ValueError, match='shutdown_abort_timeout_seconds must be a positive'):
+    with pytest.raises(ValueError, match='shutdown_abort_timeout_seconds must be a finite positive'):
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
@@ -543,7 +543,7 @@ def test_shutdown_abort_timeout_bool_rejected() -> None:
 def test_shutdown_wait_timeout_zero_rejected() -> None:
     '''Verify zero shutdown_wait_timeout_seconds raises ValueError.'''
 
-    with pytest.raises(ValueError, match='shutdown_wait_timeout_seconds must be a positive'):
+    with pytest.raises(ValueError, match='shutdown_wait_timeout_seconds must be a finite positive'):
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
@@ -555,7 +555,7 @@ def test_shutdown_wait_timeout_zero_rejected() -> None:
 def test_shutdown_abort_timeout_negative_rejected() -> None:
     '''Verify negative shutdown_abort_timeout_seconds raises ValueError.'''
 
-    with pytest.raises(ValueError, match='shutdown_abort_timeout_seconds must be a positive'):
+    with pytest.raises(ValueError, match='shutdown_abort_timeout_seconds must be a finite positive'):
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -514,3 +514,51 @@ def test_capital_pct_total_above_100_rejected() -> None:
             allocated_capital=Decimal('10000'),
             capital_pct={'momentum': Decimal('70'), 'mean_rev': Decimal('40')},
         )
+
+
+def test_shutdown_wait_timeout_bool_rejected() -> None:
+    '''Verify bool shutdown_wait_timeout_seconds raises ValueError.'''
+
+    with pytest.raises(ValueError, match='shutdown_wait_timeout_seconds must be a positive'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            shutdown_wait_timeout_seconds=True,
+        )
+
+
+def test_shutdown_abort_timeout_bool_rejected() -> None:
+    '''Verify bool shutdown_abort_timeout_seconds raises ValueError.'''
+
+    with pytest.raises(ValueError, match='shutdown_abort_timeout_seconds must be a positive'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            shutdown_abort_timeout_seconds=False,
+        )
+
+
+def test_shutdown_wait_timeout_zero_rejected() -> None:
+    '''Verify zero shutdown_wait_timeout_seconds raises ValueError.'''
+
+    with pytest.raises(ValueError, match='shutdown_wait_timeout_seconds must be a positive'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            shutdown_wait_timeout_seconds=0,
+        )
+
+
+def test_shutdown_abort_timeout_negative_rejected() -> None:
+    '''Verify negative shutdown_abort_timeout_seconds raises ValueError.'''
+
+    with pytest.raises(ValueError, match='shutdown_abort_timeout_seconds must be a positive'):
+        InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            shutdown_abort_timeout_seconds=-5.0,
+        )

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -1,0 +1,272 @@
+'''Tests for ShutdownSequencer.'''
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.instance_state import InstanceState
+from nexus.infrastructure.manifest import Manifest, StrategySpec
+from nexus.infrastructure.state_store import StateStore
+from nexus.startup.shutdown_sequencer import ShutdownSequencer
+from nexus.strategy.action import Action, ActionType
+from nexus.strategy.runner import StrategyRunner
+
+_PLACEHOLDER_PATH = Path('/placeholder/strategy_state')
+
+
+def _make_mock_runner() -> MagicMock:
+    return MagicMock(spec=StrategyRunner)
+
+
+def _make_mock_state_store() -> MagicMock:
+    return MagicMock(spec=StateStore)
+
+
+def _make_instance_state() -> InstanceState:
+    return InstanceState(capital=CapitalState(capital_pool=Decimal('10000')))
+
+
+def _make_strategy_spec(strategy_id: str = 'test_strategy') -> StrategySpec:
+    return StrategySpec(
+        strategy_id=strategy_id,
+        file='test.py',
+        permutation_ids=('perm1',),
+        capital_pct=Decimal('50'),
+    )
+
+
+def _make_manifest(strategies: tuple[StrategySpec, ...] | None = None) -> Manifest:
+    return Manifest(
+        capital_pool=Decimal('10000'),
+        strategies=strategies or (_make_strategy_spec(),),
+    )
+
+
+def _make_sequencer(
+    runner: StrategyRunner | None = None,
+    manifest: Manifest | None = None,
+    state_store: StateStore | None = None,
+    state: InstanceState | None = None,
+    strategy_state_path: Path | None = None,
+) -> ShutdownSequencer:
+    return ShutdownSequencer(
+        runner=runner or _make_mock_runner(),
+        manifest=manifest or _make_manifest(),
+        state_store=state_store or _make_mock_state_store(),
+        state=state or _make_instance_state(),
+        strategy_state_path=strategy_state_path or _PLACEHOLDER_PATH,
+    )
+
+
+class TestShutdownSequencerConstruction:
+
+    def test_valid_construction(self) -> None:
+        sequencer = _make_sequencer()
+        assert sequencer is not None
+
+    def test_invalid_runner_rejected(self) -> None:
+        with pytest.raises(ValueError, match='must be a StrategyRunner'):
+            ShutdownSequencer(
+                runner='not a runner',  # type: ignore[arg-type]
+                manifest=_make_manifest(),
+                state_store=_make_mock_state_store(),
+                state=_make_instance_state(),
+                strategy_state_path=_PLACEHOLDER_PATH,
+            )
+
+    def test_invalid_manifest_rejected(self) -> None:
+        with pytest.raises(ValueError, match='must be a Manifest'):
+            ShutdownSequencer(
+                runner=_make_mock_runner(),
+                manifest='not a manifest',  # type: ignore[arg-type]
+                state_store=_make_mock_state_store(),
+                state=_make_instance_state(),
+                strategy_state_path=_PLACEHOLDER_PATH,
+            )
+
+    def test_invalid_state_store_rejected(self) -> None:
+        with pytest.raises(ValueError, match='must be a StateStore'):
+            ShutdownSequencer(
+                runner=_make_mock_runner(),
+                manifest=_make_manifest(),
+                state_store='not a state store',  # type: ignore[arg-type]
+                state=_make_instance_state(),
+                strategy_state_path=_PLACEHOLDER_PATH,
+            )
+
+    def test_invalid_state_rejected(self) -> None:
+        with pytest.raises(ValueError, match='must be an InstanceState'):
+            ShutdownSequencer(
+                runner=_make_mock_runner(),
+                manifest=_make_manifest(),
+                state_store=_make_mock_state_store(),
+                state='not a state',  # type: ignore[arg-type]
+                strategy_state_path=_PLACEHOLDER_PATH,
+            )
+
+    def test_invalid_strategy_state_path_rejected(self) -> None:
+        with pytest.raises(ValueError, match='must be a Path'):
+            ShutdownSequencer(
+                runner=_make_mock_runner(),
+                manifest=_make_manifest(),
+                state_store=_make_mock_state_store(),
+                state=_make_instance_state(),
+                strategy_state_path='/placeholder',  # type: ignore[arg-type]
+            )
+
+
+class TestDispatchShutdown:
+
+    def test_dispatch_shutdown_calls_runner(self) -> None:
+        runner = _make_mock_runner()
+        runner.dispatch_shutdown.return_value = []
+        sequencer = _make_sequencer(runner=runner)
+
+        sequencer._dispatch_shutdown()
+
+        runner.dispatch_shutdown.assert_called_once()
+
+    def test_dispatch_shutdown_collects_actions(self) -> None:
+        runner = _make_mock_runner()
+        action = Action(action_type=ActionType.EXIT)
+        runner.dispatch_shutdown.return_value = [action]
+        sequencer = _make_sequencer(runner=runner)
+
+        sequencer._dispatch_shutdown()
+
+        assert 'test_strategy' in sequencer._shutdown_actions
+        assert sequencer._shutdown_actions['test_strategy'] == [action]
+
+    def test_dispatch_shutdown_continues_on_exception(self) -> None:
+        runner = _make_mock_runner()
+        runner.dispatch_shutdown.side_effect = RuntimeError('strategy error')
+        sequencer = _make_sequencer(runner=runner)
+
+        sequencer._dispatch_shutdown()
+
+        assert sequencer._shutdown_actions == {}
+
+
+class TestSubmitActions:
+
+    def test_submit_actions_filters_exit_abort(self) -> None:
+        sequencer = _make_sequencer()
+        sequencer._shutdown_actions = {
+            'test': [
+                Action(action_type=ActionType.EXIT),
+                Action(action_type=ActionType.ABORT),
+                Action(action_type=ActionType.ENTER),
+                Action(action_type=ActionType.MODIFY),
+            ],
+        }
+
+        sequencer._submit_actions()
+
+        assert sequencer._submitted_command_ids == []
+
+    def test_submit_actions_skips_empty(self) -> None:
+        sequencer = _make_sequencer()
+        sequencer._shutdown_actions = {}
+
+        sequencer._submit_actions()
+
+        assert sequencer._submitted_command_ids == []
+
+
+class TestDispatchSave:
+
+    def test_dispatch_save_calls_runner(self) -> None:
+        runner = _make_mock_runner()
+        runner.dispatch_save.return_value = b'state'
+        sequencer = _make_sequencer(runner=runner)
+
+        sequencer._dispatch_save()
+
+        runner.dispatch_save.assert_called_once_with('test_strategy')
+
+    def test_dispatch_save_collects_blobs(self) -> None:
+        runner = _make_mock_runner()
+        runner.dispatch_save.return_value = b'saved_state'
+        sequencer = _make_sequencer(runner=runner)
+
+        sequencer._dispatch_save()
+
+        assert sequencer._save_blobs['test_strategy'] == b'saved_state'
+
+    def test_dispatch_save_continues_on_exception(self) -> None:
+        runner = _make_mock_runner()
+        runner.dispatch_save.side_effect = RuntimeError('save error')
+        sequencer = _make_sequencer(runner=runner)
+
+        sequencer._dispatch_save()
+
+        assert sequencer._save_blobs['test_strategy'] == b''
+
+
+class TestPersistStrategyState:
+
+    def test_persist_writes_blobs(self, tmp_path: Path) -> None:
+        sequencer = _make_sequencer(strategy_state_path=tmp_path)
+        sequencer._save_blobs = {'test_strategy': b'blob_data'}
+
+        sequencer._persist_strategy_state()
+
+        blob_file = tmp_path / 'test_strategy.bin'
+        assert blob_file.exists()
+        assert blob_file.read_bytes() == b'blob_data'
+
+    def test_persist_skips_empty_blobs(self, tmp_path: Path) -> None:
+        sequencer = _make_sequencer(strategy_state_path=tmp_path)
+        sequencer._save_blobs = {'test_strategy': b''}
+
+        sequencer._persist_strategy_state()
+
+        blob_file = tmp_path / 'test_strategy.bin'
+        assert not blob_file.exists()
+
+    def test_persist_creates_directory(self, tmp_path: Path) -> None:
+        nested_path = tmp_path / 'nested' / 'state'
+        sequencer = _make_sequencer(strategy_state_path=nested_path)
+        sequencer._save_blobs = {'test_strategy': b'data'}
+
+        sequencer._persist_strategy_state()
+
+        assert nested_path.exists()
+        assert (nested_path / 'test_strategy.bin').read_bytes() == b'data'
+
+
+class TestFinalCheckpoint:
+
+    def test_checkpoint_calls_state_store(self) -> None:
+        state_store = _make_mock_state_store()
+        state = _make_instance_state()
+        sequencer = _make_sequencer(state_store=state_store, state=state)
+
+        sequencer._final_checkpoint()
+
+        state_store.checkpoint.assert_called_once_with(state)
+
+
+class TestShutdownSequence:
+
+    def test_shutdown_runs_all_steps(self, tmp_path: Path) -> None:
+        runner = _make_mock_runner()
+        runner.dispatch_shutdown.return_value = []
+        runner.dispatch_save.return_value = b''
+        state_store = _make_mock_state_store()
+        sequencer = _make_sequencer(
+            runner=runner,
+            state_store=state_store,
+            strategy_state_path=tmp_path,
+        )
+
+        sequencer.shutdown()
+
+        runner.dispatch_shutdown.assert_called_once()
+        runner.dispatch_save.assert_called_once()
+        state_store.checkpoint.assert_called_once()

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -270,3 +270,21 @@ class TestShutdownSequence:
         runner.dispatch_shutdown.assert_called_once()
         runner.dispatch_save.assert_called_once()
         state_store.checkpoint.assert_called_once()
+
+    def test_shutdown_is_idempotent(self, tmp_path: Path) -> None:
+        runner = _make_mock_runner()
+        runner.dispatch_shutdown.return_value = []
+        runner.dispatch_save.return_value = b''
+        state_store = _make_mock_state_store()
+        sequencer = _make_sequencer(
+            runner=runner,
+            state_store=state_store,
+            strategy_state_path=tmp_path,
+        )
+
+        sequencer.shutdown()
+        sequencer.shutdown()
+
+        assert runner.dispatch_shutdown.call_count == 2
+        assert runner.dispatch_save.call_count == 2
+        assert state_store.checkpoint.call_count == 2

--- a/tests/test_strategy_executor.py
+++ b/tests/test_strategy_executor.py
@@ -25,7 +25,8 @@ class StubStrategy(Strategy):
         self.delay: float = 0.0
 
     def on_save(self) -> bytes:
-        return b''
+        self.calls.append('on_save')
+        return b'saved_state'
 
     def on_load(self, _data: bytes) -> None:
         pass
@@ -176,6 +177,15 @@ class TestStrategyExecutorDispatch:
         assert strategy.calls == ['on_shutdown']
         assert len(actions) == 1
         assert actions[0].action_type == ActionType.ABORT
+
+    def test_dispatch_save_delegates(self) -> None:
+        strategy = StubStrategy('s1')
+        executor = StrategyExecutor(strategy)
+
+        blob = executor.dispatch_save()
+
+        assert strategy.calls == ['on_save']
+        assert blob == b'saved_state'
 
 
 class TestStrategyExecutorConcurrency:

--- a/tests/test_strategy_runner.py
+++ b/tests/test_strategy_runner.py
@@ -23,7 +23,8 @@ class StubStrategy(Strategy):
         self.calls: list[str] = []
 
     def on_save(self) -> bytes:
-        return b''
+        self.calls.append('on_save')
+        return b'saved_state'
 
     def on_load(self, _data: bytes) -> None:
         pass
@@ -201,6 +202,14 @@ class TestStrategyRunnerDispatch:
 
         assert strategies['s1'].calls == ['on_shutdown']
         assert actions[0].action_type == ActionType.ABORT
+
+    def test_dispatch_save_routes_to_executor(self) -> None:
+        runner, strategies = _make_runner_with_strategies('s1')
+
+        blob = runner.dispatch_save('s1')
+
+        assert strategies['s1'].calls == ['on_save']
+        assert blob == b'saved_state'
 
 
 class TestStrategyRunnerUnknownStrategy:


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

ShutdownSequencer for Manager graceful termination (RFC-3001 phase 9.2). Adds `ShutdownSequencer` orchestrating full shutdown sequence: stop signals → stop timers → dispatch on_shutdown → submit actions → wait terminal → dispatch on_save → persist strategy state → final checkpoint → deregister. Adds `_dispatch_shutdown()` building per-strategy context and collecting shutdown actions. Adds `_submit_actions()` filtering EXIT/ABORT actions, skipping ENTER/MODIFY (TD-015 for Validator integration). Adds `_dispatch_save()` calling strategy on_save() and collecting state blobs. Adds `_persist_strategy_state()` writing strategy state to individual `.bin` files with atomic tmp+rename pattern. Adds `_final_checkpoint()` delegating to `StateStore.checkpoint()`. Adds `ShutdownError` exception. Adds `StrategyExecutor.dispatch_save()` and `StrategyRunner.dispatch_save()` for on_save lifecycle dispatch. Adds `InstanceConfig.shutdown_wait_timeout_seconds` and `shutdown_abort_timeout_seconds` for configurable shutdown timeouts. Adds shutdown stubs: `_stop_signals` (TD-013), `_stop_timers` (TD-014), `_wait_terminal` (TD-016), `_deregister` (TD-012). Fixes import-in-method anti-pattern in sequencer.py. Adds 25 new tests (863 total passing). Bumps to v0.23.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (863 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable