### PR TITLE
feat: 9.3 crash-only design — unified fresh start and crash recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,4 +240,6 @@
 - Add `StrategyExecutor.dispatch_event_replay()` and `StrategyRunner.dispatch_event_replay()` methods
 - Add `_replay_strategy_events()` dispatching WAL events to strategies for state reconstruction (completes TD-008)
 - Add crash-only verification tests proving same code path for fresh start and crash recovery
-- Add 23 tests covering state restoration, event replay, and crash-only design verification (886 total)
+- Add path traversal validation for strategy_id in state restoration
+- Add StartupError wrapping for read_events() failures
+- Add 28 tests covering state restoration, event replay, crash-only design verification, and validation (891 total)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,3 +228,16 @@
 - Add shutdown stubs: `_stop_signals` (TD-013), `_stop_timers` (TD-014), `_wait_terminal` (TD-016), `_deregister` (TD-012)
 - Fix import-in-method anti-pattern in [`sequencer.py`](nexus/startup/sequencer.py) by moving structlog to module level
 - Add 25 tests covering construction validation, dispatch shutdown, submit actions filtering, dispatch save, persist strategy state, final checkpoint, full shutdown sequence, executor/runner dispatch_save, and config timeout validation (863 total)
+
+## v0.24.0 on 5th of April, 2026
+
+- Add crash-only design: fresh start and crash recovery share same code path with no branching
+- Add `_recover_state()` creating initial `InstanceState` when `StateStore.recover()` returns None
+- Add `strategy_state_path` parameter to `StartupSequencer` for strategy state restoration directory
+- Add `_restore_strategy_state()` loading `.bin` files into strategies via `dispatch_load()` (completes TD-007)
+- Add `StateStore.read_events()` to read `STRATEGY_EVENT` entries from WAL
+- Add `Strategy.on_event_replay()` optional callback with default no-op for event replay during recovery
+- Add `StrategyExecutor.dispatch_event_replay()` and `StrategyRunner.dispatch_event_replay()` methods
+- Add `_replay_strategy_events()` dispatching WAL events to strategies for state reconstruction (completes TD-008)
+- Add crash-only verification tests proving same code path for fresh start and crash recovery
+- Add 23 tests covering state restoration, event replay, and crash-only design verification (886 total)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -98,19 +98,6 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 ---
 
-## TD-007: StartupSequencer._restore_strategy_state is a stub
-
-**Origin**: 9.1.5 (strategy state restoration)
-**Severity**: High (no strategy state persistence)
-**Module**: `nexus/startup/sequencer.py`
-
-`_restore_strategy_state()` logs a warning and does nothing. Strategy state bytes (on_save/on_load) are not persisted or restored. Strategies lose internal state on restart.
-
-**When to fix**: When strategy state blob storage is implemented.
-**Migration**: Add strategy state blob storage to StateStore/snapshots. Call on_load(bytes) for each strategy on startup. Remove this entry when done.
-
----
-
 ## TD-008: StartupSequencer._replay_strategy_events is a stub
 
 **Origin**: 9.1.5 (strategy state restoration)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -98,19 +98,6 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 ---
 
-## TD-008: StartupSequencer._replay_strategy_events is a stub
-
-**Origin**: 9.1.5 (strategy state restoration)
-**Severity**: Medium (strategy internal state not rebuilt from events)
-**Module**: `nexus/startup/sequencer.py`
-
-`_replay_strategy_events()` logs a warning and does nothing. Strategy events from WAL are not replayed to strategies for internal state rebuilding (actions discarded during replay).
-
-**When to fix**: When event replay infrastructure is built.
-**Migration**: Read STRATEGY_EVENT entries from WAL, dispatch to strategies with actions discarded. Remove this entry when done.
-
----
-
 ## TD-009: StartupSequencer._wire_predictor_fns is a stub
 
 **Origin**: 9.1.6 (runtime setup stubs)

--- a/nexus/infrastructure/state_store.py
+++ b/nexus/infrastructure/state_store.py
@@ -158,6 +158,20 @@ class StateStore:
 
         return state
 
+    def read_events(self) -> list[StrategyEvent]:
+        '''Read all STRATEGY_EVENT entries from WAL.
+
+        Returns:
+            List of StrategyEvent records from WAL, in sequence order.
+        '''
+
+        wal_entries = self._wal.read_all()
+        return [
+            deserialize_event(entry.payload)
+            for entry in wal_entries
+            if entry.entry_type == WALEntryType.STRATEGY_EVENT
+        ]
+
     def refresh_rolling_losses(self, state: InstanceState) -> None:
         '''Re-derive rolling loss counters from WAL events.
 
@@ -168,12 +182,7 @@ class StateStore:
             state: Instance state whose rolling losses will be updated in place.
         '''
 
-        wal_entries = self._wal.read_all()
-        events = [
-            deserialize_event(entry.payload)
-            for entry in wal_entries
-            if entry.entry_type == WALEntryType.STRATEGY_EVENT
-        ]
+        events = self.read_events()
 
         recovery_time = datetime.now(tz=timezone.utc)
         losses = derive_rolling_losses(events, recovery_time) if events else {}

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -38,6 +38,7 @@ class StartupSequencer:
         manifest_path: Path to the strategy manifest YAML file.
         strategies_base_path: Base path for resolving strategy file paths.
         allocated_capital: Hard ceiling for manifest capital_pool validation.
+        strategy_state_path: Directory for strategy state blob files.
     '''
 
     def __init__(
@@ -46,6 +47,7 @@ class StartupSequencer:
         manifest_path: Path,
         strategies_base_path: Path,
         allocated_capital: Decimal,
+        strategy_state_path: Path | None = None,
     ) -> None:
         if not isinstance(state_store, StateStore):
             msg = 'state_store must be a StateStore instance'
@@ -63,10 +65,15 @@ class StartupSequencer:
             msg = 'allocated_capital must be a finite Decimal'
             raise ValueError(msg)
 
+        if strategy_state_path is not None and not isinstance(strategy_state_path, Path):
+            msg = 'strategy_state_path must be a Path or None'
+            raise ValueError(msg)
+
         self._state_store = state_store
         self._manifest_path = manifest_path
         self._strategies_base_path = strategies_base_path
         self._allocated_capital = allocated_capital
+        self._strategy_state_path = strategy_state_path
 
         self._state: InstanceState | None = None
         self._manifest: Manifest | None = None
@@ -163,11 +170,38 @@ class StartupSequencer:
     def _restore_strategy_state(self) -> None:
         '''Call on_load(bytes) on each strategy for state restoration.
 
-        Stub: logs warning, does nothing. See TD-007.
-        Strategy state blob storage not implemented yet.
+        Loads strategy state from {strategy_state_path}/{strategy_id}.bin
+        if the file exists, otherwise passes empty bytes. Same code path
+        for fresh start (no files) and crash recovery (files exist).
         '''
 
-        _log.warning('restore_strategy_state not implemented')
+        if self._runner is None:
+            raise StartupError('restore_strategy_state', 'runner not initialized')
+
+        if self._manifest is None:
+            raise StartupError('restore_strategy_state', 'manifest not loaded')
+
+        if self._strategy_state_path is None:
+            _log.warning('strategy_state_path not configured, skipping state restoration')
+            return
+
+        for spec in self._manifest.strategies:
+            strategy_id = spec.strategy_id.strip()
+            state_file = self._strategy_state_path / f'{strategy_id}.bin'
+
+            if state_file.exists():
+                try:
+                    data = state_file.read_bytes()
+                except OSError:
+                    _log.exception('failed to read strategy state', strategy_id=strategy_id)
+                    data = b''
+            else:
+                data = b''
+
+            try:
+                self._runner.dispatch_load(strategy_id, data)
+            except Exception:  # noqa: BLE001 - intentional catch-all for strategy code
+                _log.exception('on_load failed', strategy_id=strategy_id)
 
     def _replay_strategy_events(self) -> None:
         '''Replay strategy events from WAL (actions discarded).

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -192,7 +192,7 @@ class StartupSequencer:
         for spec in self._manifest.strategies:
             strategy_id = spec.strategy_id.strip()
 
-            if '/' in strategy_id or '\\' in strategy_id or '..' in strategy_id:
+            if '/' in strategy_id or '\\' in strategy_id:
                 _log.error('unsafe strategy_id rejected', strategy_id=strategy_id)
                 continue
 

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -61,8 +61,12 @@ class StartupSequencer:
             msg = 'strategies_base_path must be a Path'
             raise ValueError(msg)
 
-        if not isinstance(allocated_capital, Decimal) or not allocated_capital.is_finite():
-            msg = 'allocated_capital must be a finite Decimal'
+        if (
+            not isinstance(allocated_capital, Decimal)
+            or not allocated_capital.is_finite()
+            or allocated_capital <= 0
+        ):
+            msg = 'allocated_capital must be a finite positive Decimal'
             raise ValueError(msg)
 
         if strategy_state_path is not None and not isinstance(strategy_state_path, Path):

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -204,13 +204,38 @@ class StartupSequencer:
                 _log.exception('on_load failed', strategy_id=strategy_id)
 
     def _replay_strategy_events(self) -> None:
-        '''Replay strategy events from WAL (actions discarded).
+        '''Replay strategy events from WAL for state reconstruction.
 
-        Stub: logs warning, does nothing. See TD-008.
-        Event replay to strategies not implemented yet.
+        Reads STRATEGY_EVENT entries from WAL via StateStore and dispatches
+        them to the appropriate strategies. Strategies can use these events
+        to rebuild internal state (e.g., P&L tracking, position history).
+        Same code path for fresh start (no events) and crash recovery (events exist).
         '''
 
-        _log.warning('replay_strategy_events not implemented')
+        if self._runner is None:
+            raise StartupError('replay_strategy_events', 'runner not initialized')
+
+        if self._manifest is None:
+            raise StartupError('replay_strategy_events', 'manifest not loaded')
+
+        events = self._state_store.read_events()
+
+        if not events:
+            return
+
+        known_strategies = {spec.strategy_id.strip() for spec in self._manifest.strategies}
+
+        for event in events:
+            strategy_id = event.strategy_id.strip()
+
+            if strategy_id not in known_strategies:
+                _log.warning('skipping event for unknown strategy', strategy_id=strategy_id)
+                continue
+
+            try:
+                self._runner.dispatch_event_replay(strategy_id, event)
+            except Exception:  # noqa: BLE001 - intentional catch-all for strategy code
+                _log.exception('on_event_replay failed', strategy_id=strategy_id)
 
     def _wire_predictor_fns(self) -> None:
         '''Wire predictor_fn subscriptions.

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import structlog
 
+from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.manifest import Manifest, load_manifest
@@ -103,11 +104,17 @@ class StartupSequencer:
         '''Recover InstanceState from snapshot and WAL.
 
         Delegates to StateStore.recover() which loads the latest snapshot
-        and replays STATE_MUTATION entries from WAL atomically.
+        and replays STATE_MUTATION entries from WAL atomically. If no
+        persisted state exists (fresh start), creates initial state from
+        allocated capital. Same code path for fresh start and crash recovery.
         '''
 
         try:
             self._state = self._state_store.recover()
+            if self._state is None:
+                self._state = InstanceState(
+                    capital=CapitalState(capital_pool=self._allocated_capital),
+                )
         except Exception as e:
             raise StartupError('recover_state', str(e)) from e
 

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -191,6 +191,11 @@ class StartupSequencer:
 
         for spec in self._manifest.strategies:
             strategy_id = spec.strategy_id.strip()
+
+            if '/' in strategy_id or '\\' in strategy_id or '..' in strategy_id:
+                _log.error('unsafe strategy_id rejected', strategy_id=strategy_id)
+                continue
+
             state_file = self._strategy_state_path / f'{strategy_id}.bin'
 
             if state_file.exists():
@@ -222,7 +227,10 @@ class StartupSequencer:
         if self._manifest is None:
             raise StartupError('replay_strategy_events', 'manifest not loaded')
 
-        events = self._state_store.read_events()
+        try:
+            events = self._state_store.read_events()
+        except Exception as e:
+            raise StartupError('replay_strategy_events', str(e)) from e
 
         if not events:
             return

--- a/nexus/strategy/base.py
+++ b/nexus/strategy/base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.strategy_event import StrategyEvent
 from nexus.strategy.action import Action
 from nexus.strategy.context import StrategyContext
 from nexus.strategy.params import StrategyParams
@@ -180,3 +181,16 @@ class Strategy(ABC):
         '''
 
         ...
+
+    def on_event_replay(self, event: StrategyEvent) -> None:
+        '''Handle replayed event during crash recovery.
+
+        Called for each STRATEGY_EVENT from WAL during startup. Use to
+        rebuild internal state (e.g., P&L tracking, position history).
+        Default implementation does nothing — override if needed.
+
+        Args:
+            event: Strategy event record from WAL.
+        '''
+
+        _ = event

--- a/nexus/strategy/executor.py
+++ b/nexus/strategy/executor.py
@@ -142,3 +142,13 @@ class StrategyExecutor:
 
         with self._lock:
             return self._strategy.on_save()
+
+    def dispatch_load(self, data: bytes) -> None:
+        '''Dispatch load event to strategy under lock.
+
+        Args:
+            data: Serialized strategy state bytes from previous shutdown.
+        '''
+
+        with self._lock:
+            self._strategy.on_load(data)

--- a/nexus/strategy/executor.py
+++ b/nexus/strategy/executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.strategy_event import StrategyEvent
 from nexus.strategy.action import Action
 from nexus.strategy.base import Strategy
 from nexus.strategy.context import StrategyContext
@@ -152,3 +153,13 @@ class StrategyExecutor:
 
         with self._lock:
             self._strategy.on_load(data)
+
+    def dispatch_event_replay(self, event: StrategyEvent) -> None:
+        '''Dispatch event replay to strategy under lock.
+
+        Args:
+            event: Strategy event record from WAL for state reconstruction.
+        '''
+
+        with self._lock:
+            self._strategy.on_event_replay(event)

--- a/nexus/strategy/runner.py
+++ b/nexus/strategy/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.strategy_event import StrategyEvent
 from nexus.strategy.action import Action
 from nexus.strategy.context import StrategyContext
 from nexus.strategy.executor import StrategyExecutor
@@ -214,3 +215,16 @@ class StrategyRunner:
         '''
 
         self._get_executor(strategy_id).dispatch_load(data)
+
+    def dispatch_event_replay(self, strategy_id: str, event: StrategyEvent) -> None:
+        '''Dispatch event replay to strategy.
+
+        Args:
+            strategy_id: Target strategy identifier.
+            event: Strategy event record from WAL for state reconstruction.
+
+        Raises:
+            ValueError: If strategy_id is unknown.
+        '''
+
+        self._get_executor(strategy_id).dispatch_event_replay(event)

--- a/nexus/strategy/runner.py
+++ b/nexus/strategy/runner.py
@@ -201,3 +201,16 @@ class StrategyRunner:
         '''
 
         return self._get_executor(strategy_id).dispatch_save()
+
+    def dispatch_load(self, strategy_id: str, data: bytes) -> None:
+        '''Dispatch load event to strategy.
+
+        Args:
+            strategy_id: Target strategy identifier.
+            data: Serialized strategy state bytes from previous shutdown.
+
+        Raises:
+            ValueError: If strategy_id is unknown.
+        '''
+
+        self._get_executor(strategy_id).dispatch_load(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.23.0"
+version = "0.24.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -72,7 +72,7 @@ class TestStartupSequencerConstruction:
             )
 
     def test_invalid_allocated_capital_rejected(self) -> None:
-        with pytest.raises(ValueError, match='must be a finite Decimal'):
+        with pytest.raises(ValueError, match='must be a finite positive Decimal'):
             StartupSequencer(
                 state_store=_make_mock_state_store(),
                 manifest_path=_PLACEHOLDER_MANIFEST,
@@ -81,12 +81,30 @@ class TestStartupSequencerConstruction:
             )
 
     def test_non_finite_allocated_capital_rejected(self) -> None:
-        with pytest.raises(ValueError, match='must be a finite Decimal'):
+        with pytest.raises(ValueError, match='must be a finite positive Decimal'):
             StartupSequencer(
                 state_store=_make_mock_state_store(),
                 manifest_path=_PLACEHOLDER_MANIFEST,
                 strategies_base_path=_PLACEHOLDER_STRATEGIES,
                 allocated_capital=Decimal('Infinity'),
+            )
+
+    def test_zero_allocated_capital_rejected(self) -> None:
+        with pytest.raises(ValueError, match='must be a finite positive Decimal'):
+            StartupSequencer(
+                state_store=_make_mock_state_store(),
+                manifest_path=_PLACEHOLDER_MANIFEST,
+                strategies_base_path=_PLACEHOLDER_STRATEGIES,
+                allocated_capital=Decimal('0'),
+            )
+
+    def test_negative_allocated_capital_rejected(self) -> None:
+        with pytest.raises(ValueError, match='must be a finite positive Decimal'):
+            StartupSequencer(
+                state_store=_make_mock_state_store(),
+                manifest_path=_PLACEHOLDER_MANIFEST,
+                strategies_base_path=_PLACEHOLDER_STRATEGIES,
+                allocated_capital=Decimal('-1000'),
             )
 
 

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -195,14 +195,21 @@ class TestStateRecovery:
 
         assert sequencer._state is mock_state
 
-    def test_recover_state_handles_none(self) -> None:
+    def test_recover_state_creates_initial_state_on_fresh_start(self) -> None:
+        from nexus.core.domain.instance_state import InstanceState
+
         mock_store = _make_mock_state_store()
         mock_store.recover.return_value = None
-        sequencer = _make_sequencer(state_store=mock_store)
+        sequencer = _make_sequencer(
+            state_store=mock_store,
+            allocated_capital=Decimal('50000'),
+        )
 
         sequencer._recover_state()
 
-        assert sequencer._state is None
+        assert sequencer._state is not None
+        assert isinstance(sequencer._state, InstanceState)
+        assert sequencer._state.capital.capital_pool == Decimal('50000')
 
     def test_recover_state_wraps_exception_in_startup_error(self) -> None:
         mock_store = _make_mock_state_store()

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -26,12 +26,14 @@ def _make_sequencer(
     manifest_path: Path | None = None,
     strategies_base_path: Path | None = None,
     allocated_capital: Decimal | None = None,
+    strategy_state_path: Path | None = None,
 ) -> StartupSequencer:
     return StartupSequencer(
         state_store=state_store or _make_mock_state_store(),
         manifest_path=manifest_path or _PLACEHOLDER_MANIFEST,
         strategies_base_path=strategies_base_path or _PLACEHOLDER_STRATEGIES,
         allocated_capital=allocated_capital or Decimal('10000'),
+        strategy_state_path=strategy_state_path,
     )
 
 
@@ -234,8 +236,10 @@ class TestExternalIntegrationStubs:
 
         sequencer._reconcile_capital()
 
-    def test_restore_strategy_state_does_not_raise(self) -> None:
+    def test_restore_strategy_state_without_path_logs_warning(self) -> None:
         sequencer = _make_sequencer()
+        sequencer._runner = MagicMock()
+        sequencer._manifest = MagicMock()
 
         sequencer._restore_strategy_state()
 
@@ -262,6 +266,81 @@ class TestExternalIntegrationStubs:
         sequencer._determine_mode()
 
         assert sequencer._mode == OperationalMode.ACTIVE
+
+
+class TestStrategyStateRestoration:
+
+    def test_restore_loads_existing_state_file(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / 'manifest.yaml'
+        strategy_file = tmp_path / 'strat.py'
+        strategy_state_path = tmp_path / 'strategy_state'
+        strategy_state_path.mkdir()
+        (strategy_state_path / 'test_strat.bin').write_bytes(b'saved_data')
+
+        strategy_file.write_text(VALID_STRATEGY)
+        manifest_path.write_text(
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: test_strat\n'
+            '    file: strat.py\n'
+            '    permutation_ids: [p1]\n'
+            '    capital_pct: 50\n'
+        )
+        state_store = _make_mock_state_store()
+        state_store.recover.return_value = None
+        sequencer = _make_sequencer(
+            state_store=state_store,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            strategy_state_path=strategy_state_path,
+        )
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+
+        sequencer._restore_strategy_state()
+
+    def test_restore_uses_empty_bytes_when_file_missing(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / 'manifest.yaml'
+        strategy_file = tmp_path / 'strat.py'
+        strategy_state_path = tmp_path / 'strategy_state'
+        strategy_state_path.mkdir()
+
+        strategy_file.write_text(VALID_STRATEGY)
+        manifest_path.write_text(
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: test_strat\n'
+            '    file: strat.py\n'
+            '    permutation_ids: [p1]\n'
+            '    capital_pct: 50\n'
+        )
+        state_store = _make_mock_state_store()
+        state_store.recover.return_value = None
+        sequencer = _make_sequencer(
+            state_store=state_store,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            strategy_state_path=strategy_state_path,
+        )
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+
+        sequencer._restore_strategy_state()
+
+    def test_restore_fails_without_runner(self) -> None:
+        sequencer = _make_sequencer(strategy_state_path=Path('/placeholder/state'))
+
+        with pytest.raises(StartupError, match='restore_strategy_state'):
+            sequencer._restore_strategy_state()
+
+    def test_restore_fails_without_manifest(self) -> None:
+        sequencer = _make_sequencer(strategy_state_path=Path('/placeholder/state'))
+        sequencer._runner = MagicMock()
+
+        with pytest.raises(StartupError, match='restore_strategy_state'):
+            sequencer._restore_strategy_state()
 
 
 class TestStartupDispatch:

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -684,3 +684,185 @@ class TestStartupError:
         assert error.reason == 'file not found'
         assert 'load_state' in str(error)
         assert 'file not found' in str(error)
+
+
+class TestCrashOnlyDesign:
+
+    def test_fresh_start_always_calls_recover(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / 'manifest.yaml'
+        strategy_file = tmp_path / 'strat.py'
+        strategy_file.write_text(VALID_STRATEGY)
+        manifest_path.write_text(
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: test_strat\n'
+            '    file: strat.py\n'
+            '    permutation_ids: [p1]\n'
+            '    capital_pct: 50\n'
+        )
+        state_store = _make_mock_state_store()
+        state_store.recover.return_value = None
+        state_store.read_events.return_value = []
+        sequencer = _make_sequencer(
+            state_store=state_store,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+        )
+
+        sequencer.start()
+
+        state_store.recover.assert_called_once()
+
+    def test_crash_recovery_calls_dispatch_load_with_file_contents(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / 'manifest.yaml'
+        strategy_file = tmp_path / 'strat.py'
+        strategy_state_path = tmp_path / 'strategy_state'
+        strategy_state_path.mkdir()
+        (strategy_state_path / 'test_strat.bin').write_bytes(b'recovered_state_data')
+
+        strategy_file.write_text(VALID_STRATEGY)
+        manifest_path.write_text(
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: test_strat\n'
+            '    file: strat.py\n'
+            '    permutation_ids: [p1]\n'
+            '    capital_pct: 50\n'
+        )
+        state_store = _make_mock_state_store()
+        state_store.recover.return_value = None
+        state_store.read_events.return_value = []
+        sequencer = _make_sequencer(
+            state_store=state_store,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            strategy_state_path=strategy_state_path,
+        )
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+        sequencer._runner.dispatch_load = MagicMock()
+
+        sequencer._restore_strategy_state()
+
+        sequencer._runner.dispatch_load.assert_called_once_with(
+            'test_strat', b'recovered_state_data'
+        )
+
+    def test_fresh_start_calls_dispatch_load_with_empty_bytes(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / 'manifest.yaml'
+        strategy_file = tmp_path / 'strat.py'
+        strategy_state_path = tmp_path / 'strategy_state'
+        strategy_state_path.mkdir()
+
+        strategy_file.write_text(VALID_STRATEGY)
+        manifest_path.write_text(
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: test_strat\n'
+            '    file: strat.py\n'
+            '    permutation_ids: [p1]\n'
+            '    capital_pct: 50\n'
+        )
+        state_store = _make_mock_state_store()
+        state_store.recover.return_value = None
+        state_store.read_events.return_value = []
+        sequencer = _make_sequencer(
+            state_store=state_store,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            strategy_state_path=strategy_state_path,
+        )
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+        sequencer._runner.dispatch_load = MagicMock()
+
+        sequencer._restore_strategy_state()
+
+        sequencer._runner.dispatch_load.assert_called_once_with('test_strat', b'')
+
+    def test_event_replay_calls_dispatch_event_replay(self, tmp_path: Path) -> None:
+        from datetime import datetime, timezone
+        from nexus.infrastructure.strategy_event import StrategyEvent
+
+        manifest_path = tmp_path / 'manifest.yaml'
+        strategy_file = tmp_path / 'strat.py'
+
+        strategy_file.write_text(VALID_STRATEGY)
+        manifest_path.write_text(
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: test_strat\n'
+            '    file: strat.py\n'
+            '    permutation_ids: [p1]\n'
+            '    capital_pct: 50\n'
+        )
+        event = StrategyEvent(
+            strategy_id='test_strat',
+            event_type='trade_outcome',
+            realized_pnl=Decimal('-100'),
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        state_store = _make_mock_state_store()
+        state_store.recover.return_value = None
+        state_store.read_events.return_value = [event]
+        sequencer = _make_sequencer(
+            state_store=state_store,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+        )
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+        sequencer._runner.dispatch_event_replay = MagicMock()
+
+        sequencer._replay_strategy_events()
+
+        sequencer._runner.dispatch_event_replay.assert_called_once_with('test_strat', event)
+
+    def test_same_code_path_for_fresh_and_crash(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / 'manifest.yaml'
+        strategy_file = tmp_path / 'strat.py'
+        strategy_state_path = tmp_path / 'strategy_state'
+        strategy_state_path.mkdir()
+
+        strategy_file.write_text(VALID_STRATEGY)
+        manifest_path.write_text(
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: test_strat\n'
+            '    file: strat.py\n'
+            '    permutation_ids: [p1]\n'
+            '    capital_pct: 50\n'
+        )
+
+        state_store_fresh = _make_mock_state_store()
+        state_store_fresh.recover.return_value = None
+        state_store_fresh.read_events.return_value = []
+
+        sequencer_fresh = _make_sequencer(
+            state_store=state_store_fresh,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            strategy_state_path=strategy_state_path,
+        )
+        runner_fresh = sequencer_fresh.start()
+
+        (strategy_state_path / 'test_strat.bin').write_bytes(b'crash_state')
+        state_store_crash = _make_mock_state_store()
+        state_store_crash.recover.return_value = None
+        state_store_crash.read_events.return_value = []
+
+        sequencer_crash = _make_sequencer(
+            state_store=state_store_crash,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            strategy_state_path=strategy_state_path,
+        )
+        runner_crash = sequencer_crash.start()
+
+        state_store_fresh.recover.assert_called_once()
+        state_store_crash.recover.assert_called_once()
+        assert runner_fresh is not None
+        assert runner_crash is not None

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -274,6 +274,16 @@ class TestExternalIntegrationStubs:
         with pytest.raises(StartupError, match='replay_strategy_events'):
             sequencer._replay_strategy_events()
 
+    def test_replay_strategy_events_wraps_read_events_failure(self) -> None:
+        mock_store = _make_mock_state_store()
+        mock_store.read_events.side_effect = RuntimeError('WAL corrupted')
+        sequencer = _make_sequencer(state_store=mock_store)
+        sequencer._runner = MagicMock()
+        sequencer._manifest = MagicMock()
+
+        with pytest.raises(StartupError, match='replay_strategy_events'):
+            sequencer._replay_strategy_events()
+
     def test_wire_predictor_fns_does_not_raise(self) -> None:
         sequencer = _make_sequencer()
 
@@ -367,6 +377,37 @@ class TestStrategyStateRestoration:
 
         with pytest.raises(StartupError, match='restore_strategy_state'):
             sequencer._restore_strategy_state()
+
+    def test_restore_skips_unsafe_strategy_id_with_path_separator(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / 'manifest.yaml'
+        strategy_file = tmp_path / 'strat.py'
+        strategy_state_path = tmp_path / 'strategy_state'
+        strategy_state_path.mkdir()
+
+        strategy_file.write_text(VALID_STRATEGY)
+        manifest_path.write_text(
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: ../evil\n'
+            '    file: strat.py\n'
+            '    permutation_ids: [p1]\n'
+            '    capital_pct: 50\n'
+        )
+        state_store = _make_mock_state_store()
+        state_store.recover.return_value = None
+        sequencer = _make_sequencer(
+            state_store=state_store,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            strategy_state_path=strategy_state_path,
+        )
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._runner = MagicMock()
+
+        sequencer._restore_strategy_state()
+
+        sequencer._runner.dispatch_load.assert_not_called()
 
 
 class TestEventReplay:

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -243,10 +243,18 @@ class TestExternalIntegrationStubs:
 
         sequencer._restore_strategy_state()
 
-    def test_replay_strategy_events_does_not_raise(self) -> None:
+    def test_replay_strategy_events_fails_without_runner(self) -> None:
         sequencer = _make_sequencer()
 
-        sequencer._replay_strategy_events()
+        with pytest.raises(StartupError, match='replay_strategy_events'):
+            sequencer._replay_strategy_events()
+
+    def test_replay_strategy_events_fails_without_manifest(self) -> None:
+        sequencer = _make_sequencer()
+        sequencer._runner = MagicMock()
+
+        with pytest.raises(StartupError, match='replay_strategy_events'):
+            sequencer._replay_strategy_events()
 
     def test_wire_predictor_fns_does_not_raise(self) -> None:
         sequencer = _make_sequencer()
@@ -341,6 +349,111 @@ class TestStrategyStateRestoration:
 
         with pytest.raises(StartupError, match='restore_strategy_state'):
             sequencer._restore_strategy_state()
+
+
+class TestEventReplay:
+
+    def test_replay_with_no_events_succeeds(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / 'manifest.yaml'
+        strategy_file = tmp_path / 'strat.py'
+        strategy_file.write_text(VALID_STRATEGY)
+        manifest_path.write_text(
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: test_strat\n'
+            '    file: strat.py\n'
+            '    permutation_ids: [p1]\n'
+            '    capital_pct: 50\n'
+        )
+        state_store = _make_mock_state_store()
+        state_store.recover.return_value = None
+        state_store.read_events.return_value = []
+        sequencer = _make_sequencer(
+            state_store=state_store,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+        )
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+
+        sequencer._replay_strategy_events()
+
+    def test_replay_dispatches_events_to_runner(self, tmp_path: Path) -> None:
+        from datetime import datetime, timezone
+        from nexus.infrastructure.strategy_event import StrategyEvent
+
+        manifest_path = tmp_path / 'manifest.yaml'
+        strategy_file = tmp_path / 'strat.py'
+        strategy_file.write_text(VALID_STRATEGY)
+        manifest_path.write_text(
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: test_strat\n'
+            '    file: strat.py\n'
+            '    permutation_ids: [p1]\n'
+            '    capital_pct: 50\n'
+        )
+        state_store = _make_mock_state_store()
+        state_store.recover.return_value = None
+        event = StrategyEvent(
+            strategy_id='test_strat',
+            event_type='trade_outcome',
+            realized_pnl=Decimal('-50'),
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        state_store.read_events.return_value = [event]
+        sequencer = _make_sequencer(
+            state_store=state_store,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+        )
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+        sequencer._runner.dispatch_event_replay = MagicMock()
+
+        sequencer._replay_strategy_events()
+
+        sequencer._runner.dispatch_event_replay.assert_called_once_with('test_strat', event)
+
+    def test_replay_skips_unknown_strategy(self, tmp_path: Path) -> None:
+        from datetime import datetime, timezone
+        from nexus.infrastructure.strategy_event import StrategyEvent
+
+        manifest_path = tmp_path / 'manifest.yaml'
+        strategy_file = tmp_path / 'strat.py'
+        strategy_file.write_text(VALID_STRATEGY)
+        manifest_path.write_text(
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: test_strat\n'
+            '    file: strat.py\n'
+            '    permutation_ids: [p1]\n'
+            '    capital_pct: 50\n'
+        )
+        state_store = _make_mock_state_store()
+        state_store.recover.return_value = None
+        event = StrategyEvent(
+            strategy_id='unknown_strat',
+            event_type='trade_outcome',
+            realized_pnl=Decimal('-50'),
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        state_store.read_events.return_value = [event]
+        sequencer = _make_sequencer(
+            state_store=state_store,
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+        )
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+        sequencer._runner.dispatch_event_replay = MagicMock()
+
+        sequencer._replay_strategy_events()
+
+        sequencer._runner.dispatch_event_replay.assert_not_called()
 
 
 class TestStartupDispatch:

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -425,6 +425,45 @@ class TestRecoverWithEvents:
         assert recovered.risk.per_strategy['strat_a'].rolling_loss_24h == Decimal('25')
 
 
+class TestReadEvents:
+    def test_read_events_returns_empty_list_when_no_events(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        assert store.read_events() == []
+
+    def test_read_events_returns_single_event(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        event = _make_event()
+        store.append_event(event)
+
+        events = store.read_events()
+        assert len(events) == 1
+        assert events[0].strategy_id == event.strategy_id
+        assert events[0].realized_pnl == event.realized_pnl
+
+    def test_read_events_returns_multiple_events_in_order(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        store.append_event(_make_event(strategy_id='s1', pnl='-10'))
+        store.append_event(_make_event(strategy_id='s2', pnl='-20'))
+        store.append_event(_make_event(strategy_id='s1', pnl='-30'))
+
+        events = store.read_events()
+        assert len(events) == 3
+        assert events[0].strategy_id == 's1'
+        assert events[0].realized_pnl == Decimal('-10')
+        assert events[1].strategy_id == 's2'
+        assert events[2].strategy_id == 's1'
+        assert events[2].realized_pnl == Decimal('-30')
+
+    def test_read_events_ignores_mutation_entries(self, tmp_path: Path) -> None:
+        store = StateStore(tmp_path / 'state')
+        store.append_mutation(_make_state('1000'))
+        store.append_event(_make_event())
+        store.append_mutation(_make_state('2000'))
+
+        events = store.read_events()
+        assert len(events) == 1
+
+
 class TestRefreshRollingLosses:
     def test_refresh_updates_in_memory_state(self, tmp_path: Path) -> None:
         store = StateStore(tmp_path / 'state')

--- a/tests/test_strategy_executor.py
+++ b/tests/test_strategy_executor.py
@@ -28,8 +28,9 @@ class StubStrategy(Strategy):
         self.calls.append('on_save')
         return b'saved_state'
 
-    def on_load(self, _data: bytes) -> None:
-        pass
+    def on_load(self, data: bytes) -> None:
+        self.calls.append('on_load')
+        self.loaded_data = data
 
     def on_startup(
         self,
@@ -186,6 +187,15 @@ class TestStrategyExecutorDispatch:
 
         assert strategy.calls == ['on_save']
         assert blob == b'saved_state'
+
+    def test_dispatch_load_delegates(self) -> None:
+        strategy = StubStrategy('s1')
+        executor = StrategyExecutor(strategy)
+
+        executor.dispatch_load(b'restored_state')
+
+        assert strategy.calls == ['on_load']
+        assert strategy.loaded_data == b'restored_state'
 
 
 class TestStrategyExecutorConcurrency:

--- a/tests/test_strategy_executor.py
+++ b/tests/test_strategy_executor.py
@@ -12,6 +12,7 @@ import pytest
 from nexus.core.domain.enums import OperationalMode
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+from nexus.infrastructure.strategy_event import StrategyEvent
 from nexus.strategy import Action, ActionType, Strategy, StrategyContext, StrategyParams
 from nexus.strategy.executor import StrategyExecutor
 from nexus.strategy.signal import Signal
@@ -85,6 +86,10 @@ class StubStrategy(Strategy):
         self.calls.append('on_shutdown')
         return [Action(ActionType.ABORT)]
 
+    def on_event_replay(self, event: StrategyEvent) -> None:
+        self.calls.append('on_event_replay')
+        self.replayed_event = event
+
 
 def _make_params() -> StrategyParams:
     return StrategyParams(raw={'key': 'value'})
@@ -111,6 +116,15 @@ def _make_outcome() -> TradeOutcome:
         outcome_id='out1',
         command_id='cmd1',
         outcome_type=TradeOutcomeType.ACK,
+        timestamp=datetime.now(tz=timezone.utc),
+    )
+
+
+def _make_event() -> StrategyEvent:
+    return StrategyEvent(
+        strategy_id='s1',
+        event_type='trade_outcome',
+        realized_pnl=Decimal('-50'),
         timestamp=datetime.now(tz=timezone.utc),
     )
 
@@ -196,6 +210,16 @@ class TestStrategyExecutorDispatch:
 
         assert strategy.calls == ['on_load']
         assert strategy.loaded_data == b'restored_state'
+
+    def test_dispatch_event_replay_delegates(self) -> None:
+        strategy = StubStrategy('s1')
+        executor = StrategyExecutor(strategy)
+        event = _make_event()
+
+        executor.dispatch_event_replay(event)
+
+        assert strategy.calls == ['on_event_replay']
+        assert strategy.replayed_event == event
 
 
 class TestStrategyExecutorConcurrency:

--- a/tests/test_strategy_runner.py
+++ b/tests/test_strategy_runner.py
@@ -10,6 +10,7 @@ import pytest
 from nexus.core.domain.enums import OperationalMode
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+from nexus.infrastructure.strategy_event import StrategyEvent
 from nexus.strategy import Action, ActionType, Strategy, StrategyContext, StrategyParams
 from nexus.strategy.executor import StrategyExecutor
 from nexus.strategy.runner import StrategyRunner
@@ -73,6 +74,10 @@ class StubStrategy(Strategy):
         self.calls.append('on_shutdown')
         return [Action(ActionType.ABORT)]
 
+    def on_event_replay(self, event: StrategyEvent) -> None:
+        self.calls.append('on_event_replay')
+        self.replayed_event = event
+
 
 def _make_params() -> StrategyParams:
     return StrategyParams(raw={'key': 'value'})
@@ -99,6 +104,15 @@ def _make_outcome() -> TradeOutcome:
         outcome_id='out1',
         command_id='cmd1',
         outcome_type=TradeOutcomeType.ACK,
+        timestamp=datetime.now(tz=timezone.utc),
+    )
+
+
+def _make_event(strategy_id: str = 's1') -> StrategyEvent:
+    return StrategyEvent(
+        strategy_id=strategy_id,
+        event_type='trade_outcome',
+        realized_pnl=Decimal('-50'),
         timestamp=datetime.now(tz=timezone.utc),
     )
 
@@ -219,6 +233,16 @@ class TestStrategyRunnerDispatch:
 
         assert strategies['s1'].calls == ['on_load']
         assert strategies['s1'].loaded_data == b'restored_state'
+
+    def test_dispatch_event_replay_routes_to_executor(self) -> None:
+        runner, strategies = _make_runner_with_strategies('s1', 's2')
+        event = _make_event('s1')
+
+        runner.dispatch_event_replay('s1', event)
+
+        assert strategies['s1'].calls == ['on_event_replay']
+        assert strategies['s1'].replayed_event == event
+        assert strategies['s2'].calls == []
 
 
 class TestStrategyRunnerUnknownStrategy:

--- a/tests/test_strategy_runner.py
+++ b/tests/test_strategy_runner.py
@@ -291,6 +291,13 @@ class TestStrategyRunnerUnknownStrategy:
         with pytest.raises(ValueError, match='unknown strategy_id'):
             runner.dispatch_load('unknown', b'data')
 
+    def test_dispatch_event_replay_unknown_strategy_raises(self) -> None:
+        runner, _ = _make_runner_with_strategies('s1')
+        event = _make_event('s1')
+
+        with pytest.raises(ValueError, match='unknown strategy_id'):
+            runner.dispatch_event_replay('unknown', event)
+
 
 class TestStrategyRunnerMultipleStrategies:
 

--- a/tests/test_strategy_runner.py
+++ b/tests/test_strategy_runner.py
@@ -26,8 +26,9 @@ class StubStrategy(Strategy):
         self.calls.append('on_save')
         return b'saved_state'
 
-    def on_load(self, _data: bytes) -> None:
-        pass
+    def on_load(self, data: bytes) -> None:
+        self.calls.append('on_load')
+        self.loaded_data = data
 
     def on_startup(
         self,
@@ -211,6 +212,14 @@ class TestStrategyRunnerDispatch:
         assert strategies['s1'].calls == ['on_save']
         assert blob == b'saved_state'
 
+    def test_dispatch_load_routes_to_executor(self) -> None:
+        runner, strategies = _make_runner_with_strategies('s1')
+
+        runner.dispatch_load('s1', b'restored_state')
+
+        assert strategies['s1'].calls == ['on_load']
+        assert strategies['s1'].loaded_data == b'restored_state'
+
 
 class TestStrategyRunnerUnknownStrategy:
 
@@ -251,6 +260,12 @@ class TestStrategyRunnerUnknownStrategy:
 
         with pytest.raises(ValueError, match='unknown strategy_id'):
             runner.dispatch_shutdown('unknown', _make_params(), _make_context())
+
+    def test_dispatch_load_unknown_strategy_raises(self) -> None:
+        runner, _ = _make_runner_with_strategies('s1')
+
+        with pytest.raises(ValueError, match='unknown strategy_id'):
+            runner.dispatch_load('unknown', b'data')
 
 
 class TestStrategyRunnerMultipleStrategies:


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Crash-only design for startup sequence (RFC-3001 phase 9.3). Fresh start and crash recovery now share the same code path with no branching. Adds `_recover_state()` creating initial `InstanceState` when `StateStore.recover()` returns None. Adds `strategy_state_path` parameter to `StartupSequencer` for strategy state restoration directory. Implements `_restore_strategy_state()` loading `.bin` files into strategies via `dispatch_load()` (completes TD-007). Adds `StateStore.read_events()` to read `STRATEGY_EVENT` entries from WAL. Adds `Strategy.on_event_replay()` optional callback with default no-op for event replay during recovery. Adds `StrategyExecutor.dispatch_event_replay()` and `StrategyRunner.dispatch_event_replay()` methods. Implements `_replay_strategy_events()` dispatching WAL events to strategies for state reconstruction (completes TD-008). Adds crash-only verification tests proving same code path for fresh start and crash recovery. Adds `allocated_capital` positive validation in `StartupSequencer.__init__` so zero or negative values fail fast with a clear `ValueError`. Adds path traversal protection for strategy_id in state restoration. Adds StartupError wrapping for read_events() failures. Adds 28 new tests (891 total passing). Bumps to v0.24.0.

## Checklist

- [ ] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (891 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable