### PR TITLE
MMVP-X.1: Pipeline integration blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,3 +243,29 @@
 - Add path traversal validation for strategy_id in state restoration
 - Add StartupError wrapping for read_events() failures
 - Add 28 tests covering state restoration, event replay, crash-only design verification, and validation (891 total)
+
+## v0.25.0 on 14th of April, 2026
+
+- Add [`lifecycle_result.py`](nexus/core/capital_controller/lifecycle_result.py) with `LifecycleResult` dataclass and `FailureCategory` enum (EXPECTED_MISS, INVARIANT_BREACH) replacing bare bool returns in capital lifecycle methods (TD-003)
+- Refactor `CapitalController` lifecycle methods (`release_reservation`, `send_order`, `order_ack`, `order_reject`, `order_fill`, `order_cancel`) to return `LifecycleResult` with classified reason codes
+- Convert `OutcomeProcessor` invariant breach paths to raise `RuntimeError` for entry/exit fills on missing positions or overfills
+- Enforce UTC-only timestamps across all domain types: `Signal`, `TradeOutcome`, `StrategyEvent`, `Reservation`, `TrackedOrder`, `TradeCommand` (TD-004)
+- Reject whitespace-padded `strategy_id` in `StrategySpec.__post_init__` (TD-017)
+- Add version-dispatched deserialization to WAL codec with `_decode_state_v1` routing on embedded `_v` field (TD-001)
+- Preserve `STRATEGY_EVENT` WAL entries across checkpoint for rolling loss window recovery (TD-002)
+- Add [`SensorSpec`](nexus/infrastructure/manifest.py) frozen dataclass for Limen Sensor configuration (experiment_dir, permutation_ids, interval_seconds)
+- Replace `StrategySpec.permutation_ids` with `StrategySpec.sensors: tuple[SensorSpec, ...]` and update `load_manifest` YAML parsing
+- Add `vaquum_limen>=1.52.0` as runtime dependency
+- Add `WiredSensor` dataclass and implement `_wire_sensors()` in `StartupSequencer` — calls `Trainer(experiment_dir).train(permutation_ids)` to produce Sensors during startup (TD-009)
+- Add [`signal_producer.py`](nexus/strategy/signal_producer.py) with `produce_signal()` for live feature preparation via `limen_manifest.prepare_data()` and predict-to-Signal translation
+- Add [`predict_loop.py`](nexus/strategy/predict_loop.py) with `PredictLoop` timer-based signal generation — per-sensor `threading.Timer` at `interval_seconds` calling `produce_signal` → `dispatch_signal`
+- Implement `_stop_signals()` in `ShutdownSequencer` via `PredictLoop.stop()` (TD-013)
+- Add [`praxis_outbound.py`](nexus/infrastructure/praxis_connector/praxis_outbound.py) with `PraxisOutbound` sync-to-async bridge — `asyncio.run_coroutine_threadsafe` for `submit_command`, `register_account`, `deregister_account`, `pull_positions`
+- Add [`praxis_inbound.py`](nexus/infrastructure/praxis_connector/praxis_inbound.py) with `PraxisInbound` queue-based `receive_outcome()` consuming from `queue.Queue[TradeOutcome]`
+- Implement `_register_with_trading()` and `_deregister()` via `PraxisOutbound` (TD-005, TD-012)
+- Wire `PraxisOutbound` into `_submit_actions()` for shutdown EXIT/ABORT submission (TD-015)
+- Implement `_wait_terminal()` polling `PraxisInbound` for terminal outcomes with configurable `shutdown_timeout` (TD-016)
+- Implement `_reconcile_capital()` pulling Praxis positions, comparing by trade_id, updating `position_notional` (TD-006)
+- Split `test_manifest.py` into `test_sensor_spec.py`, `test_strategy_spec.py`, `test_manifest.py`
+- Add `docs/TechnicalDebt.md` entries TD-019 through TD-024 for deferred work
+- Add 53 tests across new modules (944 total)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,7 +255,7 @@
 - Preserve `STRATEGY_EVENT` WAL entries across checkpoint for rolling loss window recovery (TD-002)
 - Add [`SensorSpec`](nexus/infrastructure/manifest.py) frozen dataclass for Limen Sensor configuration (experiment_dir, permutation_ids, interval_seconds)
 - Replace `StrategySpec.permutation_ids` with `StrategySpec.sensors: tuple[SensorSpec, ...]` and update `load_manifest` YAML parsing
-- Add `vaquum_limen>=1.52.0` as runtime dependency
+- Add `vaquum_limen` as runtime dependency (installed from `git+https://github.com/Vaquum/Limen`)
 - Add `WiredSensor` dataclass and implement `_wire_sensors()` in `StartupSequencer` — calls `Trainer(experiment_dir).train(permutation_ids)` to produce Sensors during startup (TD-009)
 - Add [`signal_producer.py`](nexus/strategy/signal_producer.py) with `produce_signal()` for live feature preparation via `limen_manifest.prepare_data()` and predict-to-Signal translation
 - Add [`predict_loop.py`](nexus/strategy/predict_loop.py) with `PredictLoop` timer-based signal generation — per-sensor `threading.Timer` at `interval_seconds` calling `produce_signal` → `dispatch_signal`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,7 +263,7 @@
 - Add [`praxis_outbound.py`](nexus/infrastructure/praxis_connector/praxis_outbound.py) with `PraxisOutbound` sync-to-async bridge — `asyncio.run_coroutine_threadsafe` for `submit_command`, `register_account`, `deregister_account`, `pull_positions`
 - Add [`praxis_inbound.py`](nexus/infrastructure/praxis_connector/praxis_inbound.py) with `PraxisInbound` queue-based `receive_outcome()` consuming from `queue.Queue[TradeOutcome]`
 - Implement `_register_with_trading()` and `_deregister()` via `PraxisOutbound` (TD-005, TD-012)
-- Wire `PraxisOutbound` into `_submit_actions()` for shutdown EXIT/ABORT submission (TD-015)
+- Wire `PraxisOutbound` into `_submit_actions()` for shutdown EXIT/ABORT filtering; actual submission pending Action fields (TD-015, TD-023)
 - Implement `_wait_terminal()` polling `PraxisInbound` for terminal outcomes with configurable `shutdown_timeout` (TD-016)
 - Implement `_reconcile_capital()` pulling Praxis positions, comparing by trade_id, updating `position_notional` (TD-006)
 - Split `test_manifest.py` into `test_sensor_spec.py`, `test_strategy_spec.py`, `test_manifest.py`

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -98,16 +98,9 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 ---
 
-## TD-009: StartupSequencer._wire_sensors is a stub
+## TD-009: ~~StartupSequencer._wire_sensors is a stub~~ RESOLVED
 
-**Origin**: 9.1.6 (runtime setup stubs)
-**Severity**: High (no signal generation)
-**Module**: `nexus/startup/sequencer.py`
-
-`_wire_sensors()` logs a warning and does nothing. Limen Sensors are not trained or wired, meaning no signals will be generated.
-
-**When to fix**: When Sensor training and signal generation are built (X.1.2.2+).
-**Migration**: Implement Sensor training and timer-based predict loop. Remove this entry when done.
+**Status**: Implemented in v0.25.0 (X.1.2.2). `_wire_sensors()` trains Limen Sensors via `Trainer(experiment_dir).train(permutation_ids)` and stores `WiredSensor` entries.
 
 ---
 
@@ -156,9 +149,9 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 **Severity**: High (signals continue during shutdown)
 **Module**: `nexus/startup/shutdown_sequencer.py`
 
-`_stop_signals()` logs a warning and does nothing. Without stopping Sensor timers, new signals can arrive and trigger strategy callbacks during shutdown, causing race conditions. Blocked by TD-009 — cannot stop what was never wired.
+~~`_stop_signals()` logs a warning and does nothing.~~ RESOLVED
 
-**When to fix**: When Sensor wiring is built (after TD-009).
+**Status**: Implemented in v0.25.0 (X.1.2.5). `_stop_signals()` calls `PredictLoop.stop()` to cancel all sensor timers before shutdown proceeds.
 **Migration**: Implement signal unsubscription. Remove this entry when done.
 
 ---

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -264,3 +264,18 @@ When Cohort becomes available, Nexus must support a second path in the manifest 
 
 **When to fix**: Before multi-tenant or multi-account production deployment.
 **Migration**: Introduce per-account experiment directory allowlists or a scoped base path per account (e.g. `{base}/{account_id}/experiments/`). Validate during manifest load that all `experiment_dir` paths fall within the account's allowed scope. Reject manifests that reference experiments outside the account's sandbox.
+
+---
+
+## TD-021: PredictLoop uses stub market data provider
+
+**Origin**: MMVP-X.1 predict loop (X.1.2.4)
+**Severity**: High (no real market data flows to Sensors)
+**Module**: `nexus/strategy/predict_loop.py`
+
+`PredictLoop` accepts a `market_data_provider: Callable[[int], pl.DataFrame]` that returns a rolling DataFrame of bars for a given kline_size. No concrete provider exists — the predict loop works but has nothing to call in production.
+
+The concrete provider depends on Praxis TD-016 #3 (shared market data poller) which fetches klines per unique kline_size using `binancial.compute.get_spot_klines`. The kline_size for each sensor is in the Limen manifest's `data_source_config.params['kline_size']` — already extracted by `PredictLoop._extract_kline_size()`.
+
+**When to fix**: When Praxis TD-016 #3 (shared market data poller) is built.
+**Migration**: Implement the concrete market data provider that wraps the shared poller's rolling DataFrames. Wire it into PredictLoop construction during Nexus instance startup.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -251,3 +251,16 @@ When Cohort becomes available, Nexus must support a second path in the manifest 
 
 **When to fix**: When Limen Cohort is production-ready.
 **Migration**: Add `cohort` as an alternative to `experiment` + `permutation_ids` in the manifest `predictor_fns` schema. Implement Cohort instantiation path in StartupSequencer alongside the existing Trainer path.
+
+---
+
+## TD-020: No experiment directory sandboxing per account
+
+**Origin**: MMVP-X.1 manifest schema (X.1.2.1)
+**Severity**: High (access control gap)
+**Module**: `nexus/infrastructure/manifest.py`
+
+`SensorSpec.experiment_dir` accepts any path on disk. A manifest can reference any experiment directory, regardless of which account ran that experiment. In a multi-account process, account A's manifest could point to account B's experiments, or to experiments the account owner never ran. There is no validation that an account is authorized to use a given experiment.
+
+**When to fix**: Before multi-tenant or multi-account production deployment.
+**Migration**: Introduce per-account experiment directory allowlists or a scoped base path per account (e.g. `{base}/{account_id}/experiments/`). Validate during manifest load that all `experiment_dir` paths fall within the account's allowed scope. Reject manifests that reference experiments outside the account's sandbox.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -279,3 +279,16 @@ The concrete provider depends on Praxis TD-016 #3 (shared market data poller) wh
 
 **When to fix**: When Praxis TD-016 #3 (shared market data poller) is built.
 **Migration**: Implement the concrete market data provider that wraps the shared poller's rolling DataFrames. Wire it into PredictLoop construction during Nexus instance startup.
+
+---
+
+## TD-022: Sensor hot reload not implemented
+
+**Origin**: MMVP-X.1 signal flow (X.1.2.6)
+**Severity**: Medium (requires process restart to change sensors)
+**Modules**: `nexus/startup/sequencer.py`, `nexus/strategy/predict_loop.py`
+
+When the manifest changes experiment directories or permutation IDs, Sensors should be re-trained and the predict loop restarted without process restart. This requires: manifest file watching, diffing old vs new SensorSpecs, stopping the predict loop, re-running `_wire_sensors` with updated specs, restarting the loop with new WiredSensors. The RFC describes a full hot reload system with tier-1/tier-2/tier-3 change classification — none of this infrastructure exists yet.
+
+**When to fix**: When manifest hot reload infrastructure is built.
+**Migration**: Implement manifest file watcher, change diffing, and Sensor re-training via `importlib` reload. Integrate with PredictLoop start/stop lifecycle.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -189,16 +189,16 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 ---
 
-## TD-016: ShutdownSequencer._wait_terminal is a stub
+## TD-016: _wait_terminal lacks ABORT escalation
 
-**Origin**: 9.2.5 (shutdown sequence)
-**Severity**: High (no graceful position closure)
+**Origin**: 9.2.5 (shutdown sequence), updated X.1.4.2
+**Severity**: Medium (timeout logs warning but does not force-close)
 **Module**: `nexus/startup/shutdown_sequencer.py`
 
-`_wait_terminal()` logs a warning and returns immediately. Submitted EXIT commands are not tracked to completion. Shutdown proceeds without confirming positions are closed.
+`_wait_terminal()` now polls PraxisInbound for terminal outcomes with a configurable timeout. However, when timeout expires with commands still pending, it only logs a warning. The RFC specifies ABORT escalation: remaining in-flight commands should be force-aborted via PraxisOutbound, then wait again with a shorter timeout. This requires Action fields (TD-023) to construct ABORT TradeCommands.
 
-**When to fix**: When TradeOutcome inbound integration is built.
-**Migration**: Subscribe/poll for TradeOutcome until all commands reach terminal state. Implement timeout with ABORT escalation. Remove this entry when done.
+**When to fix**: When TD-023 (Action fields) is resolved.
+**Migration**: On timeout, submit ABORT for each pending command via PraxisOutbound, then re-enter wait loop with shorter deadline.
 
 ---
 

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -305,3 +305,18 @@ When the manifest changes experiment directories or permutation IDs, Sensors sho
 
 **When to fix**: Before end-to-end strategy → trade execution.
 **Migration**: Add RFC-specified fields to Action dataclass. Update ValidationPipeline to validate the new fields. Update `translate_to_trade_command` to map from the enriched Action.
+
+---
+
+## TD-024: Reconciliation cannot import Praxis-only positions
+
+**Origin**: MMVP-X.1 capital reconciliation (X.1.5.2)
+**Severity**: Medium (detected but not resolved)
+**Module**: `nexus/startup/sequencer.py`
+
+`_reconcile_capital()` detects positions that exist in Praxis but not in Nexus (logged as warnings). However, it cannot import them because Praxis `Position` has no `strategy_id` — Nexus requires `strategy_id` to assign positions to strategies for capital tracking, risk limits, and P&L attribution. The `trade_id → strategy_id` mapping only exists when Nexus originally submitted the command.
+
+This affects crash recovery where Nexus state is lost but Praxis still holds positions, and phantom position detection (RFC misfire handling).
+
+**When to fix**: Before production crash recovery or multi-strategy deployments.
+**Migration**: Either (a) add `strategy_id` passthrough to Praxis Position (Praxis stores what Nexus sends in trade metadata), or (b) maintain a persistent `trade_id → strategy_id` mapping in Nexus WAL that survives state loss.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -184,7 +184,7 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 `_submit_actions()` filters actions to EXIT/ABORT but cannot validate or submit them. No ValidationPipeline or OutboundConnector is wired in. EXIT actions from on_shutdown are logged but not executed.
 
-**When to fix**: When shutdown integration is built.
+**When to fix**: When Action dataclass has full fields (TD-023) and shutdown integration is built.
 **Migration**: Add validator and connector parameters to ShutdownSequencer. Validate filtered actions through pipeline, submit valid ones via connector. Remove this entry when done.
 
 ---
@@ -292,3 +292,16 @@ When the manifest changes experiment directories or permutation IDs, Sensors sho
 
 **When to fix**: When manifest hot reload infrastructure is built.
 **Migration**: Implement manifest file watcher, change diffing, and Sensor re-training via `importlib` reload. Integrate with PredictLoop start/stop lifecycle.
+
+---
+
+## TD-023: Action dataclass lacks trade fields
+
+**Origin**: MMVP-X.1 command flow (X.1.3.3)
+**Severity**: High (strategies cannot express tradeable decisions)
+**Module**: `nexus/strategy/action.py`
+
+`Action` only has `action_type` (ENTER, EXIT, MODIFY, ABORT). The RFC specifies additional fields required for trade execution: `direction` (BUY/SELL), `size` (base asset quantity), `execution_mode` (SingleShot, Bracket, TWAP, etc.), `order_type` (Market, Limit, etc.), `execution_params` (mode-specific), `deadline` (timeout seconds), `trade_id` (for EXIT/MODIFY/ABORT), `maker_preference`, `reference_price`. Without these fields, the Action → ValidationPipeline → TradeCommand → Praxis submission chain cannot function. The shutdown action submission (TD-015) and the live strategy action flow both depend on this.
+
+**When to fix**: Before end-to-end strategy → trade execution.
+**Migration**: Add RFC-specified fields to Action dataclass. Update ValidationPipeline to validate the new fields. Update `translate_to_trade_command` to map from the enriched Action.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -236,3 +236,18 @@ Several hot paths and recovery routines use linear O(N) scans and manual diction
 - Replace O(N) dictionary/list scans with O(1) or O(log N) structures (e.g., `collections.deque` or `heapq` for expiration tracking).
 - If `Decimal` precision is not required for a hot path, consider switching that path to float-based aggregation and NumPy; otherwise optimize the `Decimal` path by reducing repeated `Decimal` operations and avoiding full re-scans.
 - Implement batch processing or incremental updates for rolling loss windows so recovery and loss derivation update aggregates from prior state instead of recalculating across the full WAL.
+
+---
+
+## TD-019: Cohort (multi-decoder aggregation) not supported
+
+**Origin**: MMVP-X.1 signal flow design (X.1.2.1)
+**Severity**: Medium (single-decoder Trainer path works, Cohort deferred)
+**Module**: `nexus/startup/sequencer.py`
+
+Nexus trains Sensors via `Trainer(experiment_dir).train(permutation_ids)` — this produces one Sensor per permutation ID from a single SFD experiment. Limen's Cohort system (RegimeDiversifiedOpinionPools) aggregates predictions across multiple decoders/regimes into a single callable, but Cohort is not yet ready in Limen.
+
+When Cohort becomes available, Nexus must support a second path in the manifest where a strategy references a Cohort rather than individual Trainer permutations. The Cohort callable exposes the same `predict()` interface as Sensor, so the downstream dispatch (Signal → strategy) is unchanged.
+
+**When to fix**: When Limen Cohort is production-ready.
+**Migration**: Add `cohort` as an alternative to `experiment` + `permutation_ids` in the manifest `predictor_fns` schema. Implement Cohort instantiation path in StartupSequencer alongside the existing Trainer path.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -98,16 +98,16 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 ---
 
-## TD-009: StartupSequencer._wire_predictor_fns is a stub
+## TD-009: StartupSequencer._wire_sensors is a stub
 
 **Origin**: 9.1.6 (runtime setup stubs)
-**Severity**: High (no signal subscription)
+**Severity**: High (no signal generation)
 **Module**: `nexus/startup/sequencer.py`
 
-`_wire_predictor_fns()` logs a warning and does nothing. Strategies are not subscribed to predictor functions, meaning no signals will be received.
+`_wire_sensors()` logs a warning and does nothing. Limen Sensors are not trained or wired, meaning no signals will be generated.
 
-**When to fix**: When predictor_fn subscription system is built.
-**Migration**: Implement signal subscription wiring. Remove this entry when done.
+**When to fix**: When Sensor training and signal generation are built (X.1.2.2+).
+**Migration**: Implement Sensor training and timer-based predict loop. Remove this entry when done.
 
 ---
 
@@ -156,9 +156,9 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 **Severity**: High (signals continue during shutdown)
 **Module**: `nexus/startup/shutdown_sequencer.py`
 
-`_stop_signals()` logs a warning and does nothing. Without unsubscribing from predictor_fns, new signals can arrive and trigger strategy callbacks during shutdown, causing race conditions. Blocked by TD-009 — cannot stop what was never wired.
+`_stop_signals()` logs a warning and does nothing. Without stopping Sensor timers, new signals can arrive and trigger strategy callbacks during shutdown, causing race conditions. Blocked by TD-009 — cannot stop what was never wired.
 
-**When to fix**: When predictor_fn subscription system is built (after TD-009).
+**When to fix**: When Sensor wiring is built (after TD-009).
 **Migration**: Implement signal unsubscription. Remove this entry when done.
 
 ---
@@ -250,7 +250,7 @@ Nexus trains Sensors via `Trainer(experiment_dir).train(permutation_ids)` — th
 When Cohort becomes available, Nexus must support a second path in the manifest where a strategy references a Cohort rather than individual Trainer permutations. The Cohort callable exposes the same `predict()` interface as Sensor, so the downstream dispatch (Signal → strategy) is unchanged.
 
 **When to fix**: When Limen Cohort is production-ready.
-**Migration**: Add `cohort` as an alternative to `experiment` + `permutation_ids` in the manifest `predictor_fns` schema. Implement Cohort instantiation path in StartupSequencer alongside the existing Trainer path.
+**Migration**: Add `cohort` as an alternative to `experiment` + `permutation_ids` in the manifest `sensors` schema. Implement Cohort instantiation path in StartupSequencer alongside the existing Trainer path.
 
 ---
 

--- a/nexus/core/capital_controller/__init__.py
+++ b/nexus/core/capital_controller/__init__.py
@@ -1,12 +1,16 @@
 '''Capital controller components for the Nexus Manager.
 
-Re-exports: CapitalController, Reservation, ReservationResult,
-OrderLifecycleState, TrackedOrder.
+Re-exports: CapitalController, FailureCategory, LifecycleResult,
+Reservation, ReservationResult, OrderLifecycleState, TrackedOrder.
 '''
 
 from __future__ import annotations
 
 from nexus.core.capital_controller.capital_controller import CapitalController
+from nexus.core.capital_controller.lifecycle_result import (
+    FailureCategory,
+    LifecycleResult,
+)
 from nexus.core.capital_controller.reservation import Reservation, ReservationResult
 from nexus.core.capital_controller.tracked_order import (
     OrderLifecycleState,
@@ -15,6 +19,8 @@ from nexus.core.capital_controller.tracked_order import (
 
 __all__ = [
     'CapitalController',
+    'FailureCategory',
+    'LifecycleResult',
     'OrderLifecycleState',
     'Reservation',
     'ReservationResult',

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -12,6 +12,10 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
+from nexus.core.capital_controller.lifecycle_result import (
+    FailureCategory,
+    LifecycleResult,
+)
 from nexus.core.capital_controller.reservation import (
     Reservation,
     ReservationResult,
@@ -268,30 +272,34 @@ class CapitalController:
                 held_seconds,
             )
 
-    def release_reservation(self, reservation_id: str) -> bool:
+    def release_reservation(self, reservation_id: str) -> LifecycleResult:
         '''Release a reservation and return its capital to the available pool.
 
         Args:
             reservation_id: ID of the reservation to release.
 
         Returns:
-            True if the reservation was found and released.
+            LifecycleResult with reason on failure.
         '''
 
         with self._lock:
             reservation = self._reservations.pop(reservation_id, None)
 
             if reservation is None:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=f'reservation {reservation_id!r} not found (expired or already released)',
+                    category=FailureCategory.EXPECTED_MISS,
+                )
 
             self._state.reservation_notional -= reservation.total
             self._adjust_strategy_deployed(
                 reservation.strategy_id,
                 -reservation.total,
             )
-            return True
+            return LifecycleResult(success=True)
 
-    def send_order(self, reservation_id: str, order_id: str) -> bool:
+    def send_order(self, reservation_id: str, order_id: str) -> LifecycleResult:
         '''Convert a reservation into an in-flight order.
 
         Consumes the reservation and creates a TrackedOrder in IN_FLIGHT state.
@@ -302,7 +310,7 @@ class CapitalController:
             order_id: Venue order ID for tracking.
 
         Returns:
-            True if successful, False if reservation not found or expired.
+            LifecycleResult with reason on failure.
         '''
 
         if not order_id or not order_id.strip():
@@ -320,7 +328,11 @@ class CapitalController:
             reservation = self._reservations.pop(reservation_id, None)
 
             if reservation is None:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=f'reservation {reservation_id!r} not found (expired or already consumed)',
+                    category=FailureCategory.EXPECTED_MISS,
+                )
 
             order = TrackedOrder(
                 order_id=order_id,
@@ -337,9 +349,9 @@ class CapitalController:
             self._state.reservation_notional -= reservation.total
             self._state.in_flight_order_notional += reservation.total
 
-            return True
+            return LifecycleResult(success=True)
 
-    def order_ack(self, order_id: str) -> bool:
+    def order_ack(self, order_id: str) -> LifecycleResult:
         '''Acknowledge an in-flight order as working on venue.
 
         Transitions the order from IN_FLIGHT to WORKING state.
@@ -349,17 +361,25 @@ class CapitalController:
             order_id: ID of the order to acknowledge.
 
         Returns:
-            True if successful, False if order not found or not IN_FLIGHT.
+            LifecycleResult with reason on failure.
         '''
 
         with self._lock:
             order = self._orders.get(order_id)
 
             if order is None:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=f'order {order_id!r} not found',
+                    category=FailureCategory.INVARIANT_BREACH,
+                )
 
             if order.state != OrderLifecycleState.IN_FLIGHT:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=f'order {order_id!r} in {order.state.value}, expected IN_FLIGHT',
+                    category=FailureCategory.INVARIANT_BREACH,
+                )
 
             updated = TrackedOrder(
                 order_id=order.order_id,
@@ -376,9 +396,9 @@ class CapitalController:
             self._state.in_flight_order_notional -= order.total
             self._state.working_order_notional += order.total
 
-            return True
+            return LifecycleResult(success=True)
 
-    def order_reject(self, order_id: str) -> bool:
+    def order_reject(self, order_id: str) -> LifecycleResult:
         '''Handle venue rejection of an in-flight order.
 
         Removes the order and releases capital back to available.
@@ -387,30 +407,38 @@ class CapitalController:
             order_id: ID of the rejected order.
 
         Returns:
-            True if successful, False if order not found or not IN_FLIGHT.
+            LifecycleResult with reason on failure.
         '''
 
         with self._lock:
             order = self._orders.get(order_id)
 
             if order is None:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=f'order {order_id!r} not found',
+                    category=FailureCategory.INVARIANT_BREACH,
+                )
 
             if order.state != OrderLifecycleState.IN_FLIGHT:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=f'order {order_id!r} in {order.state.value}, expected IN_FLIGHT',
+                    category=FailureCategory.INVARIANT_BREACH,
+                )
 
             self._orders.pop(order_id)
             self._state.in_flight_order_notional -= order.total
             self._adjust_strategy_deployed(order.strategy_id, -order.total)
 
-            return True
+            return LifecycleResult(success=True)
 
     def order_fill(
         self,
         order_id: str,
         fill_notional: Decimal,
         actual_fees: Decimal,
-    ) -> bool:
+    ) -> LifecycleResult:
         '''Handle a fill (partial or full) on a working order.
 
         Moves capital from working_order_notional to position_notional.
@@ -424,8 +452,7 @@ class CapitalController:
             actual_fees: Actual fees charged by venue for this fill.
 
         Returns:
-            True if successful, False if order not found, wrong state,
-            fill_notional exceeds remaining, or insufficient fee_reserve.
+            LifecycleResult with reason on failure.
         '''
 
         if not isinstance(fill_notional, Decimal) or not fill_notional.is_finite():
@@ -448,13 +475,28 @@ class CapitalController:
             order = self._orders.get(order_id)
 
             if order is None:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=f'order {order_id!r} not found',
+                    category=FailureCategory.INVARIANT_BREACH,
+                )
 
             if order.state != OrderLifecycleState.WORKING:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=f'order {order_id!r} in {order.state.value}, expected WORKING',
+                    category=FailureCategory.INVARIANT_BREACH,
+                )
 
             if fill_notional > order.remaining_notional:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=(
+                        f'order {order_id!r} fill_notional {fill_notional} '
+                        f'exceeds remaining {order.remaining_notional}'
+                    ),
+                    category=FailureCategory.INVARIANT_BREACH,
+                )
 
             pre_fill_remaining = order.remaining_total
             new_remaining = order.remaining_notional - fill_notional
@@ -479,7 +521,14 @@ class CapitalController:
             fee_delta = proportional_estimated - actual_fees
 
             if fee_delta < _ZERO and abs(fee_delta) > self._state.fee_reserve:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=(
+                        f'order {order_id!r} fee deficit {abs(fee_delta)} '
+                        f'exceeds fee_reserve {self._state.fee_reserve}'
+                    ),
+                    category=FailureCategory.EXPECTED_MISS,
+                )
 
             if new_remaining == _ZERO:
                 self._orders.pop(order_id)
@@ -493,9 +542,9 @@ class CapitalController:
             if fee_delta != _ZERO:
                 self._adjust_strategy_deployed(order.strategy_id, -fee_delta)
 
-            return True
+            return LifecycleResult(success=True)
 
-    def order_cancel(self, order_id: str) -> bool:
+    def order_cancel(self, order_id: str) -> LifecycleResult:
         '''Handle cancellation of a working order.
 
         Removes the order and releases remaining capital back to available.
@@ -504,23 +553,31 @@ class CapitalController:
             order_id: ID of the canceled order.
 
         Returns:
-            True if successful, False if order not found or not WORKING.
+            LifecycleResult with reason on failure.
         '''
 
         with self._lock:
             order = self._orders.get(order_id)
 
             if order is None:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=f'order {order_id!r} not found (completed or unknown)',
+                    category=FailureCategory.EXPECTED_MISS,
+                )
 
             if order.state != OrderLifecycleState.WORKING:
-                return False
+                return LifecycleResult(
+                    success=False,
+                    reason=f'order {order_id!r} in {order.state.value}, expected WORKING',
+                    category=FailureCategory.EXPECTED_MISS,
+                )
 
             self._orders.pop(order_id)
             self._state.working_order_notional -= order.remaining_total
             self._adjust_strategy_deployed(order.strategy_id, -order.remaining_total)
 
-            return True
+            return LifecycleResult(success=True)
 
     def _adjust_strategy_deployed(self, strategy_id: str, delta: Decimal) -> None:
         current = self._state.per_strategy_deployed.get(strategy_id, _ZERO)

--- a/nexus/core/capital_controller/lifecycle_result.py
+++ b/nexus/core/capital_controller/lifecycle_result.py
@@ -1,0 +1,34 @@
+'''Typed result for capital lifecycle operations.
+
+Replaces bare boolean returns with structured reason codes and
+failure categories for observability (TD-003).
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = ['FailureCategory', 'LifecycleResult']
+
+
+class FailureCategory(Enum):
+    '''Classification of lifecycle operation failures.'''
+
+    EXPECTED_MISS = 'expected_miss'
+    INVARIANT_BREACH = 'invariant_breach'
+
+
+@dataclass(frozen=True)
+class LifecycleResult:
+    '''Result of a capital lifecycle state transition.
+
+    Args:
+        success: Whether the operation succeeded.
+        reason: Human-readable failure reason. None on success.
+        category: Failure classification. None on success.
+    '''
+
+    success: bool
+    reason: str | None = None
+    category: FailureCategory | None = None

--- a/nexus/core/capital_controller/reservation.py
+++ b/nexus/core/capital_controller/reservation.py
@@ -8,7 +8,7 @@ check-and-reserve attempt.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 __all__ = ['Reservation', 'ReservationResult']
@@ -67,22 +67,16 @@ class Reservation:
             msg = 'Reservation.created_at must be a datetime'
             raise ValueError(msg)
 
-        if (
-            self.created_at.tzinfo is None
-            or self.created_at.tzinfo.utcoffset(self.created_at) is None
-        ):
-            msg = 'Reservation.created_at must be timezone-aware'
+        if self.created_at.tzinfo is not timezone.utc:
+            msg = 'Reservation.created_at must be UTC'
             raise ValueError(msg)
 
         if not isinstance(self.expires_at, datetime):
             msg = 'Reservation.expires_at must be a datetime'
             raise ValueError(msg)
 
-        if (
-            self.expires_at.tzinfo is None
-            or self.expires_at.tzinfo.utcoffset(self.expires_at) is None
-        ):
-            msg = 'Reservation.expires_at must be timezone-aware'
+        if self.expires_at.tzinfo is not timezone.utc:
+            msg = 'Reservation.expires_at must be UTC'
             raise ValueError(msg)
 
         if self.expires_at <= self.created_at:
@@ -102,8 +96,8 @@ class Reservation:
             now: Timezone-aware current time to compare against expires_at.
         '''
 
-        if now.tzinfo is None or now.tzinfo.utcoffset(now) is None:
-            msg = 'Reservation.is_expired requires timezone-aware datetime'
+        if now.tzinfo is not timezone.utc:
+            msg = 'Reservation.is_expired requires UTC datetime'
             raise ValueError(msg)
 
         return now >= self.expires_at

--- a/nexus/core/capital_controller/tracked_order.py
+++ b/nexus/core/capital_controller/tracked_order.py
@@ -7,7 +7,7 @@ capital from the corresponding CapitalState buckets.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
 
@@ -106,11 +106,8 @@ class TrackedOrder:
             msg = 'TrackedOrder.created_at must be a datetime'
             raise ValueError(msg)
 
-        if (
-            self.created_at.tzinfo is None
-            or self.created_at.tzinfo.utcoffset(self.created_at) is None
-        ):
-            msg = 'TrackedOrder.created_at must be timezone-aware'
+        if self.created_at.tzinfo is not timezone.utc:
+            msg = 'TrackedOrder.created_at must be UTC'
             raise ValueError(msg)
 
     @property

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -15,10 +15,53 @@ from typing import Any
 
 import yaml
 
-__all__ = ['Manifest', 'StrategySpec', 'load_manifest']
+__all__ = ['Manifest', 'SensorSpec', 'StrategySpec', 'load_manifest']
 
 _ZERO = Decimal('0')
 _ONE_HUNDRED = Decimal('100')
+
+
+@dataclass(frozen=True)
+class SensorSpec:
+    '''Specification for making a Limen Sensor into a signal source.
+
+    Args:
+        experiment_dir: Path to completed Limen experiment directory.
+        permutation_ids: Round IDs from experiment to train as Sensors.
+        interval_seconds: How often to call predict() in seconds.
+    '''
+
+    experiment_dir: Path
+    permutation_ids: tuple[int, ...]
+    interval_seconds: int
+
+    def __post_init__(self) -> None:
+        '''Validate predictor function specification invariants.'''
+
+        if not isinstance(self.experiment_dir, Path):
+            msg = 'SensorSpec.experiment_dir must be a Path'
+            raise ValueError(msg)
+
+        if not self.experiment_dir.is_dir():
+            msg = f'SensorSpec.experiment_dir not found: {self.experiment_dir}'
+            raise ValueError(msg)
+
+        if not isinstance(self.permutation_ids, tuple) or not self.permutation_ids:
+            msg = 'SensorSpec.permutation_ids must be a non-empty tuple'
+            raise ValueError(msg)
+
+        for pid in self.permutation_ids:
+            if not isinstance(pid, int) or isinstance(pid, bool):
+                msg = f'SensorSpec.permutation_ids must contain ints, got {pid!r}'
+                raise ValueError(msg)
+
+        if not isinstance(self.interval_seconds, int) or isinstance(self.interval_seconds, bool):
+            msg = 'SensorSpec.interval_seconds must be an int'
+            raise ValueError(msg)
+
+        if self.interval_seconds <= 0:
+            msg = f'SensorSpec.interval_seconds must be positive: {self.interval_seconds}'
+            raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -28,13 +71,13 @@ class StrategySpec:
     Args:
         strategy_id: Unique identifier for this strategy.
         file: Relative path string to the Python strategy implementation.
-        permutation_ids: Limen permutation IDs for Trainer/Cohort signal sources.
+        sensors: Sensor specifications for signal sources.
         capital_pct: Capital allocation percentage for this strategy.
     '''
 
     strategy_id: str
     file: str
-    permutation_ids: tuple[str, ...]
+    sensors: tuple[SensorSpec, ...]
     capital_pct: Decimal
 
     def __post_init__(self) -> None:
@@ -52,13 +95,13 @@ class StrategySpec:
             msg = 'StrategySpec.file must be a non-empty string without surrounding whitespace'
             raise ValueError(msg)
 
-        if not isinstance(self.permutation_ids, tuple) or not self.permutation_ids:
-            msg = 'StrategySpec.permutation_ids must be a non-empty tuple'
+        if not isinstance(self.sensors, tuple) or not self.sensors:
+            msg = 'StrategySpec.sensors must be a non-empty tuple'
             raise ValueError(msg)
 
-        for perm_id in self.permutation_ids:
-            if not isinstance(perm_id, str) or not perm_id.strip():
-                msg = 'StrategySpec.permutation_ids must contain non-empty strings'
+        for pfn in self.sensors:
+            if not isinstance(pfn, SensorSpec):
+                msg = 'StrategySpec.sensors must contain SensorSpec instances'
                 raise ValueError(msg)
 
         if (
@@ -201,12 +244,40 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
             msg = f'Strategy {strategy_id!r} missing required field: file'
             raise ValueError(msg)
 
-        raw_permutation_ids = raw_spec.get('permutation_ids')
-        if not isinstance(raw_permutation_ids, list) or not raw_permutation_ids:
-            msg = f'Strategy {strategy_id!r} missing or empty permutation_ids'
+        raw_sensors = raw_spec.get('sensors')
+        if not isinstance(raw_sensors, list) or not raw_sensors:
+            msg = f'Strategy {strategy_id!r} missing or empty sensors'
             raise ValueError(msg)
 
-        permutation_ids = tuple(raw_permutation_ids)
+        sensor_specs: list[SensorSpec] = []
+
+        for raw_sensor in raw_sensors:
+            if not isinstance(raw_sensor, dict):
+                msg = f'Strategy {strategy_id!r} sensors entries must be mappings'
+                raise ValueError(msg)
+
+            raw_experiment = raw_sensor.get('experiment')
+            if raw_experiment is None:
+                msg = f'Strategy {strategy_id!r} sensor missing required field: experiment'
+                raise ValueError(msg)
+
+            raw_pids = raw_sensor.get('permutation_ids')
+            if not isinstance(raw_pids, list) or not raw_pids:
+                msg = f'Strategy {strategy_id!r} sensor missing or empty permutation_ids'
+                raise ValueError(msg)
+
+            raw_interval = raw_sensor.get('interval_seconds')
+            if raw_interval is None:
+                msg = f'Strategy {strategy_id!r} sensor missing required field: interval_seconds'
+                raise ValueError(msg)
+
+            sensor_specs.append(
+                SensorSpec(
+                    experiment_dir=Path(str(raw_experiment)),
+                    permutation_ids=tuple(int(pid) for pid in raw_pids),
+                    interval_seconds=int(raw_interval),
+                )
+            )
 
         raw_capital_pct = raw_spec.get('capital_pct')
         if raw_capital_pct is None:
@@ -223,7 +294,7 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
             StrategySpec(
                 strategy_id=strategy_id,
                 file=file,
-                permutation_ids=permutation_ids,
+                sensors=tuple(sensor_specs),
                 capital_pct=capital_pct,
             )
         )

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -40,8 +40,12 @@ class StrategySpec:
     def __post_init__(self) -> None:
         '''Validate strategy specification invariants.'''
 
-        if not isinstance(self.strategy_id, str) or not self.strategy_id.strip():
-            msg = 'StrategySpec.strategy_id must be a non-empty string'
+        if (
+            not isinstance(self.strategy_id, str)
+            or not self.strategy_id.strip()
+            or self.strategy_id != self.strategy_id.strip()
+        ):
+            msg = 'StrategySpec.strategy_id must be a non-empty string without surrounding whitespace'
             raise ValueError(msg)
 
         if not isinstance(self.file, str) or not self.file.strip() or self.file != self.file.strip():

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -271,11 +271,25 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
                 msg = f'Strategy {strategy_id!r} sensor missing required field: interval_seconds'
                 raise ValueError(msg)
 
+            for pid in raw_pids:
+                if isinstance(pid, bool) or not isinstance(pid, int):
+                    msg = f'Strategy {strategy_id!r} sensor permutation_ids must be ints, got {pid!r}'
+                    raise ValueError(msg)
+
+            if isinstance(raw_interval, bool) or not isinstance(raw_interval, int):
+                msg = f'Strategy {strategy_id!r} sensor interval_seconds must be an int, got {raw_interval!r}'
+                raise ValueError(msg)
+
+            experiment_path = Path(str(raw_experiment))
+
+            if not experiment_path.is_absolute():
+                experiment_path = (path.parent / experiment_path).resolve()
+
             sensor_specs.append(
                 SensorSpec(
-                    experiment_dir=Path(str(raw_experiment)),
-                    permutation_ids=tuple(int(pid) for pid in raw_pids),
-                    interval_seconds=int(raw_interval),
+                    experiment_dir=experiment_path,
+                    permutation_ids=tuple(raw_pids),
+                    interval_seconds=raw_interval,
                 )
             )
 

--- a/nexus/infrastructure/praxis_connector/inbound_connector.py
+++ b/nexus/infrastructure/praxis_connector/inbound_connector.py
@@ -1,8 +1,8 @@
 '''Inbound connector protocol for Trading sub-system result consumption.
 
 Defines the interface for receiving TradeOutcomes from the Trading
-sub-system (Praxis). Concrete implementations handle transport details
-such as polling, WebSocket push, or in-memory mocks for testing.
+sub-system (Praxis). Concrete implementations handle transport
+details — queue-based for production, mock for testing.
 '''
 
 from __future__ import annotations
@@ -15,10 +15,7 @@ __all__ = ['InboundConnector']
 
 
 class InboundConnector(Protocol):
-    '''Protocol for receiving TradeOutcomes from the Trading sub-system.
-
-    Concrete implementations handle transport details (polling, push, etc.).
-    '''
+    '''Protocol for receiving TradeOutcomes from the Trading sub-system.'''
 
     def receive_outcome(self) -> TradeOutcome | None:
         '''Receive next TradeOutcome from Trading sub-system.
@@ -26,5 +23,4 @@ class InboundConnector(Protocol):
         Returns:
             TradeOutcome if available, None if no outcome pending.
         '''
-
         ...

--- a/nexus/infrastructure/praxis_connector/outbound_connector.py
+++ b/nexus/infrastructure/praxis_connector/outbound_connector.py
@@ -1,8 +1,8 @@
 '''Outbound connector protocol for Trading sub-system dispatch.
 
 Defines the interface for submitting TradeCommands to the Trading
-sub-system (Praxis). Concrete implementations handle transport details
-such as HTTP, message queues, or in-memory mocks for testing.
+sub-system (Praxis). Concrete implementations handle transport
+details — in-process async bridge for production, mock for testing.
 '''
 
 from __future__ import annotations
@@ -15,11 +15,12 @@ __all__ = ['OutboundConnector']
 
 
 class OutboundConnector(Protocol):
-    '''Protocol for submitting TradeCommands to the Trading sub-system.
+    '''Protocol for submitting TradeCommands to the Trading sub-system.'''
 
-    Concrete implementations handle transport details (HTTP, queue, etc.).
-    '''
+    def send_command(self, command: TradeCommand) -> str:
+        '''Submit TradeCommand to Trading sub-system.
 
-    def send_command(self, command: TradeCommand) -> None:
-        '''Submit TradeCommand to Trading sub-system.'''
+        Returns:
+            Command ID assigned by Trading sub-system.
+        '''
         ...

--- a/nexus/infrastructure/praxis_connector/outcome_processor.py
+++ b/nexus/infrastructure/praxis_connector/outcome_processor.py
@@ -80,13 +80,13 @@ class OutcomeProcessor:
         return self._handle_cancel(outcome, context)
 
     def _handle_ack(self, outcome: TradeOutcome) -> ProcessResult:
-        success = self._capital.order_ack(outcome.command_id)
+        result = self._capital.order_ack(outcome.command_id)
 
-        if not success:
+        if not result.success:
             return ProcessResult(
                 success=False,
                 outcome_type=outcome.outcome_type,
-                error_reason='order_ack failed: order not found or wrong state',
+                error_reason=f'order_ack failed: {result.reason}',
             )
 
         return ProcessResult(
@@ -108,17 +108,17 @@ class OutcomeProcessor:
         capital_updated = False
 
         if context.is_entry:
-            success = self._capital.order_fill(
+            result = self._capital.order_fill(
                 outcome.command_id,
                 outcome.fill_notional,
                 outcome.actual_fees,
             )
 
-            if not success:
+            if not result.success:
                 return ProcessResult(
                     success=False,
                     outcome_type=outcome.outcome_type,
-                    error_reason='order_fill failed: order not found, wrong state, fill_notional exceeds remaining, or insufficient fee_reserve',
+                    error_reason=f'order_fill failed: {result.reason}',
                 )
 
             capital_updated = True
@@ -148,13 +148,13 @@ class OutcomeProcessor:
         outcome: TradeOutcome,
         context: OrderContext,
     ) -> ProcessResult:
-        success = self._capital.order_reject(outcome.command_id)
+        result = self._capital.order_reject(outcome.command_id)
 
-        if not success:
+        if not result.success:
             return ProcessResult(
                 success=False,
                 outcome_type=outcome.outcome_type,
-                error_reason='order_reject failed: order not found or wrong state',
+                error_reason=f'order_reject failed: {result.reason}',
             )
 
         position_updated = False
@@ -174,13 +174,13 @@ class OutcomeProcessor:
         outcome: TradeOutcome,
         context: OrderContext,
     ) -> ProcessResult:
-        success = self._capital.order_cancel(outcome.command_id)
+        result = self._capital.order_cancel(outcome.command_id)
 
-        if not success:
+        if not result.success:
             return ProcessResult(
                 success=False,
                 outcome_type=outcome.outcome_type,
-                error_reason='order_cancel failed: order not found or wrong state',
+                error_reason=f'order_cancel failed: {result.reason}',
             )
 
         position_updated = False
@@ -223,12 +223,14 @@ class OutcomeProcessor:
         assert outcome.fill_price is not None
 
         if context.trade_id is None:
-            return False
+            msg = f'entry fill without trade_id: command_id={outcome.command_id!r}'
+            raise RuntimeError(msg)
 
         position = self._state.positions.get(context.trade_id)
 
         if position is None:
-            return False
+            msg = f'entry fill for missing position: trade_id={context.trade_id!r}'
+            raise RuntimeError(msg)
 
         old_size = position.size
         fill_size = outcome.fill_size
@@ -253,18 +255,24 @@ class OutcomeProcessor:
         assert outcome.fill_price is not None
 
         if context.trade_id is None:
-            return False, None
+            msg = f'exit fill without trade_id: command_id={outcome.command_id!r}'
+            raise RuntimeError(msg)
 
         position = self._state.positions.get(context.trade_id)
 
         if position is None:
-            return False, None
+            msg = f'exit fill for missing position: trade_id={context.trade_id!r}'
+            raise RuntimeError(msg)
 
         fill_size = outcome.fill_size
         fill_price = outcome.fill_price
 
         if fill_size > position.size:
-            return False, None
+            msg = (
+                f'exit fill_size {fill_size} exceeds position size '
+                f'{position.size}: trade_id={context.trade_id!r}'
+            )
+            raise RuntimeError(msg)
 
         entry_price = position.entry_price
         side_multiplier = Decimal(-1) if position.side == OrderSide.SELL else Decimal(1)
@@ -280,7 +288,8 @@ class OutcomeProcessor:
 
     def _clear_pending_exit(self, context: OrderContext, size: Decimal) -> bool:
         if context.trade_id is None:
-            return False
+            msg = f'clear pending exit without trade_id: command_id={context.command_id!r}'
+            raise RuntimeError(msg)
 
         position = self._state.positions.get(context.trade_id)
 

--- a/nexus/infrastructure/praxis_connector/praxis_inbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_inbound.py
@@ -1,0 +1,46 @@
+'''Concrete inbound connector consuming TradeOutcomes from a thread-safe queue.
+
+Praxis pushes outcomes into the queue via on_trade_outcome callback,
+routed by account_id. The Nexus instance thread calls receive_outcome
+to consume them.
+'''
+
+from __future__ import annotations
+
+import queue
+
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+
+__all__ = ['PraxisInbound']
+
+_DEFAULT_POLL_TIMEOUT = 0.1
+
+
+class PraxisInbound:
+    '''Queue-based inbound connector for receiving TradeOutcomes.
+
+    Args:
+        outcome_queue: Thread-safe queue fed by Praxis on_trade_outcome callback.
+        poll_timeout: Seconds to wait on queue.get before returning None.
+    '''
+
+    def __init__(
+        self,
+        outcome_queue: queue.Queue[TradeOutcome],
+        poll_timeout: float = _DEFAULT_POLL_TIMEOUT,
+    ) -> None:
+        self._queue = outcome_queue
+        self._poll_timeout = poll_timeout
+
+    def receive_outcome(self) -> TradeOutcome | None:
+        '''Receive next TradeOutcome from the queue.
+
+        Returns:
+            TradeOutcome if available within poll_timeout, None otherwise.
+        '''
+
+        try:
+            return self._queue.get(timeout=self._poll_timeout)
+        except queue.Empty:
+            return None
+

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -86,6 +86,7 @@ class PraxisOutbound:
         try:
             command_id = future.result(timeout=self._timeout)
         except (TimeoutError, concurrent.futures.TimeoutError):
+            future.cancel()
             _log.error(
                 'submit_command timed out: command_id=%s',
                 command.command_id,
@@ -143,6 +144,7 @@ class PraxisOutbound:
         try:
             future.result(timeout=self._timeout)
         except (TimeoutError, concurrent.futures.TimeoutError):
+            future.cancel()
             _log.error('deregister timed out: account_id=%s', account_id)
             raise
 

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -74,7 +74,7 @@ class PraxisOutbound:
                 order_type=command.command_type,
                 execution_mode=None,
                 execution_params=None,
-                timeout=max(1, round(self._timeout)),
+                timeout=round(self._timeout),
                 reference_price=None,
                 maker_preference=None,
                 stp_mode=command.stp_mode,

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Coroutine
+from typing import Any
 
 from nexus.infrastructure.praxis_connector.trade_command import TradeCommand
 
@@ -34,11 +35,11 @@ class PraxisOutbound:
 
     def __init__(
         self,
-        submit_fn: Callable[..., Awaitable[str]],
+        submit_fn: Callable[..., Coroutine[Any, Any, str]],
         loop: asyncio.AbstractEventLoop,
         register_fn: Callable[[str], None] | None = None,
-        unregister_fn: Callable[[str], Awaitable[None]] | None = None,
-        pull_positions_fn: Callable[[str], dict[tuple[str, str], object]] | None = None,
+        unregister_fn: Callable[[str], Coroutine[Any, Any, None]] | None = None,
+        pull_positions_fn: Callable[[str], dict[tuple[str, str], Any]] | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
     ) -> None:
         self._submit_fn = submit_fn
@@ -64,7 +65,7 @@ class PraxisOutbound:
 
         # NOTE: execution_mode and execution_params require Action fields (TD-023).
         # Placeholder values used until full Action → TradeCommand translation is built.
-        future = asyncio.run_coroutine_threadsafe(
+        future: concurrent.futures.Future[str] = asyncio.run_coroutine_threadsafe(
             self._submit_fn(
                 trade_id=command.trade_id or command.command_id,
                 account_id=command.account_id,
@@ -101,7 +102,7 @@ class PraxisOutbound:
             },
         )
 
-        return command_id
+        return str(command_id)
 
     def register_account(self, account_id: str) -> None:
         '''Register account with Praxis Trading.
@@ -136,7 +137,7 @@ class PraxisOutbound:
             msg = 'unregister_fn not configured'
             raise RuntimeError(msg)
 
-        future = asyncio.run_coroutine_threadsafe(
+        future: concurrent.futures.Future[None] = asyncio.run_coroutine_threadsafe(
             self._unregister_fn(account_id),
             self._loop,
         )
@@ -150,7 +151,7 @@ class PraxisOutbound:
 
         _log.info('account deregistered', extra={'account_id': account_id})
 
-    def pull_positions(self, account_id: str) -> dict[tuple[str, str], object]:
+    def pull_positions(self, account_id: str) -> dict[tuple[str, str], Any]:
         '''Pull positions snapshot from Praxis Trading.
 
         Args:

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -38,7 +38,7 @@ class PraxisOutbound:
         loop: asyncio.AbstractEventLoop,
         register_fn: Callable[[str], None] | None = None,
         unregister_fn: Callable[[str], Awaitable[None]] | None = None,
-        pull_positions_fn: Callable[[str], dict] | None = None,
+        pull_positions_fn: Callable[[str], dict[tuple[str, str], object]] | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
     ) -> None:
         self._submit_fn = submit_fn
@@ -150,14 +150,14 @@ class PraxisOutbound:
 
         _log.info('account deregistered', extra={'account_id': account_id})
 
-    def pull_positions(self, account_id: str) -> dict:
+    def pull_positions(self, account_id: str) -> dict[tuple[str, str], object]:
         '''Pull positions snapshot from Praxis Trading.
 
         Args:
             account_id: Account identifier to query.
 
         Returns:
-            Detached positions snapshot from Praxis.
+            Positions keyed by (account_id, trade_id) tuples.
 
         Raises:
             RuntimeError: If pull_positions_fn is not configured.

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -59,7 +59,7 @@ class PraxisOutbound:
 
         Raises:
             TimeoutError: If Praxis does not respond within timeout.
-            RuntimeError: If the async call fails.
+            Exception: Propagates the original exception raised by submit_fn.
         '''
 
         # NOTE: execution_mode and execution_params require Action fields (TD-023).

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -7,6 +7,7 @@ from a sync Nexus thread.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import logging
 from collections.abc import Awaitable, Callable
 
@@ -84,7 +85,7 @@ class PraxisOutbound:
 
         try:
             command_id = future.result(timeout=self._timeout)
-        except TimeoutError:
+        except (TimeoutError, concurrent.futures.TimeoutError):
             _log.error(
                 'submit_command timed out: command_id=%s',
                 command.command_id,
@@ -141,7 +142,7 @@ class PraxisOutbound:
 
         try:
             future.result(timeout=self._timeout)
-        except TimeoutError:
+        except (TimeoutError, concurrent.futures.TimeoutError):
             _log.error('deregister timed out: account_id=%s', account_id)
             raise
 

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -61,6 +61,8 @@ class PraxisOutbound:
             RuntimeError: If the async call fails.
         '''
 
+        # NOTE: execution_mode and execution_params require Action fields (TD-023).
+        # Placeholder values used until full Action → TradeCommand translation is built.
         future = asyncio.run_coroutine_threadsafe(
             self._submit_fn(
                 trade_id=command.trade_id or command.command_id,
@@ -69,9 +71,9 @@ class PraxisOutbound:
                 side=command.side,
                 qty=command.size,
                 order_type=command.command_type,
-                execution_mode=command.command_type,
+                execution_mode=None,
                 execution_params=None,
-                timeout=int(self._timeout),
+                timeout=max(1, round(self._timeout)),
                 reference_price=None,
                 maker_preference=None,
                 stp_mode=command.stp_mode,

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -26,6 +26,7 @@ class PraxisOutbound:
         submit_fn: Async callable matching Praxis Trading.submit_command signature.
         register_fn: Sync callable matching Praxis Trading.register_account.
         unregister_fn: Async callable matching Praxis Trading.unregister_account.
+        pull_positions_fn: Sync callable matching Praxis Trading.pull_positions.
         loop: Asyncio event loop running in the Praxis thread.
         timeout: Seconds to wait for async calls to complete.
     '''
@@ -36,12 +37,14 @@ class PraxisOutbound:
         loop: asyncio.AbstractEventLoop,
         register_fn: Callable[[str], None] | None = None,
         unregister_fn: Callable[[str], Awaitable[None]] | None = None,
+        pull_positions_fn: Callable[[str], dict] | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
     ) -> None:
         self._submit_fn = submit_fn
         self._loop = loop
         self._register_fn = register_fn
         self._unregister_fn = unregister_fn
+        self._pull_positions_fn = pull_positions_fn
         self._timeout = timeout
 
     def send_command(self, command: TradeCommand) -> str:
@@ -141,3 +144,22 @@ class PraxisOutbound:
             raise
 
         _log.info('account deregistered', extra={'account_id': account_id})
+
+    def pull_positions(self, account_id: str) -> dict:
+        '''Pull positions snapshot from Praxis Trading.
+
+        Args:
+            account_id: Account identifier to query.
+
+        Returns:
+            Detached positions snapshot from Praxis.
+
+        Raises:
+            RuntimeError: If pull_positions_fn is not configured.
+        '''
+
+        if self._pull_positions_fn is None:
+            msg = 'pull_positions_fn not configured'
+            raise RuntimeError(msg)
+
+        return self._pull_positions_fn(account_id)

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -1,6 +1,6 @@
 '''Concrete outbound connector bridging sync Nexus to async Praxis.
 
-Uses asyncio.run_coroutine_threadsafe to call Praxis Trading.submit_command()
+Uses asyncio.run_coroutine_threadsafe to call Praxis async methods
 from a sync Nexus thread.
 '''
 
@@ -20,22 +20,28 @@ _DEFAULT_TIMEOUT = 30.0
 
 
 class PraxisOutbound:
-    '''Sync-to-async bridge for submitting commands to Praxis.
+    '''Sync-to-async bridge for Praxis Trading operations.
 
     Args:
         submit_fn: Async callable matching Praxis Trading.submit_command signature.
+        register_fn: Sync callable matching Praxis Trading.register_account.
+        unregister_fn: Async callable matching Praxis Trading.unregister_account.
         loop: Asyncio event loop running in the Praxis thread.
-        timeout: Seconds to wait for the async call to complete.
+        timeout: Seconds to wait for async calls to complete.
     '''
 
     def __init__(
         self,
         submit_fn: Callable[..., Awaitable[str]],
         loop: asyncio.AbstractEventLoop,
+        register_fn: Callable[[str], None] | None = None,
+        unregister_fn: Callable[[str], Awaitable[None]] | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
     ) -> None:
         self._submit_fn = submit_fn
         self._loop = loop
+        self._register_fn = register_fn
+        self._unregister_fn = unregister_fn
         self._timeout = timeout
 
     def send_command(self, command: TradeCommand) -> str:
@@ -89,3 +95,49 @@ class PraxisOutbound:
         )
 
         return command_id
+
+    def register_account(self, account_id: str) -> None:
+        '''Register account with Praxis Trading.
+
+        Args:
+            account_id: Account identifier to register.
+
+        Raises:
+            RuntimeError: If register_fn is not configured.
+            ValueError: If Praxis rejects the registration.
+        '''
+
+        if self._register_fn is None:
+            msg = 'register_fn not configured'
+            raise RuntimeError(msg)
+
+        self._register_fn(account_id)
+        _log.info('account registered', extra={'account_id': account_id})
+
+    def deregister_account(self, account_id: str) -> None:
+        '''Deregister account from Praxis Trading via async bridge.
+
+        Args:
+            account_id: Account identifier to deregister.
+
+        Raises:
+            RuntimeError: If unregister_fn is not configured.
+            TimeoutError: If Praxis does not respond within timeout.
+        '''
+
+        if self._unregister_fn is None:
+            msg = 'unregister_fn not configured'
+            raise RuntimeError(msg)
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._unregister_fn(account_id),
+            self._loop,
+        )
+
+        try:
+            future.result(timeout=self._timeout)
+        except TimeoutError:
+            _log.error('deregister timed out: account_id=%s', account_id)
+            raise
+
+        _log.info('account deregistered', extra={'account_id': account_id})

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -74,7 +74,7 @@ class PraxisOutbound:
                 order_type=command.command_type,
                 execution_mode=None,
                 execution_params=None,
-                timeout=round(self._timeout),
+                timeout=max(1, round(self._timeout)),
                 reference_price=None,
                 maker_preference=None,
                 stp_mode=command.stp_mode,

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -1,0 +1,91 @@
+'''Concrete outbound connector bridging sync Nexus to async Praxis.
+
+Uses asyncio.run_coroutine_threadsafe to call Praxis Trading.submit_command()
+from a sync Nexus thread.
+'''
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+from nexus.infrastructure.praxis_connector.trade_command import TradeCommand
+
+__all__ = ['PraxisOutbound']
+
+_log = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT = 30.0
+
+
+class PraxisOutbound:
+    '''Sync-to-async bridge for submitting commands to Praxis.
+
+    Args:
+        submit_fn: Async callable matching Praxis Trading.submit_command signature.
+        loop: Asyncio event loop running in the Praxis thread.
+        timeout: Seconds to wait for the async call to complete.
+    '''
+
+    def __init__(
+        self,
+        submit_fn: Callable[..., Awaitable[str]],
+        loop: asyncio.AbstractEventLoop,
+        timeout: float = _DEFAULT_TIMEOUT,
+    ) -> None:
+        self._submit_fn = submit_fn
+        self._loop = loop
+        self._timeout = timeout
+
+    def send_command(self, command: TradeCommand) -> str:
+        '''Submit TradeCommand to Praxis via async bridge.
+
+        Args:
+            command: Validated TradeCommand from Nexus.
+
+        Returns:
+            Command ID assigned by Praxis.
+
+        Raises:
+            TimeoutError: If Praxis does not respond within timeout.
+            RuntimeError: If the async call fails.
+        '''
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._submit_fn(
+                trade_id=command.trade_id or command.command_id,
+                account_id=command.account_id,
+                symbol=command.symbol,
+                side=command.side,
+                qty=command.size,
+                order_type=command.command_type,
+                execution_mode=command.command_type,
+                execution_params=None,
+                timeout=int(self._timeout),
+                reference_price=None,
+                maker_preference=None,
+                stp_mode=command.stp_mode,
+                created_at=command.created_at,
+            ),
+            self._loop,
+        )
+
+        try:
+            command_id = future.result(timeout=self._timeout)
+        except TimeoutError:
+            _log.error(
+                'submit_command timed out: command_id=%s',
+                command.command_id,
+            )
+            raise
+
+        _log.info(
+            'command submitted',
+            extra={
+                'nexus_command_id': command.command_id,
+                'praxis_command_id': command_id,
+            },
+        )
+
+        return command_id

--- a/nexus/infrastructure/praxis_connector/trade_command.py
+++ b/nexus/infrastructure/praxis_connector/trade_command.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 from nexus.core.domain.enums import OrderSide
@@ -82,11 +82,8 @@ class TradeCommand:
             msg = 'TradeCommand.created_at must be a datetime'
             raise ValueError(msg)
 
-        if (
-            self.created_at.tzinfo is None
-            or self.created_at.tzinfo.utcoffset(self.created_at) is None
-        ):
-            msg = 'TradeCommand.created_at must be timezone-aware'
+        if self.created_at.tzinfo is not timezone.utc:
+            msg = 'TradeCommand.created_at must be UTC'
             raise ValueError(msg)
 
         if self.side is not None and not isinstance(self.side, OrderSide):

--- a/nexus/infrastructure/praxis_connector/trade_outcome.py
+++ b/nexus/infrastructure/praxis_connector/trade_outcome.py
@@ -7,7 +7,7 @@ Represents execution results from Trading sub-system. Fill outcomes
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
@@ -67,11 +67,8 @@ class TradeOutcome:
             msg = 'TradeOutcome.timestamp must be a datetime instance'
             raise ValueError(msg)
 
-        if (
-            self.timestamp.tzinfo is None
-            or self.timestamp.tzinfo.utcoffset(self.timestamp) is None
-        ):
-            msg = 'TradeOutcome.timestamp must be timezone-aware'
+        if self.timestamp.tzinfo is not timezone.utc:
+            msg = 'TradeOutcome.timestamp must be UTC'
             raise ValueError(msg)
 
         if self.outcome_type.is_fill:

--- a/nexus/infrastructure/praxis_connector/trade_outcome.py
+++ b/nexus/infrastructure/praxis_connector/trade_outcome.py
@@ -25,7 +25,7 @@ class TradeOutcome:
         outcome_id: Unique outcome reference.
         command_id: Links to original TradeCommand.
         outcome_type: ACK, PARTIAL, FILLED, REJECTED, EXPIRED, or CANCELED.
-        timestamp: When outcome occurred (must be timezone-aware).
+        timestamp: When outcome occurred (must be UTC).
         fill_size: Base asset filled; required for PARTIAL/FILLED.
         fill_price: Execution price; required for PARTIAL/FILLED.
         fill_notional: Quote amount filled; required for PARTIAL/FILLED.

--- a/nexus/infrastructure/praxis_connector/translate.py
+++ b/nexus/infrastructure/praxis_connector/translate.py
@@ -43,7 +43,7 @@ def translate_to_trade_command(
 
     Raises:
         ValueError: If decision is not allowed, command_id is missing,
-            or now is not timezone-aware.
+            or now is not UTC.
     '''
 
     if not decision.allowed:

--- a/nexus/infrastructure/praxis_connector/translate.py
+++ b/nexus/infrastructure/praxis_connector/translate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from nexus.core.validator.pipeline_models import (
     ValidationAction,
@@ -50,8 +50,8 @@ def translate_to_trade_command(
         msg = 'translate_to_trade_command: decision must be allowed'
         raise ValueError(msg)
 
-    if now.tzinfo is None or now.tzinfo.utcoffset(now) is None:
-        msg = 'translate_to_trade_command requires timezone-aware datetime'
+    if now.tzinfo is not timezone.utc:
+        msg = 'translate_to_trade_command requires UTC datetime'
         raise ValueError(msg)
 
     if not context.command_id:

--- a/nexus/infrastructure/snapshot.py
+++ b/nexus/infrastructure/snapshot.py
@@ -1,12 +1,14 @@
 '''Snapshot manager for persisting full InstanceState to disk.
 
 Saves and loads complete InstanceState snapshots via the WAL codec.
-A save triggers WAL truncation to keep the log bounded.
+A save triggers WAL truncation while preserving recent events for
+rolling loss window derivation.
 '''
 
 from __future__ import annotations
 
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from nexus.core.domain.instance_state import InstanceState
@@ -14,6 +16,8 @@ from nexus.infrastructure.wal import WriteAheadLog
 from nexus.infrastructure.wal_codec import deserialize_state, serialize_state
 
 __all__ = ['load_snapshot', 'save_snapshot']
+
+_EVENT_RETENTION_DAYS = 30
 
 
 def _fsync_directory(dir_path: Path) -> None:
@@ -30,6 +34,7 @@ def save_snapshot(state: InstanceState, path: Path, wal: WriteAheadLog) -> None:
     '''Serialize full InstanceState to disk and truncate the WAL.
 
     Writes to a temporary file then atomically renames for crash safety.
+    Preserves STRATEGY_EVENT entries within the 30-day rolling loss window.
 
     Args:
         state: The instance state to persist.
@@ -44,7 +49,8 @@ def save_snapshot(state: InstanceState, path: Path, wal: WriteAheadLog) -> None:
         os.fsync(f.fileno())
     tmp.replace(path)
     _fsync_directory(path.parent)
-    wal.truncate()
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(days=_EVENT_RETENTION_DAYS)
+    wal.truncate_keeping_events(cutoff)
 
 
 def load_snapshot(path: Path) -> InstanceState | None:

--- a/nexus/infrastructure/strategy_event.py
+++ b/nexus/infrastructure/strategy_event.py
@@ -8,7 +8,7 @@ re-derive rolling loss counters.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 __all__ = ['StrategyEvent']
@@ -52,9 +52,6 @@ class StrategyEvent:
             msg = 'StrategyEvent.timestamp must be a datetime'
             raise ValueError(msg)
 
-        if (
-            self.timestamp.tzinfo is None
-            or self.timestamp.tzinfo.utcoffset(self.timestamp) is None
-        ):
-            msg = 'StrategyEvent.timestamp must be timezone-aware'
+        if self.timestamp.tzinfo is not timezone.utc:
+            msg = 'StrategyEvent.timestamp must be UTC'
             raise ValueError(msg)

--- a/nexus/infrastructure/wal.py
+++ b/nexus/infrastructure/wal.py
@@ -156,6 +156,37 @@ class WriteAheadLog:
                 f.flush()
                 os.fsync(f.fileno())
 
+    def truncate_keeping_events(self, cutoff: datetime) -> None:
+        '''Truncate WAL but preserve STRATEGY_EVENT entries after cutoff.
+
+        Removes STATE_MUTATION entries and old events, keeping only
+        STRATEGY_EVENT entries with timestamp >= cutoff for rolling
+        loss window derivation.
+
+        Args:
+            cutoff: Keep events with timestamp >= this value.
+        '''
+
+        if not self._path.exists():
+            return
+
+        entries = self.read_all()
+        events_to_keep = [
+            e for e in entries
+            if e.entry_type == WALEntryType.STRATEGY_EVENT and e.timestamp >= cutoff
+        ]
+
+        with self._path.open('wb') as f:
+            f.write(_MAGIC)
+            for entry in events_to_keep:
+                payload = _serialize_entry(entry)
+                crc = zlib.crc32(payload) & 0xFFFFFFFF
+                header = struct.pack(_RECORD_HEADER_FMT, len(payload), crc)
+                f.write(header)
+                f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+
 
 def _fsync_directory(dir_path: Path) -> None:
     '''Fsync a directory to make rename/create durable across power loss.'''

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -69,7 +69,7 @@ def deserialize_state(data: bytes) -> InstanceState:
     if not isinstance(d, dict):
         msg = f'Expected dict from WAL payload, got {type(d).__name__}'
         raise ValueError(msg)
-    version = d.get('_v', 0)
+    version = d.get('_v', 1)
 
     if version == 1:
         return _decode_state_v1(d)
@@ -405,7 +405,7 @@ def deserialize_event(data: bytes) -> StrategyEvent:
         msg = f'Expected dict from event payload, got {type(d).__name__}'
         raise ValueError(msg)
     try:
-        version = int(d.get('_v', 0))
+        version = int(d.get('_v', 1))
     except (ValueError, TypeError) as exc:
         msg = f'Malformed event codec version: {exc}'
         raise ValueError(msg) from exc

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -70,9 +70,23 @@ def deserialize_state(data: bytes) -> InstanceState:
         msg = f'Expected dict from WAL payload, got {type(d).__name__}'
         raise ValueError(msg)
     version = d.get('_v', 0)
-    if version != _CODEC_VERSION:
-        msg = f'Unsupported WAL codec version: {version}'
-        raise ValueError(msg)
+
+    if version == 1:
+        return _decode_state_v1(d)
+
+    msg = f'Unsupported WAL codec version: {version}'
+    raise ValueError(msg)
+
+
+def _decode_state_v1(d: dict[str, Any]) -> InstanceState:
+    '''Decode v1 state payload to InstanceState.
+
+    Args:
+        d: Decoded msgpack dict with v1 schema.
+
+    Returns:
+        Reconstructed InstanceState.
+    '''
 
     try:
         return InstanceState(
@@ -396,9 +410,22 @@ def deserialize_event(data: bytes) -> StrategyEvent:
         msg = f'Malformed event codec version: {exc}'
         raise ValueError(msg) from exc
 
-    if version != _EVENT_CODEC_VERSION:
-        msg = f'Unsupported event codec version: {version}'
-        raise ValueError(msg)
+    if version == 1:
+        return _decode_event_v1(d)
+
+    msg = f'Unsupported event codec version: {version}'
+    raise ValueError(msg)
+
+
+def _decode_event_v1(d: dict[str, Any]) -> StrategyEvent:
+    '''Decode v1 event payload to StrategyEvent.
+
+    Args:
+        d: Decoded msgpack dict with v1 schema.
+
+    Returns:
+        Reconstructed StrategyEvent.
+    '''
 
     try:
         return StrategyEvent(

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -23,6 +23,7 @@ from nexus.strategy.loader import instantiate_strategy
 from nexus.strategy.params import StrategyParams
 from nexus.strategy.runner import StrategyRunner
 
+_ZERO = Decimal(0)
 _HUNDRED = Decimal('100')
 _log = structlog.get_logger()
 
@@ -182,10 +183,75 @@ class StartupSequencer:
     def _reconcile_capital(self) -> None:
         '''Reconcile capital state against Trading positions.
 
-        Stub: logs warning, does nothing. See TD-006.
+        Pulls positions from Praxis, compares against Nexus state by trade_id,
+        updates position_notional to match actual venue state. Logs discrepancies.
         '''
 
-        _log.warning('reconcile_capital not implemented')
+        if self._praxis_outbound is None or self._account_id is None:
+            _log.warning('praxis_outbound or account_id not configured, skipping reconciliation')
+            return
+
+        if self._state is None:
+            raise StartupError('reconcile_capital', 'state not recovered')
+
+        try:
+            praxis_positions = self._praxis_outbound.pull_positions(self._account_id)
+        except Exception as e:
+            raise StartupError('reconcile_capital', str(e)) from e
+
+        praxis_by_trade_id = {
+            trade_id: pos
+            for (_, trade_id), pos in praxis_positions.items()
+            if isinstance(trade_id, str)
+        }
+
+        praxis_total_notional = _ZERO
+
+        for trade_id, praxis_pos in praxis_by_trade_id.items():
+            notional = praxis_pos.qty * praxis_pos.avg_entry_price
+            praxis_total_notional += notional
+
+            nexus_pos = self._state.positions.get(trade_id)
+
+            if nexus_pos is None:
+                _log.warning(
+                    'position in Praxis but not in Nexus',
+                    trade_id=trade_id,
+                    praxis_qty=str(praxis_pos.qty),
+                )
+                continue
+
+            if nexus_pos.size != praxis_pos.qty:
+                _log.warning(
+                    'position size mismatch',
+                    trade_id=trade_id,
+                    nexus_size=str(nexus_pos.size),
+                    praxis_qty=str(praxis_pos.qty),
+                )
+
+        for trade_id in self._state.positions:
+            if trade_id not in praxis_by_trade_id:
+                _log.warning(
+                    'position in Nexus but not in Praxis',
+                    trade_id=trade_id,
+                )
+
+        old_notional = self._state.capital.position_notional
+
+        if old_notional != praxis_total_notional:
+            _log.warning(
+                'position_notional adjusted',
+                old=str(old_notional),
+                new=str(praxis_total_notional),
+            )
+            self._state.capital.position_notional = praxis_total_notional
+
+        _log.info(
+            'capital reconciliation complete',
+            nexus_positions=len(self._state.positions),
+            praxis_positions=len(praxis_by_trade_id),
+            position_notional=str(self._state.capital.position_notional),
+        )
 
     def _load_manifest(self) -> None:
         '''Load and validate strategy manifest.'''

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -214,7 +214,9 @@ class StartupSequencer:
         praxis_total_notional = _ZERO
 
         for trade_id, praxis_pos in praxis_by_trade_id.items():
-            notional = praxis_pos.qty * praxis_pos.avg_entry_price
+            qty = Decimal(str(praxis_pos.qty))
+            price = Decimal(str(praxis_pos.avg_entry_price))
+            notional = qty * price
             praxis_total_notional += notional
 
             nexus_pos = self._state.positions.get(trade_id)

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
+from typing import Any
 
 import structlog
+
+from limen.experiment.trainer.trainer import Trainer
 
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode
@@ -22,7 +26,28 @@ from nexus.strategy.runner import StrategyRunner
 _HUNDRED = Decimal('100')
 _log = structlog.get_logger()
 
-__all__ = ['StartupSequencer']
+__all__ = ['StartupSequencer', 'WiredSensor']
+
+
+@dataclass(frozen=True)
+class WiredSensor:
+    '''A trained Sensor ready for signal generation.
+
+    Args:
+        sensor_id: Unique identifier ({experiment_name}:{permutation_id}).
+        sensor: Limen Sensor callable (predict(data) -> dict).
+        limen_manifest: Limen Manifest for feature preparation.
+        round_params: Hyperparameters used to train this Sensor.
+        strategy_id: Strategy this Sensor feeds signals to.
+        interval_seconds: How often to call predict().
+    '''
+
+    sensor_id: str
+    sensor: Any
+    limen_manifest: Any
+    round_params: dict[str, Any]
+    strategy_id: str
+    interval_seconds: int
 
 
 class StartupSequencer:
@@ -83,6 +108,13 @@ class StartupSequencer:
         self._manifest: Manifest | None = None
         self._runner: StrategyRunner | None = None
         self._mode: OperationalMode | None = None
+        self._wired_sensors: list[WiredSensor] = []
+
+    @property
+    def wired_sensors(self) -> list[WiredSensor]:
+        '''Return trained Sensors wired during startup.'''
+
+        return list(self._wired_sensors)
 
     def start(self) -> StrategyRunner:
         '''Execute the full startup sequence.
@@ -250,12 +282,48 @@ class StartupSequencer:
                 _log.exception('on_event_replay failed', strategy_id=strategy_id)
 
     def _wire_sensors(self) -> None:
-        '''Wire Limen Sensors for signal generation.
+        '''Train Limen Sensors and wire them for signal generation.
 
-        Stub: logs warning, does nothing. See TD-009.
+        For each SensorSpec in the manifest, calls Trainer(experiment_dir).train(permutation_ids)
+        to produce Sensor callables. Stores WiredSensor entries for later use by the predict loop.
         '''
 
-        _log.warning('wire_sensors not implemented')
+        if self._manifest is None:
+            raise StartupError('wire_sensors', 'manifest not loaded')
+
+        for spec in self._manifest.strategies:
+            strategy_id = spec.strategy_id
+
+            for sensor_spec in spec.sensors:
+                experiment_name = sensor_spec.experiment_dir.name
+
+                try:
+                    trainer = Trainer(sensor_spec.experiment_dir)
+                    sensors = trainer.train(list(sensor_spec.permutation_ids))
+                except Exception as e:
+                    raise StartupError(
+                        'wire_sensors',
+                        f'strategy {strategy_id!r} experiment '
+                        f'{sensor_spec.experiment_dir}: {e}',
+                    ) from e
+
+                for sensor in sensors:
+                    sensor_id = f'{experiment_name}:{sensor.permutation_id}'
+                    wired = WiredSensor(
+                        sensor_id=sensor_id,
+                        sensor=sensor,
+                        limen_manifest=trainer._manifest,
+                        round_params=sensor.round_params,
+                        strategy_id=strategy_id,
+                        interval_seconds=sensor_spec.interval_seconds,
+                    )
+                    self._wired_sensors.append(wired)
+                    _log.info(
+                        'wired sensor',
+                        sensor_id=sensor_id,
+                        strategy_id=strategy_id,
+                        interval_seconds=sensor_spec.interval_seconds,
+                    )
 
     def _register_timers(self) -> None:
         '''Register strategy timers.

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -64,6 +64,8 @@ class StartupSequencer:
         strategies_base_path: Base path for resolving strategy file paths.
         allocated_capital: Hard ceiling for manifest capital_pool validation.
         strategy_state_path: Directory for strategy state blob files.
+        praxis_outbound: Outbound connector for Praxis Trading operations.
+        account_id: Account identifier for Praxis registration.
     '''
 
     def __init__(
@@ -73,6 +75,8 @@ class StartupSequencer:
         strategies_base_path: Path,
         allocated_capital: Decimal,
         strategy_state_path: Path | None = None,
+        praxis_outbound: object | None = None,
+        account_id: str | None = None,
     ) -> None:
         if not isinstance(state_store, StateStore):
             msg = 'state_store must be a StateStore instance'
@@ -103,6 +107,8 @@ class StartupSequencer:
         self._strategies_base_path = strategies_base_path
         self._allocated_capital = allocated_capital
         self._strategy_state_path = strategy_state_path
+        self._praxis_outbound = praxis_outbound
+        self._account_id = account_id
 
         self._state: InstanceState | None = None
         self._manifest: Manifest | None = None
@@ -162,12 +168,16 @@ class StartupSequencer:
             raise StartupError('recover_state', str(e)) from e
 
     def _register_with_trading(self) -> None:
-        '''Register with Trading sub-system.
+        '''Register this account with Trading sub-system via PraxisOutbound.'''
 
-        Stub: logs warning, does nothing. See TD-005.
-        '''
+        if self._praxis_outbound is None or self._account_id is None:
+            _log.warning('praxis_outbound or account_id not configured, skipping registration')
+            return
 
-        _log.warning('register_with_trading not implemented')
+        try:
+            self._praxis_outbound.register_account(self._account_id)
+        except Exception as e:
+            raise StartupError('register_with_trading', str(e)) from e
 
     def _reconcile_capital(self) -> None:
         '''Reconcile capital state against Trading positions.

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -229,12 +229,12 @@ class StartupSequencer:
                 )
                 continue
 
-            if nexus_pos.size != praxis_pos.qty:
+            if nexus_pos.size != qty:
                 _log.warning(
                     'position size mismatch',
                     trade_id=trade_id,
                     nexus_size=str(nexus_pos.size),
-                    praxis_qty=str(praxis_pos.qty),
+                    praxis_qty=str(qty),
                 )
 
         for trade_id in self._state.positions:

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -202,7 +202,7 @@ class StartupSequencer:
         except Exception as e:
             raise StartupError('reconcile_capital', str(e)) from e
 
-        praxis_by_trade_id: dict[str, object] = {}
+        praxis_by_trade_id: dict[str, Any] = {}
 
         try:
             for key, pos in praxis_positions.items():

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -38,7 +38,7 @@ class WiredSensor:
     '''A trained Sensor ready for signal generation.
 
     Args:
-        sensor_id: Unique identifier ({experiment_name}:{permutation_id}).
+        sensor_id: Unique identifier ({path_hash_12}:{permutation_id}).
         sensor: Limen Sensor callable (predict(data) -> dict).
         limen_manifest: Limen Manifest for feature preparation.
         round_params: Hyperparameters used to train this Sensor.

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -26,6 +26,7 @@ from nexus.strategy.runner import StrategyRunner
 
 _ZERO = Decimal(0)
 _HUNDRED = Decimal('100')
+_POSITION_KEY_LENGTH = 2
 _log = structlog.get_logger()
 
 __all__ = ['StartupSequencer', 'WiredSensor']
@@ -202,20 +203,31 @@ class StartupSequencer:
 
         praxis_by_trade_id: dict[str, object] = {}
 
-        for (_, trade_id), pos in praxis_positions.items():
-            if isinstance(trade_id, str):
-                praxis_by_trade_id[trade_id] = pos
-            else:
-                _log.warning(
-                    'skipping Praxis position with non-string trade_id',
-                    trade_id=repr(trade_id),
-                )
+        try:
+            for key, pos in praxis_positions.items():
+                if not isinstance(key, tuple) or len(key) != _POSITION_KEY_LENGTH:
+                    _log.warning('skipping Praxis position with unexpected key', key=repr(key))
+                    continue
+                _, trade_id = key
+                if isinstance(trade_id, str):
+                    praxis_by_trade_id[trade_id] = pos
+                else:
+                    _log.warning(
+                        'skipping Praxis position with non-string trade_id',
+                        trade_id=repr(trade_id),
+                    )
+        except Exception as e:
+            raise StartupError('reconcile_capital', f'failed to parse Praxis positions: {e}') from e
 
         praxis_total_notional = _ZERO
 
         for trade_id, praxis_pos in praxis_by_trade_id.items():
-            qty = Decimal(str(praxis_pos.qty))
-            price = Decimal(str(praxis_pos.avg_entry_price))
+            try:
+                qty = Decimal(str(praxis_pos.qty))
+                price = Decimal(str(praxis_pos.avg_entry_price))
+            except (AttributeError, ArithmeticError) as e:
+                _log.warning('skipping position with invalid fields', trade_id=trade_id, error=str(e))
+                continue
             notional = qty * price
             praxis_total_notional += notional
 

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -252,7 +252,6 @@ class StartupSequencer:
             )
             self._state.capital.position_notional = praxis_total_notional
 
-        if old_notional != praxis_total_notional:
             try:
                 self._state_store.checkpoint(self._state)
             except Exception as e:

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -380,11 +380,13 @@ class StartupSequencer:
         if self._manifest is None:
             raise StartupError('wire_sensors', 'manifest not loaded')
 
+        self._wired_sensors.clear()
+
         for spec in self._manifest.strategies:
             strategy_id = spec.strategy_id
 
             for sensor_spec in spec.sensors:
-                experiment_name = sensor_spec.experiment_dir.name
+                experiment_name = str(sensor_spec.experiment_dir.resolve())
 
                 try:
                     trainer = Trainer(sensor_spec.experiment_dir)

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -12,6 +12,7 @@ import structlog
 from limen.experiment.trainer.trainer import Trainer
 
 from nexus.core.domain.capital_state import CapitalState
+from nexus.infrastructure.praxis_connector.praxis_outbound import PraxisOutbound
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.manifest import Manifest, load_manifest
@@ -76,7 +77,7 @@ class StartupSequencer:
         strategies_base_path: Path,
         allocated_capital: Decimal,
         strategy_state_path: Path | None = None,
-        praxis_outbound: object | None = None,
+        praxis_outbound: PraxisOutbound | None = None,
         account_id: str | None = None,
     ) -> None:
         if not isinstance(state_store, StateStore):
@@ -199,11 +200,16 @@ class StartupSequencer:
         except Exception as e:
             raise StartupError('reconcile_capital', str(e)) from e
 
-        praxis_by_trade_id = {
-            trade_id: pos
-            for (_, trade_id), pos in praxis_positions.items()
-            if isinstance(trade_id, str)
-        }
+        praxis_by_trade_id: dict[str, object] = {}
+
+        for (_, trade_id), pos in praxis_positions.items():
+            if isinstance(trade_id, str):
+                praxis_by_trade_id[trade_id] = pos
+            else:
+                _log.warning(
+                    'skipping Praxis position with non-string trade_id',
+                    trade_id=repr(trade_id),
+                )
 
         praxis_total_notional = _ZERO
 
@@ -245,6 +251,12 @@ class StartupSequencer:
                 new=str(praxis_total_notional),
             )
             self._state.capital.position_notional = praxis_total_notional
+
+        if old_notional != praxis_total_notional:
+            try:
+                self._state_store.checkpoint(self._state)
+            except Exception as e:
+                raise StartupError('reconcile_capital', f'checkpoint after reconciliation failed: {e}') from e
 
         _log.info(
             'capital reconciliation complete',
@@ -385,6 +397,8 @@ class StartupSequencer:
 
                 for sensor in sensors:
                     sensor_id = f'{experiment_name}:{sensor.permutation_id}'
+                    # NOTE: trainer._manifest is a private attribute on Limen Trainer.
+                    # No public accessor exists as of vaquum_limen 1.52.0.
                     wired = WiredSensor(
                         sensor_id=sensor_id,
                         sensor=sensor,

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -30,7 +30,7 @@ class StartupSequencer:
 
     Executes steps in order: recover state (snapshot + WAL) → register with Trading →
     reconcile capital → load manifest → instantiate strategies → restore strategy state →
-    replay strategy events → wire predictor_fns → register timers →
+    replay strategy events → wire sensors → register timers →
     determine mode → dispatch on_startup.
 
     Args:
@@ -101,7 +101,7 @@ class StartupSequencer:
         self._instantiate_strategies()
         self._restore_strategy_state()
         self._replay_strategy_events()
-        self._wire_predictor_fns()
+        self._wire_sensors()
         self._register_timers()
         self._determine_mode()
         self._dispatch_startup()
@@ -249,14 +249,13 @@ class StartupSequencer:
             except Exception:  # noqa: BLE001 - intentional catch-all for strategy code
                 _log.exception('on_event_replay failed', strategy_id=strategy_id)
 
-    def _wire_predictor_fns(self) -> None:
-        '''Wire predictor_fn subscriptions.
+    def _wire_sensors(self) -> None:
+        '''Wire Limen Sensors for signal generation.
 
         Stub: logs warning, does nothing. See TD-009.
-        Predictor function wiring not implemented yet.
         '''
 
-        _log.warning('wire_predictor_fns not implemented')
+        _log.warning('wire_sensors not implemented')
 
     def _register_timers(self) -> None:
         '''Register strategy timers.

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
@@ -398,7 +399,9 @@ class StartupSequencer:
             strategy_id = spec.strategy_id
 
             for sensor_spec in spec.sensors:
-                experiment_name = str(sensor_spec.experiment_dir.resolve())
+                path_hash = hashlib.sha256(
+                    str(sensor_spec.experiment_dir.resolve()).encode(),
+                ).hexdigest()[:12]
 
                 try:
                     trainer = Trainer(sensor_spec.experiment_dir)
@@ -411,7 +414,7 @@ class StartupSequencer:
                     ) from e
 
                 for sensor in sensors:
-                    sensor_id = f'{experiment_name}:{sensor.permutation_id}'
+                    sensor_id = f'{path_hash}:{sensor.permutation_id}'
                     # NOTE: trainer._manifest is a private attribute on Limen Trainer.
                     # No public accessor exists as of vaquum_limen 1.52.0.
                     wired = WiredSensor(

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -208,13 +208,11 @@ class ShutdownSequencer:
             )
             return
 
-        for strategy_id, action in filtered:
-            _log.info(
-                'shutdown action pending submission',
-                strategy_id=strategy_id,
-                action_type=action.action_type.value,
-            )
-            self._submitted_command_ids.append(f'{strategy_id}:{action.action_type.value}')
+        _log.warning(
+            'shutdown action submission not yet functional — '
+            'Action fields (TD-023) required for TradeCommand translation',
+            action_count=len(filtered),
+        )
 
     def _wait_terminal(self) -> None:
         '''Wait for all submitted commands to reach terminal state.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -12,6 +12,8 @@ import structlog
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.manifest import Manifest
 from nexus.infrastructure.state_store import StateStore
+from nexus.infrastructure.praxis_connector.praxis_inbound import PraxisInbound
+from nexus.infrastructure.praxis_connector.praxis_outbound import PraxisOutbound
 from nexus.strategy.action import Action, ActionType
 from nexus.strategy.context import StrategyContext
 from nexus.strategy.params import StrategyParams
@@ -52,8 +54,8 @@ class ShutdownSequencer:
         state: InstanceState,
         strategy_state_path: Path,
         predict_loop: PredictLoop | None = None,
-        praxis_outbound: object | None = None,
-        praxis_inbound: object | None = None,
+        praxis_outbound: PraxisOutbound | None = None,
+        praxis_inbound: PraxisInbound | None = None,
         account_id: str | None = None,
         shutdown_timeout: float = 120.0,
     ) -> None:
@@ -225,7 +227,7 @@ class ShutdownSequencer:
         if not self._submitted_command_ids:
             return
 
-        if not hasattr(self, '_praxis_inbound') or self._praxis_inbound is None:
+        if self._praxis_inbound is None:
             _log.warning(
                 'praxis_inbound not configured, cannot wait for terminal outcomes',
                 command_count=len(self._submitted_command_ids),

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -160,11 +160,11 @@ class ShutdownSequencer:
                 _log.exception('on_shutdown failed', strategy_id=strategy_id)
 
     def _submit_actions(self) -> None:
-        '''Submit EXIT/ABORT actions through Validator.
+        '''Submit EXIT/ABORT actions through Validator to Praxis.
 
         Filters actions returned by strategies from _dispatch_shutdown.
         Only EXIT/ABORT are allowed during shutdown; ENTER/MODIFY skipped.
-        Validation and submission are stubs until Validator/Connector wired.
+        Filtered actions are submitted via PraxisOutbound when available.
         '''
 
         allowed_types = (ActionType.EXIT, ActionType.ABORT)
@@ -192,10 +192,20 @@ class ShutdownSequencer:
         if not filtered:
             return
 
-        _log.warning(
-            'submit_actions validation/submission not implemented',
-            action_count=len(filtered),
-        )
+        if self._praxis_outbound is None:
+            _log.warning(
+                'praxis_outbound not configured, cannot submit shutdown actions',
+                action_count=len(filtered),
+            )
+            return
+
+        for strategy_id, action in filtered:
+            _log.info(
+                'shutdown action pending submission',
+                strategy_id=strategy_id,
+                action_type=action.action_type.value,
+            )
+            self._submitted_command_ids.append(f'{strategy_id}:{action.action_type.value}')
 
     def _wait_terminal(self) -> None:
         '''Wait for all submitted commands to reach terminal state.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from decimal import Decimal
 from pathlib import Path
 
@@ -38,7 +39,9 @@ class ShutdownSequencer:
         strategy_state_path: Directory for strategy state blobs.
         predict_loop: Running PredictLoop to stop during shutdown.
         praxis_outbound: Outbound connector for deregistration.
+        praxis_inbound: Inbound connector for outcome consumption.
         account_id: Account identifier for Praxis deregistration.
+        shutdown_timeout: Seconds to wait for commands to reach terminal state.
     '''
 
     def __init__(
@@ -50,7 +53,9 @@ class ShutdownSequencer:
         strategy_state_path: Path,
         predict_loop: PredictLoop | None = None,
         praxis_outbound: object | None = None,
+        praxis_inbound: object | None = None,
         account_id: str | None = None,
+        shutdown_timeout: float = 120.0,
     ) -> None:
         if not isinstance(runner, StrategyRunner):
             msg = 'runner must be a StrategyRunner instance'
@@ -79,7 +84,9 @@ class ShutdownSequencer:
         self._strategy_state_path = strategy_state_path
         self._predict_loop = predict_loop
         self._praxis_outbound = praxis_outbound
+        self._praxis_inbound = praxis_inbound
         self._account_id = account_id
+        self._shutdown_timeout = shutdown_timeout
         self._shutdown_actions: dict[str, list[Action]] = {}
         self._submitted_command_ids: list[str] = []
         self._save_blobs: dict[str, bytes] = {}
@@ -210,18 +217,44 @@ class ShutdownSequencer:
     def _wait_terminal(self) -> None:
         '''Wait for all submitted commands to reach terminal state.
 
-        Stub: logs warning, returns immediately. No outcome tracking yet.
-        Future: poll/subscribe for TradeOutcome until all commands terminal.
-        On timeout: ABORT remaining commands, wait again with shorter timeout.
+        Polls PraxisInbound for outcomes matching submitted commands.
+        Returns when all commands are terminal or timeout expires.
+        Full ABORT escalation requires Action fields (TD-023).
         '''
 
         if not self._submitted_command_ids:
             return
 
-        _log.warning(
-            'wait_terminal not implemented',
-            command_count=len(self._submitted_command_ids),
-        )
+        if not hasattr(self, '_praxis_inbound') or self._praxis_inbound is None:
+            _log.warning(
+                'praxis_inbound not configured, cannot wait for terminal outcomes',
+                command_count=len(self._submitted_command_ids),
+            )
+            return
+
+        deadline = time.monotonic() + self._shutdown_timeout
+        pending = set(self._submitted_command_ids)
+
+        while pending and time.monotonic() < deadline:
+            outcome = self._praxis_inbound.receive_outcome()
+
+            if outcome is None:
+                continue
+
+            if outcome.command_id in pending and outcome.outcome_type.is_terminal:
+                pending.discard(outcome.command_id)
+                _log.info(
+                    'command reached terminal state',
+                    command_id=outcome.command_id,
+                    outcome_type=outcome.outcome_type.value,
+                )
+
+        if pending:
+            _log.warning(
+                'shutdown timeout: commands still pending',
+                pending_count=len(pending),
+                pending_ids=sorted(pending),
+            )
 
     def _dispatch_save(self) -> None:
         '''Dispatch on_save to all strategies.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -341,4 +341,4 @@ class ShutdownSequencer:
         try:
             self._praxis_outbound.deregister_account(self._account_id)
         except Exception:  # noqa: BLE001 - deregister failure must not prevent shutdown completion
-            _log.exception('deregister failed for account %s', self._account_id)
+            _log.exception('deregister failed', account_id=self._account_id)

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -14,6 +14,7 @@ from nexus.infrastructure.state_store import StateStore
 from nexus.strategy.action import Action, ActionType
 from nexus.strategy.context import StrategyContext
 from nexus.strategy.params import StrategyParams
+from nexus.strategy.predict_loop import PredictLoop
 from nexus.strategy.runner import StrategyRunner
 
 __all__ = ['ShutdownSequencer']
@@ -35,6 +36,7 @@ class ShutdownSequencer:
         state_store: Persistence facade for checkpointing.
         state: Current instance state.
         strategy_state_path: Directory for strategy state blobs.
+        predict_loop: Running PredictLoop to stop during shutdown.
     '''
 
     def __init__(
@@ -44,6 +46,7 @@ class ShutdownSequencer:
         state_store: StateStore,
         state: InstanceState,
         strategy_state_path: Path,
+        predict_loop: PredictLoop | None = None,
     ) -> None:
         if not isinstance(runner, StrategyRunner):
             msg = 'runner must be a StrategyRunner instance'
@@ -70,6 +73,7 @@ class ShutdownSequencer:
         self._state_store = state_store
         self._state = state
         self._strategy_state_path = strategy_state_path
+        self._predict_loop = predict_loop
         self._shutdown_actions: dict[str, list[Action]] = {}
         self._submitted_command_ids: list[str] = []
         self._save_blobs: dict[str, bytes] = {}
@@ -97,10 +101,16 @@ class ShutdownSequencer:
     def _stop_signals(self) -> None:
         '''Stop Sensor signal generation.
 
-        Stub: logs warning, does nothing. See TD-013.
+        Stops the PredictLoop, preventing further predict cycles
+        and signal dispatch during shutdown.
         '''
 
-        _log.warning('stop_signals not implemented')
+        if self._predict_loop is None:
+            _log.warning('predict_loop not configured, skipping signal stop')
+            return
+
+        self._predict_loop.stop()
+        _log.info('predict loop stopped')
 
     def _stop_timers(self) -> None:
         '''Cancel all registered strategy timers.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -37,6 +37,8 @@ class ShutdownSequencer:
         state: Current instance state.
         strategy_state_path: Directory for strategy state blobs.
         predict_loop: Running PredictLoop to stop during shutdown.
+        praxis_outbound: Outbound connector for deregistration.
+        account_id: Account identifier for Praxis deregistration.
     '''
 
     def __init__(
@@ -47,6 +49,8 @@ class ShutdownSequencer:
         state: InstanceState,
         strategy_state_path: Path,
         predict_loop: PredictLoop | None = None,
+        praxis_outbound: object | None = None,
+        account_id: str | None = None,
     ) -> None:
         if not isinstance(runner, StrategyRunner):
             msg = 'runner must be a StrategyRunner instance'
@@ -74,6 +78,8 @@ class ShutdownSequencer:
         self._state = state
         self._strategy_state_path = strategy_state_path
         self._predict_loop = predict_loop
+        self._praxis_outbound = praxis_outbound
+        self._account_id = account_id
         self._shutdown_actions: dict[str, list[Action]] = {}
         self._submitted_command_ids: list[str] = []
         self._save_blobs: dict[str, bytes] = {}
@@ -283,9 +289,13 @@ class ShutdownSequencer:
         self._state_store.checkpoint(self._state)
 
     def _deregister(self) -> None:
-        '''Deregister from Trading sub-system.
+        '''Deregister this account from Trading sub-system via PraxisOutbound.'''
 
-        Stub: logs warning, does nothing. See TD-012.
-        '''
+        if self._praxis_outbound is None or self._account_id is None:
+            _log.warning('praxis_outbound or account_id not configured, skipping deregistration')
+            return
 
-        _log.warning('deregister not implemented')
+        try:
+            self._praxis_outbound.deregister_account(self._account_id)
+        except Exception:  # noqa: BLE001 - deregister failure must not prevent shutdown completion
+            _log.exception('deregister failed for account %s', self._account_id)

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -95,7 +95,7 @@ class ShutdownSequencer:
         self._deregister()
 
     def _stop_signals(self) -> None:
-        '''Stop predictor_fn signal subscriptions.
+        '''Stop Sensor signal generation.
 
         Stub: logs warning, does nothing. See TD-013.
         '''

--- a/nexus/strategy/predict_loop.py
+++ b/nexus/strategy/predict_loop.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import threading
 from collections.abc import Callable
+
 import polars as pl
 
 from nexus.startup.sequencer import WiredSensor
@@ -45,7 +46,7 @@ class PredictLoop:
         self._wired_sensors = list(wired_sensors)
         self._market_data_provider = market_data_provider
         self._context_provider = context_provider
-        self._timers: list[threading.Timer] = []
+        self._active_timers: dict[str, threading.Timer] = {}
         self._running = False
         self._lock = threading.Lock()
 
@@ -65,7 +66,7 @@ class PredictLoop:
             self._running = True
 
             for wired in self._wired_sensors:
-                self._schedule(wired)
+                self._schedule_locked(wired)
 
     def stop(self) -> None:
         '''Stop all predict timers.'''
@@ -73,12 +74,14 @@ class PredictLoop:
         with self._lock:
             self._running = False
 
-            for timer in self._timers:
+            for timer in self._active_timers.values():
                 timer.cancel()
 
-            self._timers.clear()
+            self._active_timers.clear()
 
-    def _schedule(self, wired: WiredSensor) -> None:
+    def _schedule_locked(self, wired: WiredSensor) -> None:
+        '''Schedule next timer for a sensor. Must be called with lock held.'''
+
         if not self._running:
             return
 
@@ -88,12 +91,13 @@ class PredictLoop:
             args=(wired,),
         )
         timer.daemon = True
+        self._active_timers[wired.sensor_id] = timer
         timer.start()
-        self._timers.append(timer)
 
     def _tick(self, wired: WiredSensor) -> None:
-        if not self._running:
-            return
+        with self._lock:
+            if not self._running:
+                return
 
         try:
             kline_size = _extract_kline_size(wired)
@@ -104,7 +108,8 @@ class PredictLoop:
                     'no market data for sensor %s, skipping',
                     wired.sensor_id,
                 )
-                self._schedule(wired)
+                with self._lock:
+                    self._schedule_locked(wired)
                 return
 
             signal = produce_signal(wired, market_data)
@@ -122,7 +127,8 @@ class PredictLoop:
                 wired.sensor_id,
             )
 
-        self._schedule(wired)
+        with self._lock:
+            self._schedule_locked(wired)
 
 
 def _extract_kline_size(wired: WiredSensor) -> int:

--- a/nexus/strategy/predict_loop.py
+++ b/nexus/strategy/predict_loop.py
@@ -91,7 +91,8 @@ class PredictLoop:
             args=(wired,),
         )
         timer.daemon = True
-        self._active_timers[wired.sensor_id] = timer
+        timer_key = f'{wired.strategy_id}:{wired.sensor_id}'
+        self._active_timers[timer_key] = timer
         timer.start()
 
     def _tick(self, wired: WiredSensor) -> None:

--- a/nexus/strategy/predict_loop.py
+++ b/nexus/strategy/predict_loop.py
@@ -112,6 +112,10 @@ class PredictLoop:
                     self._schedule_locked(wired)
                 return
 
+            with self._lock:
+                if not self._running:
+                    return
+
             signal = produce_signal(wired, market_data)
             context = self._context_provider(wired.strategy_id)
 

--- a/nexus/strategy/predict_loop.py
+++ b/nexus/strategy/predict_loop.py
@@ -1,0 +1,143 @@
+'''Timer-based predict loop for signal generation.
+
+Runs per-sensor timers that call produce_signal and dispatch
+the resulting Signal to the bound strategy.
+'''
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+import polars as pl
+
+from nexus.startup.sequencer import WiredSensor
+from nexus.strategy.context import StrategyContext
+from nexus.strategy.params import StrategyParams
+from nexus.strategy.runner import StrategyRunner
+from nexus.strategy.signal_producer import produce_signal
+
+__all__ = ['PredictLoop']
+
+_log = logging.getLogger(__name__)
+
+
+class PredictLoop:
+    '''Timer-based predict loop for wired Sensors.
+
+    Args:
+        runner: StrategyRunner for signal dispatch.
+        wired_sensors: Sensors to run predict on.
+        market_data_provider: Callable that returns rolling DataFrame
+            for a given kline_size. Signature: (kline_size: int) -> pl.DataFrame.
+        context_provider: Callable that returns current StrategyContext
+            for a given strategy_id.
+    '''
+
+    def __init__(
+        self,
+        runner: StrategyRunner,
+        wired_sensors: list[WiredSensor],
+        market_data_provider: Callable[[int], pl.DataFrame],
+        context_provider: Callable[[str], StrategyContext],
+    ) -> None:
+        self._runner = runner
+        self._wired_sensors = list(wired_sensors)
+        self._market_data_provider = market_data_provider
+        self._context_provider = context_provider
+        self._timers: list[threading.Timer] = []
+        self._running = False
+        self._lock = threading.Lock()
+
+    @property
+    def running(self) -> bool:
+        '''Whether the predict loop is currently running.'''
+
+        return self._running
+
+    def start(self) -> None:
+        '''Start predict timers for all wired Sensors.'''
+
+        with self._lock:
+            if self._running:
+                return
+
+            self._running = True
+
+            for wired in self._wired_sensors:
+                self._schedule(wired)
+
+    def stop(self) -> None:
+        '''Stop all predict timers.'''
+
+        with self._lock:
+            self._running = False
+
+            for timer in self._timers:
+                timer.cancel()
+
+            self._timers.clear()
+
+    def _schedule(self, wired: WiredSensor) -> None:
+        if not self._running:
+            return
+
+        timer = threading.Timer(
+            wired.interval_seconds,
+            self._tick,
+            args=(wired,),
+        )
+        timer.daemon = True
+        timer.start()
+        self._timers.append(timer)
+
+    def _tick(self, wired: WiredSensor) -> None:
+        if not self._running:
+            return
+
+        try:
+            kline_size = _extract_kline_size(wired)
+            market_data = self._market_data_provider(kline_size)
+
+            if market_data.is_empty():
+                _log.warning(
+                    'no market data for sensor %s, skipping',
+                    wired.sensor_id,
+                )
+                self._schedule(wired)
+                return
+
+            signal = produce_signal(wired, market_data)
+            context = self._context_provider(wired.strategy_id)
+
+            self._runner.dispatch_signal(
+                wired.strategy_id,
+                signal,
+                StrategyParams(raw={}),
+                context,
+            )
+        except Exception:  # noqa: BLE001 - intentional catch-all for predict cycle
+            _log.exception(
+                'predict failed for sensor %s',
+                wired.sensor_id,
+            )
+
+        self._schedule(wired)
+
+
+def _extract_kline_size(wired: WiredSensor) -> int:
+    '''Extract kline_size from Limen manifest data source config.'''
+
+    config = getattr(wired.limen_manifest, 'data_source_config', None)
+
+    if config is None:
+        msg = f'sensor {wired.sensor_id} has no data_source_config'
+        raise ValueError(msg)
+
+    kline_size = config.params.get('kline_size')
+
+    if kline_size is None:
+        msg = f'sensor {wired.sensor_id} data_source_config missing kline_size'
+        raise ValueError(msg)
+
+    return int(kline_size)

--- a/nexus/strategy/signal.py
+++ b/nexus/strategy/signal.py
@@ -19,7 +19,7 @@ class Signal:
         values: Signal values dict. Keys must be strings. Numeric values (int, float,
             Decimal) must be finite. Common patterns: binary flags (CAN_ENTER=1),
             confidence scores, directional strength.
-        timestamp: When the signal was generated (must be timezone-aware).
+        timestamp: When the signal was generated (must be UTC).
     '''
 
     predictor_fn_id: str

--- a/nexus/strategy/signal.py
+++ b/nexus/strategy/signal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from types import MappingProxyType
 from typing import Any
@@ -54,11 +54,8 @@ class Signal:
             msg = 'timestamp must be a datetime'
             raise ValueError(msg)
 
-        if (
-            self.timestamp.tzinfo is None
-            or self.timestamp.tzinfo.utcoffset(self.timestamp) is None
-        ):
-            msg = 'timestamp must be timezone-aware'
+        if self.timestamp.tzinfo is not timezone.utc:
+            msg = 'timestamp must be UTC'
             raise ValueError(msg)
 
         object.__setattr__(self, 'values', MappingProxyType(dict(self.values)))

--- a/nexus/strategy/signal_producer.py
+++ b/nexus/strategy/signal_producer.py
@@ -36,7 +36,14 @@ def produce_signal(wired: WiredSensor, market_data: pl.DataFrame) -> Signal:
         split_config=(1, 0, 0),
     )
     data_dict = manifest_full.prepare_data(market_data, wired.round_params)
-    last_row = data_dict['x_train'][-1].to_numpy()
+
+    x_train = data_dict.get('x_train')
+
+    if x_train is None or x_train.is_empty():
+        msg = f'prepare_data returned no x_train for sensor {wired.sensor_id}'
+        raise ValueError(msg)
+
+    last_row = x_train[-1].to_numpy()
 
     result = wired.sensor.predict({'x_test': last_row})
 

--- a/nexus/strategy/signal_producer.py
+++ b/nexus/strategy/signal_producer.py
@@ -1,0 +1,74 @@
+'''Produce Signal from a WiredSensor and market data.'''
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from nexus.startup.sequencer import WiredSensor
+from nexus.strategy.signal import Signal
+
+__all__ = ['produce_signal']
+
+
+def produce_signal(wired: WiredSensor, market_data: pl.DataFrame) -> Signal:
+    '''Run feature preparation and predict to produce a Signal.
+
+    Args:
+        wired: Trained Sensor with limen_manifest and round_params.
+        market_data: Rolling DataFrame of market bars.
+
+    Returns:
+        Signal with predict output as values.
+
+    Raises:
+        ValueError: If market_data is empty or predict fails.
+    '''
+
+    if market_data.is_empty():
+        msg = f'market_data is empty for sensor {wired.sensor_id}'
+        raise ValueError(msg)
+
+    manifest_full = wired.limen_manifest.with_params_override(
+        split_config=(1, 0, 0),
+    )
+    data_dict = manifest_full.prepare_data(market_data, wired.round_params)
+    last_row = data_dict['x_train'][-1].to_numpy()
+
+    result = wired.sensor.predict({'x_test': last_row})
+
+    values = _extract_values(result)
+
+    return Signal(
+        predictor_fn_id=wired.sensor_id,
+        values=values,
+        timestamp=datetime.now(tz=timezone.utc),
+    )
+
+
+def _extract_values(result: dict[str, Any]) -> dict[str, Any]:
+    '''Convert predict output to Signal-compatible values dict.
+
+    Extracts scalar values from numpy arrays. Skips private keys
+    that are not signal values.
+    '''
+
+    values: dict[str, Any] = {}
+
+    for key, val in result.items():
+        if key.startswith('_') and key not in ('_preds', '_probs'):
+            continue
+
+        if isinstance(val, np.ndarray):
+            if val.size == 1:
+                scalar = val.item()
+                values[key] = int(scalar) if isinstance(scalar, (np.integer, int)) else float(scalar)
+            else:
+                values[key] = float(val[-1])
+        elif isinstance(val, (int, float)):
+            values[key] = val
+
+    return values

--- a/nexus/strategy/signal_producer.py
+++ b/nexus/strategy/signal_producer.py
@@ -25,7 +25,8 @@ def produce_signal(wired: WiredSensor, market_data: pl.DataFrame) -> Signal:
         Signal with predict output as values.
 
     Raises:
-        ValueError: If market_data is empty or predict fails.
+        ValueError: If market_data is empty or x_train is missing.
+        Exception: Arbitrary exceptions from Limen prepare_data or predict.
     '''
 
     if market_data.is_empty():

--- a/nexus/strategy/signal_producer.py
+++ b/nexus/strategy/signal_producer.py
@@ -76,6 +76,8 @@ def _extract_values(result: dict[str, Any]) -> dict[str, Any]:
                 values[key] = int(scalar) if isinstance(scalar, (np.integer, int)) else float(scalar)
             else:
                 values[key] = float(val[-1])
+        elif isinstance(val, np.generic):
+            values[key] = int(val) if isinstance(val, np.integer) else float(val)
         elif isinstance(val, (int, float)):
             values[key] = val
 

--- a/nexus/strategy/signal_producer.py
+++ b/nexus/strategy/signal_producer.py
@@ -44,7 +44,7 @@ def produce_signal(wired: WiredSensor, market_data: pl.DataFrame) -> Signal:
         msg = f'prepare_data returned no x_train for sensor {wired.sensor_id}'
         raise ValueError(msg)
 
-    last_row = x_train[-1].to_numpy()
+    last_row = x_train.tail(1).to_numpy()
 
     result = wired.sensor.predict({'x_test': last_row})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,18 @@ ignore_missing_imports = true
 module = ["yaml", "yaml.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["limen", "limen.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["polars", "polars.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["numpy", "numpy.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.24.0"
+version = "0.25.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.10"
-dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0", "pyyaml>=6.0"]
+dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0", "pyyaml>=6.0", "vaquum_limen>=1.52.0"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.10"
-dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0", "pyyaml>=6.0", "vaquum_limen>=1.52.0"]
+dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0", "pyyaml>=6.0", "vaquum_limen @ git+https://github.com/Vaquum/Limen"]
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -280,13 +280,13 @@ class TestReleaseReservation:
         assert result.reservation is not None
 
         released = ctrl.release_reservation(result.reservation.reservation_id)
-        assert released is True
+        assert released.success is True
         assert ctrl._state.reservation_notional == _ZERO
         assert 'strat_a' not in ctrl._state.per_strategy_deployed
 
     def test_release_unknown_id(self) -> None:
         ctrl = _make_controller()
-        assert ctrl.release_reservation('nonexistent') is False
+        assert ctrl.release_reservation('nonexistent').success is False
 
     def test_double_release(self) -> None:
         ctrl = _make_controller()
@@ -294,8 +294,8 @@ class TestReleaseReservation:
         assert result.reservation is not None
         rid = result.reservation.reservation_id
 
-        assert ctrl.release_reservation(rid) is True
-        assert ctrl.release_reservation(rid) is False
+        assert ctrl.release_reservation(rid).success is True
+        assert ctrl.release_reservation(rid).success is False
 
 
 class TestConcurrency:
@@ -446,7 +446,7 @@ class TestSendOrder:
         assert result.reservation is not None
 
         sent = ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
-        assert sent is True
+        assert sent.success is True
         assert ctrl._state.reservation_notional == _ZERO
         assert ctrl._state.in_flight_order_notional == Decimal('101')
         assert 'ORD-001' in ctrl._orders
@@ -455,7 +455,7 @@ class TestSendOrder:
     def test_send_order_reservation_not_found(self) -> None:
         ctrl = _make_controller()
         sent = ctrl.send_order('nonexistent', 'ORD-001')
-        assert sent is False
+        assert sent.success is False
         assert ctrl._state.in_flight_order_notional == _ZERO
 
     def test_send_order_expired_reservation(self) -> None:
@@ -473,7 +473,7 @@ class TestSendOrder:
         ctrl._state.reservation_notional = Decimal('101')
 
         sent = ctrl.send_order('expired_001', 'ORD-001')
-        assert sent is False
+        assert sent.success is False
         assert ctrl._state.reservation_notional == _ZERO
         assert ctrl._state.in_flight_order_notional == _ZERO
 
@@ -504,7 +504,7 @@ class TestOrderAck:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
 
         acked = ctrl.order_ack('ORD-001')
-        assert acked is True
+        assert acked.success is True
         assert ctrl._state.in_flight_order_notional == _ZERO
         assert ctrl._state.working_order_notional == Decimal('101')
         assert ctrl._orders['ORD-001'].state == OrderLifecycleState.WORKING
@@ -512,7 +512,7 @@ class TestOrderAck:
     def test_order_ack_not_found(self) -> None:
         ctrl = _make_controller()
         acked = ctrl.order_ack('nonexistent')
-        assert acked is False
+        assert acked.success is False
 
     def test_order_ack_wrong_state(self) -> None:
         ctrl = _make_controller()
@@ -522,7 +522,7 @@ class TestOrderAck:
         ctrl.order_ack('ORD-001')
 
         acked_again = ctrl.order_ack('ORD-001')
-        assert acked_again is False
+        assert acked_again.success is False
 
 
 class TestOrderReject:
@@ -535,7 +535,7 @@ class TestOrderReject:
         assert ctrl._state.in_flight_order_notional == Decimal('101')
 
         rejected = ctrl.order_reject('ORD-001')
-        assert rejected is True
+        assert rejected.success is True
         assert ctrl._state.in_flight_order_notional == _ZERO
         assert 'strat_a' not in ctrl._state.per_strategy_deployed
         assert 'ORD-001' not in ctrl._orders
@@ -543,7 +543,7 @@ class TestOrderReject:
     def test_order_reject_not_found(self) -> None:
         ctrl = _make_controller()
         rejected = ctrl.order_reject('nonexistent')
-        assert rejected is False
+        assert rejected.success is False
 
     def test_order_reject_wrong_state(self) -> None:
         ctrl = _make_controller()
@@ -553,7 +553,7 @@ class TestOrderReject:
         ctrl.order_ack('ORD-001')
 
         rejected = ctrl.order_reject('ORD-001')
-        assert rejected is False
+        assert rejected.success is False
 
 
 class TestOrderFill:
@@ -565,7 +565,7 @@ class TestOrderFill:
         ctrl.order_ack('ORD-001')
 
         filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('1'))
-        assert filled is True
+        assert filled.success is True
         assert ctrl._state.working_order_notional == _ZERO
         assert ctrl._state.position_notional == Decimal('101')
         assert 'ORD-001' not in ctrl._orders
@@ -578,7 +578,7 @@ class TestOrderFill:
         ctrl.order_ack('ORD-001')
 
         filled = ctrl.order_fill('ORD-001', Decimal('400'), Decimal('4'))
-        assert filled is True
+        assert filled.success is True
         assert ctrl._state.working_order_notional == Decimal('606')
         assert ctrl._state.position_notional == Decimal('404')
         assert 'ORD-001' in ctrl._orders
@@ -592,14 +592,14 @@ class TestOrderFill:
         ctrl.order_ack('ORD-001')
 
         filled = ctrl.order_fill('ORD-001', Decimal('200'), Decimal('2'))
-        assert filled is False
+        assert filled.success is False
         assert ctrl._state.working_order_notional == Decimal('101')
         assert ctrl._state.position_notional == _ZERO
 
     def test_order_fill_not_found(self) -> None:
         ctrl = _make_controller()
         filled = ctrl.order_fill('nonexistent', Decimal('100'), Decimal('1'))
-        assert filled is False
+        assert filled.success is False
 
     def test_order_fill_wrong_state(self) -> None:
         ctrl = _make_controller()
@@ -608,7 +608,7 @@ class TestOrderFill:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
 
         filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('1'))
-        assert filled is False
+        assert filled.success is False
 
     def test_order_fill_invalid_notional(self) -> None:
         ctrl = _make_controller()
@@ -642,7 +642,7 @@ class TestOrderFill:
         pre_reserve = ctrl._state.fee_reserve
 
         filled = ctrl.order_fill('ORD-001', Decimal('100'), Decimal('10'))
-        assert filled is False
+        assert filled.success is False
         assert ctrl._state.working_order_notional == pre_working
         assert ctrl._state.position_notional == pre_position
         assert ctrl._state.fee_reserve == pre_reserve
@@ -687,7 +687,7 @@ class TestOrderCancel:
         ctrl.order_ack('ORD-001')
 
         canceled = ctrl.order_cancel('ORD-001')
-        assert canceled is True
+        assert canceled.success is True
         assert ctrl._state.working_order_notional == _ZERO
         assert 'strat_a' not in ctrl._state.per_strategy_deployed
         assert 'ORD-001' not in ctrl._orders
@@ -701,14 +701,14 @@ class TestOrderCancel:
         ctrl.order_fill('ORD-001', Decimal('400'), Decimal('4'))
 
         canceled = ctrl.order_cancel('ORD-001')
-        assert canceled is True
+        assert canceled.success is True
         assert ctrl._state.working_order_notional == _ZERO
         assert ctrl._state.position_notional == Decimal('404')
 
     def test_order_cancel_not_found(self) -> None:
         ctrl = _make_controller()
         canceled = ctrl.order_cancel('nonexistent')
-        assert canceled is False
+        assert canceled.success is False
 
     def test_order_cancel_wrong_state(self) -> None:
         ctrl = _make_controller()
@@ -717,7 +717,7 @@ class TestOrderCancel:
         ctrl.send_order(result.reservation.reservation_id, 'ORD-001')
 
         canceled = ctrl.order_cancel('ORD-001')
-        assert canceled is False
+        assert canceled.success is False
 
 
 class TestLifecycleHappyPath:
@@ -832,12 +832,12 @@ class TestLifecycleConcurrency:
                 )
                 if res.granted and res.reservation:
                     sent = ctrl.send_order(res.reservation.reservation_id, f'ORD-{idx}')
-                    if sent:
+                    if sent.success:
                         acked = ctrl.order_ack(f'ORD-{idx}')
                         filled = ctrl.order_fill(
                             f'ORD-{idx}', Decimal('500'), Decimal('5')
                         )
-                        if not acked or not filled:
+                        if not acked.success or not filled.success:
                             msg = (
                                 f'Lifecycle failure ORD-{idx}: '
                                 f'acked={acked}, filled={filled}'

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -64,6 +64,45 @@ class TestStrategySpec:
                 capital_pct=Decimal('10'),
             )
 
+    def test_padded_whitespace_strategy_id_raises(self) -> None:
+        '''Strategy_id with surrounding whitespace raises ValueError.'''
+
+        with pytest.raises(
+            ValueError, match='strategy_id must be a non-empty string without surrounding whitespace'
+        ):
+            StrategySpec(
+                strategy_id=' s1 ',
+                file='test.py',
+                permutation_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_leading_whitespace_strategy_id_raises(self) -> None:
+        '''Strategy_id with leading whitespace raises ValueError.'''
+
+        with pytest.raises(
+            ValueError, match='strategy_id must be a non-empty string without surrounding whitespace'
+        ):
+            StrategySpec(
+                strategy_id=' s1',
+                file='test.py',
+                permutation_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_trailing_whitespace_strategy_id_raises(self) -> None:
+        '''Strategy_id with trailing whitespace raises ValueError.'''
+
+        with pytest.raises(
+            ValueError, match='strategy_id must be a non-empty string without surrounding whitespace'
+        ):
+            StrategySpec(
+                strategy_id='s1 ',
+                file='test.py',
+                permutation_ids=('pred1',),
+                capital_pct=Decimal('10'),
+            )
+
     def test_empty_file_raises(self) -> None:
         '''Empty file raises ValueError.'''
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,333 +1,74 @@
-'''Tests for manifest loading and validation.'''
+'''Tests for Manifest dataclass and load_manifest function.'''
 
 from __future__ import annotations
 
-import tempfile
 from decimal import Decimal
 from pathlib import Path
 
 import pytest
+import yaml
 
-from nexus.infrastructure.manifest import Manifest, StrategySpec, load_manifest
+from nexus.infrastructure.manifest import (
+    Manifest,
+    SensorSpec,
+    StrategySpec,
+    load_manifest,
+)
 
 
-class TestStrategySpec:
-    '''Tests for StrategySpec dataclass.'''
-
-    def test_valid_strategy_spec(self) -> None:
-        '''Valid StrategySpec creates successfully.'''
-
-        spec = StrategySpec(
-            strategy_id='momentum_v1',
-            file='strategies/momentum.py',
-            permutation_ids=('cohort_alpha_v3', 'sensor_volatility'),
-            capital_pct=Decimal('25'),
-        )
-
-        assert spec.strategy_id == 'momentum_v1'
-        assert spec.file == 'strategies/momentum.py'
-        assert spec.permutation_ids == ('cohort_alpha_v3', 'sensor_volatility')
-        assert spec.capital_pct == Decimal('25')
-
-    def test_strategy_spec_is_frozen(self) -> None:
-        '''StrategySpec is immutable.'''
-
-        spec = StrategySpec(
-            strategy_id='test',
-            file='test.py',
-            permutation_ids=('pred1',),
-            capital_pct=Decimal('10'),
-        )
-
-        with pytest.raises(AttributeError):
-            spec.strategy_id = 'changed'  # type: ignore[misc]
-
-    def test_empty_strategy_id_raises(self) -> None:
-        '''Empty strategy_id raises ValueError.'''
-
-        with pytest.raises(ValueError, match='strategy_id must be a non-empty string'):
-            StrategySpec(
-                strategy_id='',
-                file='test.py',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('10'),
-            )
-
-    def test_whitespace_strategy_id_raises(self) -> None:
-        '''Whitespace-only strategy_id raises ValueError.'''
-
-        with pytest.raises(ValueError, match='strategy_id must be a non-empty string'):
-            StrategySpec(
-                strategy_id='   ',
-                file='test.py',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('10'),
-            )
-
-    def test_padded_whitespace_strategy_id_raises(self) -> None:
-        '''Strategy_id with surrounding whitespace raises ValueError.'''
-
-        with pytest.raises(
-            ValueError, match='strategy_id must be a non-empty string without surrounding whitespace'
-        ):
-            StrategySpec(
-                strategy_id=' s1 ',
-                file='test.py',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('10'),
-            )
-
-    def test_leading_whitespace_strategy_id_raises(self) -> None:
-        '''Strategy_id with leading whitespace raises ValueError.'''
-
-        with pytest.raises(
-            ValueError, match='strategy_id must be a non-empty string without surrounding whitespace'
-        ):
-            StrategySpec(
-                strategy_id=' s1',
-                file='test.py',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('10'),
-            )
-
-    def test_trailing_whitespace_strategy_id_raises(self) -> None:
-        '''Strategy_id with trailing whitespace raises ValueError.'''
-
-        with pytest.raises(
-            ValueError, match='strategy_id must be a non-empty string without surrounding whitespace'
-        ):
-            StrategySpec(
-                strategy_id='s1 ',
-                file='test.py',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('10'),
-            )
-
-    def test_empty_file_raises(self) -> None:
-        '''Empty file raises ValueError.'''
-
-        with pytest.raises(ValueError, match='file must be a non-empty string'):
-            StrategySpec(
-                strategy_id='test',
-                file='',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('10'),
-            )
-
-    def test_whitespace_file_raises(self) -> None:
-        '''Whitespace-only file raises ValueError.'''
-
-        with pytest.raises(ValueError, match='file must be a non-empty string'):
-            StrategySpec(
-                strategy_id='test',
-                file='  ',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('10'),
-            )
-
-    def test_padded_whitespace_file_raises(self) -> None:
-        '''File with surrounding whitespace raises ValueError.'''
-
-        with pytest.raises(ValueError, match='file must be a non-empty string without surrounding whitespace'):
-            StrategySpec(
-                strategy_id='test',
-                file=' strategies/foo.py ',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('10'),
-            )
-
-    def test_empty_permutation_ids_raises(self) -> None:
-        '''Empty permutation_ids raises ValueError.'''
-
-        with pytest.raises(ValueError, match='permutation_ids must be a non-empty tuple'):
-            StrategySpec(
-                strategy_id='test',
-                file='test.py',
-                permutation_ids=(),
-                capital_pct=Decimal('10'),
-            )
-
-    def test_permutation_ids_not_tuple_raises(self) -> None:
-        '''Non-tuple permutation_ids raises ValueError.'''
-
-        with pytest.raises(ValueError, match='permutation_ids must be a non-empty tuple'):
-            StrategySpec(
-                strategy_id='test',
-                file='test.py',
-                permutation_ids=['pred1'],  # type: ignore[arg-type]
-                capital_pct=Decimal('10'),
-            )
-
-    def test_permutation_ids_with_empty_string_raises(self) -> None:
-        '''permutation_ids containing empty string raises ValueError.'''
-
-        with pytest.raises(ValueError, match='permutation_ids must contain non-empty strings'):
-            StrategySpec(
-                strategy_id='test',
-                file='test.py',
-                permutation_ids=('pred1', ''),
-                capital_pct=Decimal('10'),
-            )
-
-    def test_permutation_ids_with_whitespace_raises(self) -> None:
-        '''permutation_ids containing whitespace-only string raises ValueError.'''
-
-        with pytest.raises(ValueError, match='permutation_ids must contain non-empty strings'):
-            StrategySpec(
-                strategy_id='test',
-                file='test.py',
-                permutation_ids=('pred1', '   '),
-                capital_pct=Decimal('10'),
-            )
-
-    def test_permutation_ids_with_non_string_raises(self) -> None:
-        '''permutation_ids containing non-string raises ValueError.'''
-
-        with pytest.raises(ValueError, match='permutation_ids must contain non-empty strings'):
-            StrategySpec(
-                strategy_id='test',
-                file='test.py',
-                permutation_ids=('pred1', 123),  # type: ignore[arg-type]
-                capital_pct=Decimal('10'),
-            )
-
-    def test_non_decimal_capital_pct_raises(self) -> None:
-        '''Non-Decimal capital_pct raises ValueError.'''
-
-        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
-            StrategySpec(
-                strategy_id='test',
-                file='test.py',
-                permutation_ids=('pred1',),
-                capital_pct=25,  # type: ignore[arg-type]
-            )
-
-    def test_infinite_capital_pct_raises(self) -> None:
-        '''Infinite capital_pct raises ValueError.'''
-
-        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
-            StrategySpec(
-                strategy_id='test',
-                file='test.py',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('inf'),
-            )
-
-    def test_nan_capital_pct_raises(self) -> None:
-        '''NaN capital_pct raises ValueError.'''
-
-        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
-            StrategySpec(
-                strategy_id='test',
-                file='test.py',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('nan'),
-            )
-
-    def test_zero_capital_pct_raises(self) -> None:
-        '''Zero capital_pct raises ValueError.'''
-
-        with pytest.raises(ValueError, match='capital_pct must be in'):
-            StrategySpec(
-                strategy_id='test',
-                file='test.py',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('0'),
-            )
-
-    def test_negative_capital_pct_raises(self) -> None:
-        '''Negative capital_pct raises ValueError.'''
-
-        with pytest.raises(ValueError, match='capital_pct must be in'):
-            StrategySpec(
-                strategy_id='test',
-                file='test.py',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('-5'),
-            )
-
-    def test_capital_pct_over_100_raises(self) -> None:
-        '''capital_pct > 100 raises ValueError.'''
-
-        with pytest.raises(ValueError, match='capital_pct must be in'):
-            StrategySpec(
-                strategy_id='test',
-                file='test.py',
-                permutation_ids=('pred1',),
-                capital_pct=Decimal('101'),
-            )
-
-    def test_capital_pct_exactly_100_allowed(self) -> None:
-        '''capital_pct of exactly 100 is allowed.'''
-
-        spec = StrategySpec(
-            strategy_id='test',
-            file='test.py',
-            permutation_ids=('pred1',),
-            capital_pct=Decimal('100'),
-        )
-
-        assert spec.capital_pct == Decimal('100')
-
-    def test_capital_pct_fractional_allowed(self) -> None:
-        '''Fractional capital_pct is allowed.'''
-
-        spec = StrategySpec(
-            strategy_id='test',
-            file='test.py',
-            permutation_ids=('pred1',),
-            capital_pct=Decimal('12.5'),
-        )
-
-        assert spec.capital_pct == Decimal('12.5')
-
-    def test_single_permutation_id_allowed(self) -> None:
-        '''Single permutation_id in tuple is allowed.'''
-
-        spec = StrategySpec(
-            strategy_id='test',
-            file='test.py',
-            permutation_ids=('single_pred',),
-            capital_pct=Decimal('50'),
-        )
-
-        assert spec.permutation_ids == ('single_pred',)
-
-    def test_multiple_permutation_ids_allowed(self) -> None:
-        '''Multiple permutation_ids are allowed.'''
-
-        spec = StrategySpec(
-            strategy_id='test',
-            file='test.py',
-            permutation_ids=('pred1', 'pred2', 'pred3'),
-            capital_pct=Decimal('50'),
-        )
-
-        assert spec.permutation_ids == ('pred1', 'pred2', 'pred3')
+def _pfn(tmp_path: Path) -> SensorSpec:
+    exp_dir = tmp_path / 'experiment'
+    exp_dir.mkdir(exist_ok=True)
+    return SensorSpec(
+        experiment_dir=exp_dir,
+        permutation_ids=(1,),
+        interval_seconds=60,
+    )
 
 
 def _make_spec(
+    tmp_path: Path,
     strategy_id: str = 'test',
     capital_pct: Decimal = Decimal('50'),
 ) -> StrategySpec:
-    '''Create a valid StrategySpec for testing.'''
-
     return StrategySpec(
         strategy_id=strategy_id,
         file='test.py',
-        permutation_ids=('pred1',),
+        sensors=(_pfn(tmp_path),),
         capital_pct=capital_pct,
     )
 
 
-class TestManifest:
-    '''Tests for Manifest dataclass.'''
+def _write_yaml(path: Path, content: str) -> None:
+    path.write_text(content, encoding='utf-8')
 
-    def test_valid_manifest(self) -> None:
+
+def _write_strategy_file(base: Path, rel_path: str, content: str = '') -> None:
+    file_path = base / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content or '# Strategy file\n', encoding='utf-8')
+
+
+def _yaml_sensors(tmp_path: Path) -> str:
+    '''Return YAML sensors block pointing to a real experiment dir.'''
+
+    exp_dir = tmp_path / 'experiment'
+    exp_dir.mkdir(exist_ok=True)
+    return (
+        f'    sensors:\n'
+        f'      - experiment: {exp_dir}\n'
+        f'        permutation_ids: [1]\n'
+        f'        interval_seconds: 60\n'
+    )
+
+
+class TestManifest:
+
+    def test_valid_manifest(self, tmp_path: Path) -> None:
         '''Valid Manifest creates successfully.'''
 
-        spec1 = _make_spec('strategy_a', Decimal('60'))
-        spec2 = _make_spec('strategy_b', Decimal('40'))
+        spec1 = _make_spec(tmp_path, 'strategy_a', Decimal('60'))
+        spec2 = _make_spec(tmp_path, 'strategy_b', Decimal('40'))
 
         manifest = Manifest(
             capital_pool=Decimal('10000'),
@@ -337,60 +78,60 @@ class TestManifest:
         assert manifest.capital_pool == Decimal('10000')
         assert manifest.strategies == (spec1, spec2)
 
-    def test_manifest_is_frozen(self) -> None:
+    def test_manifest_is_frozen(self, tmp_path: Path) -> None:
         '''Manifest is immutable.'''
 
         manifest = Manifest(
             capital_pool=Decimal('10000'),
-            strategies=(_make_spec(),),
+            strategies=(_make_spec(tmp_path),),
         )
 
         with pytest.raises(AttributeError):
             manifest.capital_pool = Decimal('5000')  # type: ignore[misc]
 
-    def test_non_decimal_capital_pool_raises(self) -> None:
+    def test_non_decimal_capital_pool_raises(self, tmp_path: Path) -> None:
         '''Non-Decimal capital_pool raises ValueError.'''
 
         with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
             Manifest(
                 capital_pool=10000,  # type: ignore[arg-type]
-                strategies=(_make_spec(),),
+                strategies=(_make_spec(tmp_path),),
             )
 
-    def test_infinite_capital_pool_raises(self) -> None:
+    def test_infinite_capital_pool_raises(self, tmp_path: Path) -> None:
         '''Infinite capital_pool raises ValueError.'''
 
         with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
             Manifest(
                 capital_pool=Decimal('inf'),
-                strategies=(_make_spec(),),
+                strategies=(_make_spec(tmp_path),),
             )
 
-    def test_nan_capital_pool_raises(self) -> None:
+    def test_nan_capital_pool_raises(self, tmp_path: Path) -> None:
         '''NaN capital_pool raises ValueError.'''
 
         with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
             Manifest(
                 capital_pool=Decimal('nan'),
-                strategies=(_make_spec(),),
+                strategies=(_make_spec(tmp_path),),
             )
 
-    def test_zero_capital_pool_raises(self) -> None:
+    def test_zero_capital_pool_raises(self, tmp_path: Path) -> None:
         '''Zero capital_pool raises ValueError.'''
 
         with pytest.raises(ValueError, match='capital_pool must be positive'):
             Manifest(
                 capital_pool=Decimal('0'),
-                strategies=(_make_spec(),),
+                strategies=(_make_spec(tmp_path),),
             )
 
-    def test_negative_capital_pool_raises(self) -> None:
+    def test_negative_capital_pool_raises(self, tmp_path: Path) -> None:
         '''Negative capital_pool raises ValueError.'''
 
         with pytest.raises(ValueError, match='capital_pool must be positive'):
             Manifest(
                 capital_pool=Decimal('-1000'),
-                strategies=(_make_spec(),),
+                strategies=(_make_spec(tmp_path),),
             )
 
     def test_empty_strategies_raises(self) -> None:
@@ -402,136 +143,125 @@ class TestManifest:
                 strategies=(),
             )
 
-    def test_strategies_not_tuple_raises(self) -> None:
+    def test_strategies_not_tuple_raises(self, tmp_path: Path) -> None:
         '''Non-tuple strategies raises ValueError.'''
 
         with pytest.raises(ValueError, match='strategies must be a non-empty tuple'):
             Manifest(
                 capital_pool=Decimal('10000'),
-                strategies=[_make_spec()],  # type: ignore[arg-type]
+                strategies=[_make_spec(tmp_path)],  # type: ignore[arg-type]
             )
 
-    def test_strategies_with_non_spec_raises(self) -> None:
+    def test_strategies_with_non_spec_raises(self, tmp_path: Path) -> None:
         '''Strategies containing non-StrategySpec raises ValueError.'''
 
         with pytest.raises(ValueError, match='strategies must contain StrategySpec'):
             Manifest(
                 capital_pool=Decimal('10000'),
-                strategies=(_make_spec(), 'not a spec'),  # type: ignore[arg-type]
+                strategies=(_make_spec(tmp_path), 'not a spec'),  # type: ignore[arg-type]
             )
 
-    def test_duplicate_strategy_id_raises(self) -> None:
+    def test_duplicate_strategy_id_raises(self, tmp_path: Path) -> None:
         '''Duplicate strategy_id raises ValueError.'''
 
         with pytest.raises(ValueError, match='duplicate strategy_id'):
             Manifest(
                 capital_pool=Decimal('10000'),
                 strategies=(
-                    _make_spec('same_id', Decimal('50')),
-                    _make_spec('same_id', Decimal('50')),
+                    _make_spec(tmp_path, 'same_id', Decimal('50')),
+                    _make_spec(tmp_path, 'same_id', Decimal('50')),
                 ),
             )
 
-    def test_capital_pct_sum_over_100_raises(self) -> None:
+    def test_capital_pct_sum_over_100_raises(self, tmp_path: Path) -> None:
         '''capital_pct sum > 100 raises ValueError.'''
 
         with pytest.raises(ValueError, match=r'capital_pct sum .* exceeds 100'):
             Manifest(
                 capital_pool=Decimal('10000'),
                 strategies=(
-                    _make_spec('a', Decimal('60')),
-                    _make_spec('b', Decimal('50')),
+                    _make_spec(tmp_path, 'a', Decimal('60')),
+                    _make_spec(tmp_path, 'b', Decimal('50')),
                 ),
             )
 
-    def test_capital_pct_sum_exactly_100_allowed(self) -> None:
+    def test_capital_pct_sum_exactly_100_allowed(self, tmp_path: Path) -> None:
         '''capital_pct sum of exactly 100 is allowed.'''
 
         manifest = Manifest(
             capital_pool=Decimal('10000'),
             strategies=(
-                _make_spec('a', Decimal('60')),
-                _make_spec('b', Decimal('40')),
+                _make_spec(tmp_path, 'a', Decimal('60')),
+                _make_spec(tmp_path, 'b', Decimal('40')),
             ),
         )
 
         assert manifest.capital_pool == Decimal('10000')
 
-    def test_capital_pct_sum_under_100_allowed(self) -> None:
+    def test_capital_pct_sum_under_100_allowed(self, tmp_path: Path) -> None:
         '''capital_pct sum under 100 is allowed.'''
 
         manifest = Manifest(
             capital_pool=Decimal('10000'),
             strategies=(
-                _make_spec('a', Decimal('30')),
-                _make_spec('b', Decimal('20')),
+                _make_spec(tmp_path, 'a', Decimal('30')),
+                _make_spec(tmp_path, 'b', Decimal('20')),
             ),
         )
 
         assert manifest.capital_pool == Decimal('10000')
 
-    def test_single_strategy_allowed(self) -> None:
+    def test_single_strategy_allowed(self, tmp_path: Path) -> None:
         '''Single strategy in manifest is allowed.'''
 
         manifest = Manifest(
             capital_pool=Decimal('10000'),
-            strategies=(_make_spec('only_one', Decimal('100')),),
+            strategies=(_make_spec(tmp_path, 'only_one', Decimal('100')),),
         )
 
         assert len(manifest.strategies) == 1
 
 
-def _write_yaml(path: Path, content: str) -> None:
-    '''Write YAML content to a file.'''
-
-    path.write_text(content, encoding='utf-8')
-
-
-def _write_strategy_file(base: Path, rel_path: str, content: str = '') -> None:
-    '''Create a strategy .py file.'''
-
-    file_path = base / rel_path
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(content or '# Strategy file\n', encoding='utf-8')
-
-
 class TestLoadManifest:
-    '''Tests for load_manifest function.'''
 
-    def test_valid_manifest_loads(self) -> None:
+    def test_valid_manifest_loads(self, tmp_path: Path) -> None:
         '''Valid YAML manifest loads successfully.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            path = tmp_path / 'manifest.yaml'
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
 
-            _write_strategy_file(tmp_path, 'strategies/momentum.py')
-            _write_strategy_file(tmp_path, 'strategies/mean_rev.py')
+        _write_strategy_file(tmp_path, 'strategies/momentum.py')
+        _write_strategy_file(tmp_path, 'strategies/mean_rev.py')
 
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: momentum
-    file: strategies/momentum.py
-    permutation_ids:
-      - alpha_v1
-    capital_pct: 60
-  - id: mean_rev
-    file: strategies/mean_rev.py
-    permutation_ids:
-      - sensor_vol
-    capital_pct: 40
-''',
-            )
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: momentum\n'
+            f'    file: strategies/momentum.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 60\n'
+            f'  - id: mean_rev\n'
+            f'    file: strategies/mean_rev.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [2]\n'
+            f'        interval_seconds: 300\n'
+            f'    capital_pct: 40\n',
+        )
 
-            manifest = load_manifest(path, Decimal('20000'))
+        manifest = load_manifest(path, Decimal('20000'))
 
-            assert manifest.capital_pool == Decimal('10000')
-            assert len(manifest.strategies) == 2
-            assert manifest.strategies[0].strategy_id == 'momentum'
-            assert manifest.strategies[1].strategy_id == 'mean_rev'
+        assert manifest.capital_pool == Decimal('10000')
+        assert len(manifest.strategies) == 2
+        assert manifest.strategies[0].strategy_id == 'momentum'
+        assert manifest.strategies[1].strategy_id == 'mean_rev'
+        assert manifest.strategies[0].sensors[0].permutation_ids == (1,)
+        assert manifest.strategies[0].sensors[0].interval_seconds == 60
 
     def test_file_not_found_raises(self) -> None:
         '''Missing manifest file raises FileNotFoundError.'''
@@ -539,400 +269,423 @@ strategies:
         with pytest.raises(FileNotFoundError, match='Manifest file not found'):
             load_manifest(Path('/nonexistent/manifest.yaml'), Decimal('10000'))
 
-    def test_capital_pool_exceeds_allocated_raises(self) -> None:
+    def test_capital_pool_exceeds_allocated_raises(self, tmp_path: Path) -> None:
         '''capital_pool > allocated_capital raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(
-                path,
-                '''
-capital_pool: 15000
-strategies:
-  - id: test
-    file: test.py
-    permutation_ids: [pred1]
-    capital_pct: 100
-''',
-            )
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
 
-            with pytest.raises(ValueError, match='exceeds allocated_capital'):
-                load_manifest(path, Decimal('10000'))
+        _write_yaml(
+            path,
+            f'capital_pool: 15000\n'
+            f'strategies:\n'
+            f'  - id: test\n'
+            f'    file: test.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
 
-    def test_non_finite_allocated_capital_raises(self) -> None:
+        with pytest.raises(ValueError, match='exceeds allocated_capital'):
+            load_manifest(path, Decimal('10000'))
+
+    def test_non_finite_allocated_capital_raises(self, tmp_path: Path) -> None:
         '''Non-finite allocated_capital raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            strategy = Path(tmp) / 'test.py'
-            strategy.write_text('pass')
-            _write_yaml(
-                path,
-                '''
-capital_pool: 5000
-strategies:
-  - id: test
-    file: test.py
-    permutation_ids: [pred1]
-    capital_pct: 100
-''',
-            )
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+        strategy = tmp_path / 'test.py'
+        strategy.write_text('pass')
 
-            with pytest.raises(ValueError, match='allocated_capital must be a finite'):
-                load_manifest(path, Decimal('NaN'))
+        _write_yaml(
+            path,
+            f'capital_pool: 5000\n'
+            f'strategies:\n'
+            f'  - id: test\n'
+            f'    file: test.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
 
-            with pytest.raises(ValueError, match='allocated_capital must be a finite'):
-                load_manifest(path, Decimal('Infinity'))
+        with pytest.raises(ValueError, match='allocated_capital must be a finite'):
+            load_manifest(path, Decimal('NaN'))
 
-    def test_missing_capital_pool_raises(self) -> None:
+        with pytest.raises(ValueError, match='allocated_capital must be a finite'):
+            load_manifest(path, Decimal('Infinity'))
+
+    def test_missing_capital_pool_raises(self, tmp_path: Path) -> None:
         '''Missing capital_pool raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(
-                path,
-                '''
-strategies:
-  - id: test
-    file: test.py
-    permutation_ids: [pred1]
-    capital_pct: 100
-''',
-            )
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
 
-            with pytest.raises(ValueError, match='missing required field: capital_pool'):
-                load_manifest(path, Decimal('10000'))
+        _write_yaml(
+            path,
+            f'strategies:\n'
+            f'  - id: test\n'
+            f'    file: test.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
 
-    def test_missing_strategies_raises(self) -> None:
+        with pytest.raises(ValueError, match='missing required field: capital_pool'):
+            load_manifest(path, Decimal('10000'))
+
+    def test_missing_strategies_raises(self, tmp_path: Path) -> None:
         '''Missing strategies raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(path, 'capital_pool: 10000\n')
+        path = tmp_path / 'manifest.yaml'
+        _write_yaml(path, 'capital_pool: 10000\n')
 
-            with pytest.raises(ValueError, match='missing or empty strategies'):
-                load_manifest(path, Decimal('20000'))
+        with pytest.raises(ValueError, match='missing or empty strategies'):
+            load_manifest(path, Decimal('20000'))
 
-    def test_empty_strategies_raises(self) -> None:
+    def test_empty_strategies_raises(self, tmp_path: Path) -> None:
         '''Empty strategies list raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies: []
-''',
-            )
+        path = tmp_path / 'manifest.yaml'
+        _write_yaml(path, 'capital_pool: 10000\nstrategies: []\n')
 
-            with pytest.raises(ValueError, match='missing or empty strategies'):
-                load_manifest(path, Decimal('20000'))
+        with pytest.raises(ValueError, match='missing or empty strategies'):
+            load_manifest(path, Decimal('20000'))
 
-    def test_strategy_missing_id_raises(self) -> None:
+    def test_strategy_missing_id_raises(self, tmp_path: Path) -> None:
         '''Strategy missing id raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - file: test.py
-    permutation_ids: [pred1]
-    capital_pct: 100
-''',
-            )
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
 
-            with pytest.raises(ValueError, match='missing required field: id'):
-                load_manifest(path, Decimal('20000'))
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - file: test.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
 
-    def test_strategy_missing_file_raises(self) -> None:
+        with pytest.raises(ValueError, match='missing required field: id'):
+            load_manifest(path, Decimal('20000'))
+
+    def test_strategy_missing_file_raises(self, tmp_path: Path) -> None:
         '''Strategy missing file raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: test
-    permutation_ids: [pred1]
-    capital_pct: 100
-''',
-            )
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
 
-            with pytest.raises(ValueError, match='missing required field: file'):
-                load_manifest(path, Decimal('20000'))
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: test\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
 
-    def test_strategy_missing_permutation_ids_raises(self) -> None:
-        '''Strategy missing permutation_ids raises ValueError.'''
+        with pytest.raises(ValueError, match='missing required field: file'):
+            load_manifest(path, Decimal('20000'))
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: test
-    file: test.py
-    capital_pct: 100
-''',
-            )
+    def test_strategy_missing_sensors_raises(self, tmp_path: Path) -> None:
+        '''Strategy missing sensors raises ValueError.'''
 
-            with pytest.raises(ValueError, match='missing or empty permutation_ids'):
-                load_manifest(path, Decimal('20000'))
+        path = tmp_path / 'manifest.yaml'
 
-    def test_strategy_missing_capital_pct_raises(self) -> None:
+        _write_yaml(
+            path,
+            'capital_pool: 10000\n'
+            'strategies:\n'
+            '  - id: test\n'
+            '    file: test.py\n'
+            '    capital_pct: 100\n',
+        )
+
+        with pytest.raises(ValueError, match='missing or empty sensors'):
+            load_manifest(path, Decimal('20000'))
+
+    def test_strategy_missing_capital_pct_raises(self, tmp_path: Path) -> None:
         '''Strategy missing capital_pct raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: test
-    file: test.py
-    permutation_ids: [pred1]
-''',
-            )
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
 
-            with pytest.raises(ValueError, match='missing required field: capital_pct'):
-                load_manifest(path, Decimal('20000'))
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: test\n'
+            f'    file: test.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n',
+        )
 
-    def test_malformed_yaml_raises(self) -> None:
+        with pytest.raises(ValueError, match='missing required field: capital_pct'):
+            load_manifest(path, Decimal('20000'))
+
+    def test_malformed_yaml_raises(self, tmp_path: Path) -> None:
         '''Malformed YAML raises yaml.YAMLError.'''
 
-        import yaml
+        path = tmp_path / 'manifest.yaml'
+        _write_yaml(path, 'capital_pool: [unclosed')
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(path, 'capital_pool: [unclosed')
+        with pytest.raises(yaml.YAMLError):
+            load_manifest(path, Decimal('20000'))
 
-            with pytest.raises(yaml.YAMLError):
-                load_manifest(path, Decimal('20000'))
-
-    def test_non_mapping_yaml_raises(self) -> None:
+    def test_non_mapping_yaml_raises(self, tmp_path: Path) -> None:
         '''Non-mapping YAML raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(path, '- item1\n- item2\n')
+        path = tmp_path / 'manifest.yaml'
+        _write_yaml(path, '- item1\n- item2\n')
 
-            with pytest.raises(ValueError, match='must be a YAML mapping'):
-                load_manifest(path, Decimal('20000'))
+        with pytest.raises(ValueError, match='must be a YAML mapping'):
+            load_manifest(path, Decimal('20000'))
 
-    def test_duplicate_strategy_id_raises(self) -> None:
+    def test_duplicate_strategy_id_raises(self, tmp_path: Path) -> None:
         '''Duplicate strategy_id raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: same
-    file: test1.py
-    permutation_ids: [pred1]
-    capital_pct: 50
-  - id: same
-    file: test2.py
-    permutation_ids: [pred2]
-    capital_pct: 50
-''',
-            )
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
 
-            with pytest.raises(ValueError, match='duplicate strategy_id'):
-                load_manifest(path, Decimal('20000'))
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: same\n'
+            f'    file: test1.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 50\n'
+            f'  - id: same\n'
+            f'    file: test2.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [2]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 50\n',
+        )
 
-    def test_capital_pct_sum_over_100_raises(self) -> None:
+        with pytest.raises(ValueError, match='duplicate strategy_id'):
+            load_manifest(path, Decimal('20000'))
+
+    def test_capital_pct_sum_over_100_raises(self, tmp_path: Path) -> None:
         '''capital_pct sum > 100 raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'manifest.yaml'
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: a
-    file: a.py
-    permutation_ids: [pred1]
-    capital_pct: 60
-  - id: b
-    file: b.py
-    permutation_ids: [pred2]
-    capital_pct: 50
-''',
-            )
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+        _write_strategy_file(tmp_path, 'a.py')
+        _write_strategy_file(tmp_path, 'b.py')
 
-            with pytest.raises(ValueError, match='exceeds 100'):
-                load_manifest(path, Decimal('20000'))
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: a\n'
+            f'    file: a.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 60\n'
+            f'  - id: b\n'
+            f'    file: b.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [2]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 50\n',
+        )
 
-    def test_strategy_file_not_found_raises(self) -> None:
+        with pytest.raises(ValueError, match='exceeds 100'):
+            load_manifest(path, Decimal('20000'))
+
+    def test_strategy_file_not_found_raises(self, tmp_path: Path) -> None:
         '''Missing strategy .py file raises ValueError with path.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            path = tmp_path / 'manifest.yaml'
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: missing_file
-    file: nonexistent/strategy.py
-    permutation_ids: [pred1]
-    capital_pct: 100
-''',
-            )
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
 
-            with pytest.raises(ValueError, match=r"file not found.*nonexistent/strategy\.py"):
-                load_manifest(path, Decimal('20000'))
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: missing_file\n'
+            f'    file: nonexistent/strategy.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
 
-    def test_strategy_file_syntax_error_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"file not found.*nonexistent/strategy\.py"):
+            load_manifest(path, Decimal('20000'))
+
+    def test_strategy_file_syntax_error_raises(self, tmp_path: Path) -> None:
         '''Invalid Python syntax in strategy file raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            path = tmp_path / 'manifest.yaml'
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
 
-            strategy_file = tmp_path / 'bad_syntax.py'
-            strategy_file.write_text('def broken(\n')
+        strategy_file = tmp_path / 'bad_syntax.py'
+        strategy_file.write_text('def broken(\n')
 
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: bad_syntax
-    file: bad_syntax.py
-    permutation_ids: [pred1]
-    capital_pct: 100
-''',
-            )
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: bad_syntax\n'
+            f'    file: bad_syntax.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
 
-            with pytest.raises(ValueError, match=r'syntax error.*bad_syntax\.py'):
-                load_manifest(path, Decimal('20000'))
+        with pytest.raises(ValueError, match=r'syntax error.*bad_syntax\.py'):
+            load_manifest(path, Decimal('20000'))
 
-    def test_invalid_capital_pool_decimal_raises(self) -> None:
+    def test_invalid_capital_pool_decimal_raises(self, tmp_path: Path) -> None:
         '''Non-numeric capital_pool raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            path = tmp_path / 'manifest.yaml'
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+        _write_strategy_file(tmp_path, 'test.py')
 
-            _write_strategy_file(tmp_path, 'test.py')
+        _write_yaml(
+            path,
+            f'capital_pool: not_a_number\n'
+            f'strategies:\n'
+            f'  - id: test\n'
+            f'    file: test.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
 
-            _write_yaml(
-                path,
-                '''
-capital_pool: not_a_number
-strategies:
-  - id: test
-    file: test.py
-    permutation_ids: [pred1]
-    capital_pct: 100
-''',
-            )
+        with pytest.raises(ValueError, match='capital_pool is not a valid number'):
+            load_manifest(path, Decimal('20000'))
 
-            with pytest.raises(ValueError, match='capital_pool is not a valid number'):
-                load_manifest(path, Decimal('20000'))
-
-    def test_invalid_capital_pct_decimal_raises(self) -> None:
+    def test_invalid_capital_pct_decimal_raises(self, tmp_path: Path) -> None:
         '''Non-numeric capital_pct raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            path = tmp_path / 'manifest.yaml'
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+        _write_strategy_file(tmp_path, 'test.py')
 
-            _write_strategy_file(tmp_path, 'test.py')
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: test\n'
+            f'    file: test.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: invalid\n',
+        )
 
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: test
-    file: test.py
-    permutation_ids: [pred1]
-    capital_pct: invalid
-''',
-            )
+        with pytest.raises(ValueError, match='capital_pct is not a valid number'):
+            load_manifest(path, Decimal('20000'))
 
-            with pytest.raises(ValueError, match='capital_pct is not a valid number'):
-                load_manifest(path, Decimal('20000'))
-
-    def test_absolute_file_path_raises(self) -> None:
+    def test_absolute_file_path_raises(self, tmp_path: Path) -> None:
         '''Absolute strategy file path raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            path = tmp_path / 'manifest.yaml'
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
 
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: absolute
-    file: /etc/passwd
-    permutation_ids: [pred1]
-    capital_pct: 100
-''',
-            )
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: absolute\n'
+            f'    file: /etc/passwd\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
 
-            with pytest.raises(ValueError, match='file must be relative'):
-                load_manifest(path, Decimal('20000'))
+        with pytest.raises(ValueError, match='file must be relative'):
+            load_manifest(path, Decimal('20000'))
 
-    def test_path_traversal_raises(self) -> None:
+    def test_path_traversal_raises(self, tmp_path: Path) -> None:
         '''Strategy file path escaping base raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            path = tmp_path / 'manifest.yaml'
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
 
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: escape
-    file: ../../../etc/passwd
-    permutation_ids: [pred1]
-    capital_pct: 100
-''',
-            )
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: escape\n'
+            f'    file: ../../../etc/passwd\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
 
-            with pytest.raises(ValueError, match='escapes base path'):
-                load_manifest(path, Decimal('20000'))
+        with pytest.raises(ValueError, match='escapes base path'):
+            load_manifest(path, Decimal('20000'))
 
-    def test_directory_instead_of_file_raises(self) -> None:
+    def test_directory_instead_of_file_raises(self, tmp_path: Path) -> None:
         '''Directory path instead of file raises ValueError.'''
 
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            path = tmp_path / 'manifest.yaml'
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+        (tmp_path / 'a_directory').mkdir()
 
-            (tmp_path / 'a_directory').mkdir()
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: dir_not_file\n'
+            f'    file: a_directory\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
 
-            _write_yaml(
-                path,
-                '''
-capital_pool: 10000
-strategies:
-  - id: dir_not_file
-    file: a_directory
-    permutation_ids: [pred1]
-    capital_pct: 100
-''',
-            )
-
-            with pytest.raises(ValueError, match='file not found'):
-                load_manifest(path, Decimal('20000'))
+        with pytest.raises(ValueError, match='file not found'):
+            load_manifest(path, Decimal('20000'))

--- a/tests/test_outcome_processor.py
+++ b/tests/test_outcome_processor.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 
+import pytest
+
 from nexus.core.capital_controller.capital_controller import CapitalController
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OrderSide
@@ -384,7 +386,7 @@ class TestPositionGrowth:
         ) / Decimal('0.03')
         assert state.positions['trade_001'].entry_price == expected
 
-    def test_entry_fill_no_position_returns_false(self) -> None:
+    def test_entry_fill_no_position_raises(self) -> None:
         proc, ctrl, _, _, _tmp = _make_processor()
         _setup_working_order(ctrl)
 
@@ -399,9 +401,8 @@ class TestPositionGrowth:
             actual_fees=Decimal('1'),
         )
 
-        result = proc.process(outcome, _entry_context())
-        assert result.success is True
-        assert result.position_updated is False
+        with pytest.raises(RuntimeError, match='missing position'):
+            proc.process(outcome, _entry_context())
 
 
 class TestPositionReduction:
@@ -462,7 +463,7 @@ class TestPositionReduction:
         proc.process(outcome, _exit_context())
         assert 'trade_001' not in state.positions
 
-    def test_exit_fill_overfill_rejected(self) -> None:
+    def test_exit_fill_overfill_raises(self) -> None:
         proc, ctrl, state, _, _tmp = _make_processor()
         _setup_working_order(ctrl)
 
@@ -487,10 +488,8 @@ class TestPositionReduction:
             actual_fees=Decimal('1'),
         )
 
-        result = proc.process(outcome, _exit_context())
-        assert result.success is True
-        assert result.position_updated is False
-        assert state.positions['trade_001'].size == Decimal('0.01')
+        with pytest.raises(RuntimeError, match='exceeds position size'):
+            proc.process(outcome, _exit_context())
 
 
 class TestCommandIdMismatch:

--- a/tests/test_praxis_inbound.py
+++ b/tests/test_praxis_inbound.py
@@ -1,0 +1,59 @@
+'''Tests for PraxisInbound queue-based outcome consumption.'''
+
+from __future__ import annotations
+
+import queue
+from datetime import datetime, timezone
+
+from nexus.infrastructure.praxis_connector.praxis_inbound import PraxisInbound
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+
+
+def _make_outcome(command_id: str = 'cmd_001') -> TradeOutcome:
+    return TradeOutcome(
+        outcome_id='out_001',
+        command_id=command_id,
+        outcome_type=TradeOutcomeType.ACK,
+        timestamp=datetime.now(tz=timezone.utc),
+    )
+
+
+class TestPraxisInbound:
+
+    def test_receive_returns_outcome(self) -> None:
+        '''receive_outcome returns queued outcome.'''
+
+        q: queue.Queue[TradeOutcome] = queue.Queue()
+        outcome = _make_outcome()
+        q.put(outcome)
+
+        inbound = PraxisInbound(outcome_queue=q)
+        result = inbound.receive_outcome()
+
+        assert result is outcome
+
+    def test_receive_returns_none_when_empty(self) -> None:
+        '''receive_outcome returns None when queue is empty.'''
+
+        q: queue.Queue[TradeOutcome] = queue.Queue()
+        inbound = PraxisInbound(outcome_queue=q, poll_timeout=0.01)
+
+        result = inbound.receive_outcome()
+
+        assert result is None
+
+    def test_receive_preserves_order(self) -> None:
+        '''Outcomes are received in FIFO order.'''
+
+        q: queue.Queue[TradeOutcome] = queue.Queue()
+        o1 = _make_outcome('cmd_001')
+        o2 = _make_outcome('cmd_002')
+        q.put(o1)
+        q.put(o2)
+
+        inbound = PraxisInbound(outcome_queue=q)
+
+        assert inbound.receive_outcome() is o1
+        assert inbound.receive_outcome() is o2
+

--- a/tests/test_praxis_outbound.py
+++ b/tests/test_praxis_outbound.py
@@ -1,0 +1,141 @@
+'''Tests for PraxisOutbound sync-to-async bridge.'''
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from nexus.core.domain.enums import OrderSide
+from nexus.core.stp_mode import STPMode
+from nexus.infrastructure.praxis_connector.praxis_outbound import PraxisOutbound
+from nexus.infrastructure.praxis_connector.trade_command import TradeCommand
+from nexus.infrastructure.praxis_connector.trade_command_type import TradeCommandType
+
+
+@pytest.fixture()
+def event_loop_thread() -> tuple[asyncio.AbstractEventLoop, threading.Thread]:
+    '''Start an asyncio event loop in a background thread.'''
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    yield loop, thread
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5)
+    loop.close()
+
+
+def _make_command(command_id: str = 'cmd_001') -> TradeCommand:
+    return TradeCommand(
+        command_id=command_id,
+        command_type=TradeCommandType.NEW_ORDER,
+        account_id='acc_001',
+        venue='binance_spot',
+        symbol='BTCUSDT',
+        notional=Decimal('1000'),
+        created_at=datetime.now(tz=timezone.utc),
+        side=OrderSide.BUY,
+        size=Decimal('0.01'),
+        stp_mode=STPMode.CANCEL_TAKER,
+        trade_id='trade_001',
+    )
+
+
+class TestPraxisOutbound:
+
+    def test_sends_command_and_returns_id(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''send_command bridges to async and returns command_id.'''
+
+        loop, _ = event_loop_thread
+
+        async def mock_submit(**_kwargs: object) -> str:
+            return 'praxis_cmd_42'
+
+        outbound = PraxisOutbound(
+            submit_fn=mock_submit,
+            loop=loop,
+        )
+
+        command = _make_command()
+        result = outbound.send_command(command)
+
+        assert result == 'praxis_cmd_42'
+
+    def test_passes_correct_fields(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''send_command passes TradeCommand fields to submit_fn.'''
+
+        loop, _ = event_loop_thread
+        received_kwargs: dict[str, object] = {}
+
+        async def capture_submit(**kwargs: object) -> str:
+            received_kwargs.update(kwargs)
+            return 'cmd_id'
+
+        outbound = PraxisOutbound(
+            submit_fn=capture_submit,
+            loop=loop,
+        )
+
+        command = _make_command()
+        outbound.send_command(command)
+
+        assert received_kwargs['account_id'] == 'acc_001'
+        assert received_kwargs['symbol'] == 'BTCUSDT'
+        assert received_kwargs['side'] == OrderSide.BUY
+        assert received_kwargs['trade_id'] == 'trade_001'
+        assert received_kwargs['stp_mode'] == STPMode.CANCEL_TAKER
+
+    def test_timeout_raises(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''send_command raises TimeoutError if async call exceeds timeout.'''
+
+        loop, _ = event_loop_thread
+
+        async def slow_submit(**_kwargs: object) -> str:
+            await asyncio.sleep(10)
+            return 'never'
+
+        outbound = PraxisOutbound(
+            submit_fn=slow_submit,
+            loop=loop,
+            timeout=0.5,
+        )
+
+        command = _make_command()
+
+        with pytest.raises(TimeoutError):
+            outbound.send_command(command)
+
+    def test_async_error_propagates(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''Async exception propagates to sync caller.'''
+
+        loop, _ = event_loop_thread
+
+        async def failing_submit(**_kwargs: object) -> str:
+            msg = 'account not registered'
+            raise ValueError(msg)
+
+        outbound = PraxisOutbound(
+            submit_fn=failing_submit,
+            loop=loop,
+        )
+
+        command = _make_command()
+
+        with pytest.raises(ValueError, match='account not registered'):
+            outbound.send_command(command)

--- a/tests/test_praxis_outbound.py
+++ b/tests/test_praxis_outbound.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import threading
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -115,7 +116,7 @@ class TestPraxisOutbound:
 
         command = _make_command()
 
-        with pytest.raises(TimeoutError):
+        with pytest.raises((TimeoutError, concurrent.futures.TimeoutError)):
             outbound.send_command(command)
 
     def test_async_error_propagates(

--- a/tests/test_predict_loop.py
+++ b/tests/test_predict_loop.py
@@ -1,0 +1,233 @@
+'''Tests for PredictLoop timer-based signal generation.'''
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import polars as pl
+
+from nexus.core.domain.enums import OperationalMode
+from nexus.startup.sequencer import WiredSensor
+from nexus.strategy.context import StrategyContext
+from nexus.strategy.predict_loop import PredictLoop
+from nexus.strategy.runner import StrategyRunner
+from nexus.strategy.signal import Signal
+
+
+def _mock_sensor() -> MagicMock:
+    sensor = MagicMock()
+    sensor.predict.return_value = {
+        '_preds': np.array([1]),
+        '_probs': np.array([0.85]),
+    }
+    return sensor
+
+
+def _mock_limen_manifest() -> MagicMock:
+    manifest = MagicMock()
+    override = MagicMock()
+
+    x_train = pl.DataFrame({'f1': [1.0, 2.0], 'f2': [3.0, 4.0]})
+    override.prepare_data.return_value = {'x_train': x_train}
+    manifest.with_params_override.return_value = override
+    manifest.data_source_config.params = {'kline_size': 3600}
+
+    return manifest
+
+
+def _make_wired(
+    sensor_id: str = 'exp:1',
+    strategy_id: str = 'strat_a',
+    interval_seconds: int = 1,
+) -> WiredSensor:
+    return WiredSensor(
+        sensor_id=sensor_id,
+        sensor=_mock_sensor(),
+        limen_manifest=_mock_limen_manifest(),
+        round_params={'random_weights': 0.5},
+        strategy_id=strategy_id,
+        interval_seconds=interval_seconds,
+    )
+
+
+def _mock_market_data_provider(_kline_size: int) -> pl.DataFrame:
+    return pl.DataFrame({
+        'datetime': [datetime(2026, 1, 1, tzinfo=timezone.utc)],
+        'open': [70000.0],
+        'high': [71000.0],
+        'low': [69000.0],
+        'close': [70500.0],
+        'volume': [100.0],
+    })
+
+
+def _mock_context_provider(_strategy_id: str) -> StrategyContext:
+    return StrategyContext(
+        positions=(),
+        capital_available=Decimal('10000'),
+        operational_mode=OperationalMode.ACTIVE,
+    )
+
+
+class TestPredictLoop:
+
+    def test_start_and_stop(self) -> None:
+        '''PredictLoop starts and stops without error.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+        wired = _make_wired(interval_seconds=10)
+
+        loop = PredictLoop(
+            runner=runner,
+            wired_sensors=[wired],
+            market_data_provider=_mock_market_data_provider,
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        assert loop.running is True
+
+        loop.stop()
+        assert loop.running is False
+
+    def test_dispatches_signal(self) -> None:
+        '''PredictLoop dispatches Signal to runner after timer fires.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+        dispatched = threading.Event()
+
+        def track_dispatch(*_args: Any, **_kwargs: Any) -> list:
+            dispatched.set()
+            return []
+
+        runner.dispatch_signal.side_effect = track_dispatch
+        wired = _make_wired(interval_seconds=1)
+
+        loop = PredictLoop(
+            runner=runner,
+            wired_sensors=[wired],
+            market_data_provider=_mock_market_data_provider,
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        dispatched.wait(timeout=3)
+        loop.stop()
+
+        assert runner.dispatch_signal.called
+        call_args = runner.dispatch_signal.call_args
+        assert call_args[0][0] == 'strat_a'
+        assert isinstance(call_args[0][1], Signal)
+
+    def test_empty_market_data_skips(self) -> None:
+        '''Empty market data logs warning and reschedules.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+
+        def empty_provider(_kline_size: int) -> pl.DataFrame:
+            return pl.DataFrame()
+
+        wired = _make_wired(interval_seconds=1)
+
+        loop = PredictLoop(
+            runner=runner,
+            wired_sensors=[wired],
+            market_data_provider=empty_provider,
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        time.sleep(1.5)
+        loop.stop()
+
+        assert not runner.dispatch_signal.called
+
+    def test_predict_error_does_not_crash_loop(self) -> None:
+        '''Exception in predict cycle is caught, loop continues.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+        call_count = 0
+        dispatched_second = threading.Event()
+
+        def failing_then_ok(kline_size: int) -> pl.DataFrame:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                msg = 'transient error'
+                raise RuntimeError(msg)
+            dispatched_second.set()
+            return _mock_market_data_provider(kline_size)
+
+        wired = _make_wired(interval_seconds=1)
+
+        loop = PredictLoop(
+            runner=runner,
+            wired_sensors=[wired],
+            market_data_provider=failing_then_ok,
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        dispatched_second.wait(timeout=4)
+        loop.stop()
+
+        assert call_count >= 2
+
+    def test_stop_prevents_further_dispatch(self) -> None:
+        '''After stop, no more signals are dispatched.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+        wired = _make_wired(interval_seconds=1)
+
+        loop = PredictLoop(
+            runner=runner,
+            wired_sensors=[wired],
+            market_data_provider=_mock_market_data_provider,
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        loop.stop()
+
+        runner.dispatch_signal.reset_mock()
+        time.sleep(1.5)
+
+        assert not runner.dispatch_signal.called
+
+    def test_multiple_sensors(self) -> None:
+        '''PredictLoop handles multiple sensors dispatching to different strategies.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+        dispatched = threading.Event()
+        strategies_seen: list[str] = []
+
+        def track_dispatch(*args: Any, **_kwargs: Any) -> list:
+            strategies_seen.append(args[0])
+            if len(strategies_seen) >= 2:
+                dispatched.set()
+            return []
+
+        runner.dispatch_signal.side_effect = track_dispatch
+
+        wired_a = _make_wired(sensor_id='exp:1', strategy_id='strat_a', interval_seconds=1)
+        wired_b = _make_wired(sensor_id='exp:2', strategy_id='strat_b', interval_seconds=1)
+
+        loop = PredictLoop(
+            runner=runner,
+            wired_sensors=[wired_a, wired_b],
+            market_data_provider=_mock_market_data_provider,
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        dispatched.wait(timeout=3)
+        loop.stop()
+
+        assert 'strat_a' in strategies_seen
+        assert 'strat_b' in strategies_seen

--- a/tests/test_reservation.py
+++ b/tests/test_reservation.py
@@ -108,12 +108,22 @@ class TestValidation:
             _make_reservation(estimated_fees=Decimal('Inf'))
 
     def test_naive_created_at_rejected(self) -> None:
-        with pytest.raises(ValueError, match='timezone-aware'):
+        with pytest.raises(ValueError, match='must be UTC'):
             _make_reservation(created_at=datetime(2026, 3, 19, 12, 0, 0))
 
+    def test_non_utc_created_at_rejected(self) -> None:
+        non_utc = datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+        with pytest.raises(ValueError, match='must be UTC'):
+            _make_reservation(created_at=non_utc)
+
     def test_naive_expires_at_rejected(self) -> None:
-        with pytest.raises(ValueError, match='timezone-aware'):
+        with pytest.raises(ValueError, match='must be UTC'):
             _make_reservation(expires_at=datetime(2026, 3, 19, 12, 0, 30))
+
+    def test_non_utc_expires_at_rejected(self) -> None:
+        non_utc = datetime(2026, 3, 19, 12, 0, 30, tzinfo=timezone(timedelta(hours=5)))
+        with pytest.raises(ValueError, match='must be UTC'):
+            _make_reservation(expires_at=non_utc)
 
     def test_expires_at_before_created_at_rejected(self) -> None:
         with pytest.raises(ValueError, match='expires_at must be after'):
@@ -160,5 +170,11 @@ class TestReservationResult:
 class TestIsExpiredValidation:
     def test_naive_now_rejected(self) -> None:
         r = _make_reservation()
-        with pytest.raises(ValueError, match='timezone-aware'):
+        with pytest.raises(ValueError, match='requires UTC'):
             r.is_expired(datetime(2026, 3, 19, 12, 0, 30))
+
+    def test_non_utc_now_rejected(self) -> None:
+        r = _make_reservation()
+        non_utc = datetime(2026, 3, 19, 12, 0, 30, tzinfo=timezone(timedelta(hours=5)))
+        with pytest.raises(ValueError, match='requires UTC'):
+            r.is_expired(non_utc)

--- a/tests/test_sensor_spec.py
+++ b/tests/test_sensor_spec.py
@@ -1,0 +1,182 @@
+'''Tests for SensorSpec dataclass.'''
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.infrastructure.manifest import SensorSpec
+
+
+class TestSensorSpec:
+
+    def test_valid_spec(self, tmp_path: Path) -> None:
+        '''Valid SensorSpec creates successfully.'''
+
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+
+        spec = SensorSpec(
+            experiment_dir=exp_dir,
+            permutation_ids=(42, 107),
+            interval_seconds=60,
+        )
+
+        assert spec.experiment_dir == exp_dir
+        assert spec.permutation_ids == (42, 107)
+        assert spec.interval_seconds == 60
+
+    def test_frozen(self, tmp_path: Path) -> None:
+        '''SensorSpec is immutable.'''
+
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+
+        spec = SensorSpec(
+            experiment_dir=exp_dir,
+            permutation_ids=(1,),
+            interval_seconds=60,
+        )
+
+        with pytest.raises(AttributeError):
+            spec.interval_seconds = 30  # type: ignore[misc]
+
+    def test_missing_experiment_dir_raises(self, tmp_path: Path) -> None:
+        '''Non-existent experiment_dir raises ValueError.'''
+
+        with pytest.raises(ValueError, match='experiment_dir not found'):
+            SensorSpec(
+                experiment_dir=tmp_path / 'nonexistent',
+                permutation_ids=(1,),
+                interval_seconds=60,
+            )
+
+    def test_experiment_dir_not_path_raises(self) -> None:
+        '''Non-Path experiment_dir raises ValueError.'''
+
+        with pytest.raises(ValueError, match='experiment_dir must be a Path'):
+            SensorSpec(
+                experiment_dir='/some/string/path',  # type: ignore[arg-type]
+                permutation_ids=(1,),
+                interval_seconds=60,
+            )
+
+    def test_empty_permutation_ids_raises(self, tmp_path: Path) -> None:
+        '''Empty permutation_ids raises ValueError.'''
+
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+
+        with pytest.raises(ValueError, match='permutation_ids must be a non-empty tuple'):
+            SensorSpec(
+                experiment_dir=exp_dir,
+                permutation_ids=(),
+                interval_seconds=60,
+            )
+
+    def test_permutation_ids_not_tuple_raises(self, tmp_path: Path) -> None:
+        '''Non-tuple permutation_ids raises ValueError.'''
+
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+
+        with pytest.raises(ValueError, match='permutation_ids must be a non-empty tuple'):
+            SensorSpec(
+                experiment_dir=exp_dir,
+                permutation_ids=[1, 2],  # type: ignore[arg-type]
+                interval_seconds=60,
+            )
+
+    def test_permutation_ids_with_non_int_raises(self, tmp_path: Path) -> None:
+        '''permutation_ids containing non-int raises ValueError.'''
+
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+
+        with pytest.raises(ValueError, match='permutation_ids must contain ints'):
+            SensorSpec(
+                experiment_dir=exp_dir,
+                permutation_ids=(1, 'two'),  # type: ignore[arg-type]
+                interval_seconds=60,
+            )
+
+    def test_permutation_ids_with_bool_raises(self, tmp_path: Path) -> None:
+        '''permutation_ids containing bool raises ValueError.'''
+
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+
+        with pytest.raises(ValueError, match='permutation_ids must contain ints'):
+            SensorSpec(
+                experiment_dir=exp_dir,
+                permutation_ids=(True,),  # type: ignore[arg-type]
+                interval_seconds=60,
+            )
+
+    def test_zero_interval_raises(self, tmp_path: Path) -> None:
+        '''Zero interval_seconds raises ValueError.'''
+
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+
+        with pytest.raises(ValueError, match='interval_seconds must be positive'):
+            SensorSpec(
+                experiment_dir=exp_dir,
+                permutation_ids=(1,),
+                interval_seconds=0,
+            )
+
+    def test_negative_interval_raises(self, tmp_path: Path) -> None:
+        '''Negative interval_seconds raises ValueError.'''
+
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+
+        with pytest.raises(ValueError, match='interval_seconds must be positive'):
+            SensorSpec(
+                experiment_dir=exp_dir,
+                permutation_ids=(1,),
+                interval_seconds=-10,
+            )
+
+    def test_bool_interval_raises(self, tmp_path: Path) -> None:
+        '''Bool interval_seconds raises ValueError.'''
+
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+
+        with pytest.raises(ValueError, match='interval_seconds must be an int'):
+            SensorSpec(
+                experiment_dir=exp_dir,
+                permutation_ids=(1,),
+                interval_seconds=True,  # type: ignore[arg-type]
+            )
+
+    def test_single_permutation_id(self, tmp_path: Path) -> None:
+        '''Single permutation_id is allowed.'''
+
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+
+        spec = SensorSpec(
+            experiment_dir=exp_dir,
+            permutation_ids=(42,),
+            interval_seconds=300,
+        )
+
+        assert spec.permutation_ids == (42,)
+
+    def test_multiple_permutation_ids(self, tmp_path: Path) -> None:
+        '''Multiple permutation_ids are allowed.'''
+
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+
+        spec = SensorSpec(
+            experiment_dir=exp_dir,
+            permutation_ids=(1, 2, 3),
+            interval_seconds=60,
+        )
+
+        assert spec.permutation_ids == (1, 2, 3)

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -24,7 +24,8 @@ from nexus.strategy.action import Action, ActionType
 from nexus.strategy.runner import StrategyRunner
 
 _PLACEHOLDER_PATH = Path('/placeholder/strategy_state')
-_EXP_DIR = Path(tempfile.mkdtemp())
+_EXP_DIR_HANDLE = tempfile.TemporaryDirectory()
+_EXP_DIR = Path(_EXP_DIR_HANDLE.name)
 
 
 def _make_mock_runner() -> MagicMock:

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tempfile
 from decimal import Decimal
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -10,13 +11,14 @@ import pytest
 
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.instance_state import InstanceState
-from nexus.infrastructure.manifest import Manifest, StrategySpec
+from nexus.infrastructure.manifest import Manifest, SensorSpec, StrategySpec
 from nexus.infrastructure.state_store import StateStore
 from nexus.startup.shutdown_sequencer import ShutdownSequencer
 from nexus.strategy.action import Action, ActionType
 from nexus.strategy.runner import StrategyRunner
 
 _PLACEHOLDER_PATH = Path('/placeholder/strategy_state')
+_EXP_DIR = Path(tempfile.mkdtemp())
 
 
 def _make_mock_runner() -> MagicMock:
@@ -32,10 +34,15 @@ def _make_instance_state() -> InstanceState:
 
 
 def _make_strategy_spec(strategy_id: str = 'test_strategy') -> StrategySpec:
+    pfn = SensorSpec(
+        experiment_dir=_EXP_DIR,
+        permutation_ids=(1,),
+        interval_seconds=60,
+    )
     return StrategySpec(
         strategy_id=strategy_id,
         file='test.py',
-        permutation_ids=('perm1',),
+        sensors=(pfn,),
         capital_pct=Decimal('50'),
     )
 

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -9,15 +9,14 @@ from decimal import Decimal
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from nexus.infrastructure.praxis_connector.praxis_inbound import PraxisInbound
-from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
-from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
-
 import pytest
 
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.manifest import Manifest, SensorSpec, StrategySpec
+from nexus.infrastructure.praxis_connector.praxis_inbound import PraxisInbound
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
 from nexus.infrastructure.state_store import StateStore
 from nexus.startup.shutdown_sequencer import ShutdownSequencer
 from nexus.strategy.action import Action, ActionType

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -295,3 +295,53 @@ class TestShutdownSequence:
         assert runner.dispatch_shutdown.call_count == 2
         assert runner.dispatch_save.call_count == 2
         assert state_store.checkpoint.call_count == 2
+
+
+class TestStopSignals:
+
+    def test_stop_signals_calls_predict_loop_stop(self) -> None:
+        '''_stop_signals calls predict_loop.stop().'''
+
+        mock_loop = MagicMock()
+        sequencer = ShutdownSequencer(
+            runner=_make_mock_runner(),
+            manifest=_make_manifest(),
+            state_store=_make_mock_state_store(),
+            state=_make_instance_state(),
+            strategy_state_path=_PLACEHOLDER_PATH,
+            predict_loop=mock_loop,
+        )
+
+        sequencer._stop_signals()
+
+        mock_loop.stop.assert_called_once()
+
+    def test_stop_signals_without_predict_loop(self) -> None:
+        '''_stop_signals completes without error when predict_loop is None.'''
+
+        sequencer = _make_sequencer()
+        sequencer._stop_signals()
+
+    def test_shutdown_stops_signals_before_dispatch(self) -> None:
+        '''Full shutdown calls predict_loop.stop() before dispatching on_shutdown.'''
+
+        call_order: list[str] = []
+
+        mock_loop = MagicMock()
+        mock_loop.stop.side_effect = lambda: call_order.append('stop_signals')
+
+        runner = _make_mock_runner()
+        runner.dispatch_shutdown.side_effect = lambda *_a, **_kw: call_order.append('dispatch_shutdown')
+
+        sequencer = ShutdownSequencer(
+            runner=runner,
+            manifest=_make_manifest(),
+            state_store=_make_mock_state_store(),
+            state=_make_instance_state(),
+            strategy_state_path=_PLACEHOLDER_PATH,
+            predict_loop=mock_loop,
+        )
+
+        sequencer.shutdown()
+
+        assert call_order.index('stop_signals') < call_order.index('dispatch_shutdown')

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import queue
 import tempfile
+from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from unittest.mock import MagicMock
+
+from nexus.infrastructure.praxis_connector.praxis_inbound import PraxisInbound
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
 
 import pytest
 
@@ -345,3 +351,98 @@ class TestStopSignals:
         sequencer.shutdown()
 
         assert call_order.index('stop_signals') < call_order.index('dispatch_shutdown')
+
+
+class TestWaitTerminal:
+
+    def test_wait_terminal_completes_on_terminal_outcome(self) -> None:
+        '''_wait_terminal returns when submitted commands reach terminal state.'''
+
+        q: queue.Queue[TradeOutcome] = queue.Queue()
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.CANCELED,
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        q.put(outcome)
+
+        inbound = PraxisInbound(outcome_queue=q, poll_timeout=0.01)
+
+        sequencer = ShutdownSequencer(
+            runner=_make_mock_runner(),
+            manifest=_make_manifest(),
+            state_store=_make_mock_state_store(),
+            state=_make_instance_state(),
+            strategy_state_path=_PLACEHOLDER_PATH,
+            praxis_inbound=inbound,
+            shutdown_timeout=5.0,
+        )
+        sequencer._submitted_command_ids.append('cmd_001')
+
+        sequencer._wait_terminal()
+
+        assert q.empty()
+
+    def test_wait_terminal_times_out_on_missing_outcome(self) -> None:
+        '''_wait_terminal logs warning when timeout expires with pending commands.'''
+
+        q: queue.Queue[TradeOutcome] = queue.Queue()
+        inbound = PraxisInbound(outcome_queue=q, poll_timeout=0.01)
+
+        sequencer = ShutdownSequencer(
+            runner=_make_mock_runner(),
+            manifest=_make_manifest(),
+            state_store=_make_mock_state_store(),
+            state=_make_instance_state(),
+            strategy_state_path=_PLACEHOLDER_PATH,
+            praxis_inbound=inbound,
+            shutdown_timeout=0.1,
+        )
+        sequencer._submitted_command_ids.append('cmd_never')
+
+        sequencer._wait_terminal()
+
+    def test_wait_terminal_without_inbound_skips(self) -> None:
+        '''_wait_terminal skips when praxis_inbound is not configured.'''
+
+        sequencer = _make_sequencer()
+        sequencer._submitted_command_ids.append('cmd_001')
+
+        sequencer._wait_terminal()
+
+    def test_wait_terminal_ignores_non_terminal_outcomes(self) -> None:
+        '''_wait_terminal ignores ACK/PARTIAL outcomes.'''
+
+        q: queue.Queue[TradeOutcome] = queue.Queue()
+        ack = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.ACK,
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        filled = TradeOutcome(
+            outcome_id='out_002',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.CANCELED,
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        q.put(ack)
+        q.put(filled)
+
+        inbound = PraxisInbound(outcome_queue=q, poll_timeout=0.01)
+
+        sequencer = ShutdownSequencer(
+            runner=_make_mock_runner(),
+            manifest=_make_manifest(),
+            state_store=_make_mock_state_store(),
+            state=_make_instance_state(),
+            strategy_state_path=_PLACEHOLDER_PATH,
+            praxis_inbound=inbound,
+            shutdown_timeout=5.0,
+        )
+        sequencer._submitted_command_ids.append('cmd_001')
+
+        sequencer._wait_terminal()
+
+        assert q.empty()

--- a/tests/test_signal_producer.py
+++ b/tests/test_signal_producer.py
@@ -1,0 +1,178 @@
+'''Tests for signal_producer with real Limen Sensors.'''
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import polars as pl
+import pytest
+
+from limen.experiment.trainer.trainer import Trainer
+
+from nexus.startup.sequencer import WiredSensor
+from nexus.strategy.signal_producer import _extract_values, produce_signal
+
+
+def _find_limen_root() -> Path | None:
+    try:
+        import limen
+        root = Path(limen.__file__).parent.parent
+        if (root / 'datasets').is_dir():
+            return root
+    except ImportError:
+        pass
+    return None
+
+
+_LIMEN_ROOT = _find_limen_root()
+_HAS_LIMEN_DATA = _LIMEN_ROOT is not None
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_LIMEN_DATA,
+    reason='Limen datasets not available',
+)
+
+
+@pytest.fixture(autouse=True)
+def _limen_cwd() -> None:
+    '''Run tests from Limen root so Trainer can find datasets.'''
+
+    original = Path.cwd()
+    os.chdir(_LIMEN_ROOT)
+    os.environ['LOOP_ENV'] = 'test'
+    try:
+        yield
+    finally:
+        os.chdir(original)
+        os.environ.pop('LOOP_ENV', None)
+
+
+def _make_wired_sensor(tmp_path: Path) -> tuple[WiredSensor, pl.DataFrame]:
+    '''Create a WiredSensor from real Limen Trainer and return with market data.'''
+
+    exp_dir = tmp_path / 'experiment'
+    exp_dir.mkdir()
+
+    metadata = {
+        'sfd_module': 'limen.sfd.foundational_sfd.random_binary',
+        'limen_version': '1.52.0',
+        'created_at': '2026-01-01T00:00:00+00:00',
+    }
+    (exp_dir / 'metadata.json').write_text(json.dumps(metadata))
+
+    round_params = {
+        'random_weights': 0.5,
+        'breakout_threshold': 0.1,
+        'shift': -1,
+    }
+    (exp_dir / 'round_data.jsonl').write_text(
+        json.dumps({'round_id': 1, 'round_params': round_params}) + '\n'
+    )
+
+    trainer = Trainer(exp_dir)
+    sensors = trainer.train([1])
+    sensor = sensors[0]
+
+    wired = WiredSensor(
+        sensor_id='experiment:1',
+        sensor=sensor,
+        limen_manifest=trainer._manifest,
+        round_params=sensor.round_params,
+        strategy_id='test_strat',
+        interval_seconds=60,
+    )
+
+    return wired, trainer._data
+
+
+class TestProduceSignal:
+
+    def test_produces_valid_signal(self, tmp_path: Path) -> None:
+        '''produce_signal returns a Signal with correct fields.'''
+
+        wired, market_data = _make_wired_sensor(tmp_path)
+        signal = produce_signal(wired, market_data)
+
+        assert signal.predictor_fn_id == 'experiment:1'
+        assert signal.timestamp.tzinfo is timezone.utc
+        assert '_preds' in signal.values
+        assert '_probs' in signal.values
+
+    def test_signal_values_are_scalars(self, tmp_path: Path) -> None:
+        '''Signal values are Python scalars, not numpy types.'''
+
+        wired, market_data = _make_wired_sensor(tmp_path)
+        signal = produce_signal(wired, market_data)
+
+        for val in signal.values.values():
+            assert isinstance(val, (int, float))
+
+    def test_empty_market_data_raises(self, tmp_path: Path) -> None:
+        '''Empty market data raises ValueError.'''
+
+        wired, _ = _make_wired_sensor(tmp_path)
+        empty_df = pl.DataFrame()
+
+        with pytest.raises(ValueError, match='market_data is empty'):
+            produce_signal(wired, empty_df)
+
+
+class TestExtractValues:
+
+    def test_extracts_preds_and_probs(self) -> None:
+        '''Extracts _preds and _probs from numpy arrays.'''
+
+        result: dict[str, Any] = {
+            '_preds': np.array([1]),
+            '_probs': np.array([0.85]),
+        }
+
+        values = _extract_values(result)
+
+        assert values['_preds'] == 1
+        assert isinstance(values['_preds'], int)
+        assert values['_probs'] == pytest.approx(0.85)
+        assert isinstance(values['_probs'], float)
+
+    def test_skips_private_keys(self) -> None:
+        '''Skips private keys other than _preds and _probs.'''
+
+        result: dict[str, Any] = {
+            '_preds': np.array([1]),
+            '_probs': np.array([0.9]),
+            '_internal': np.array([42]),
+        }
+
+        values = _extract_values(result)
+
+        assert '_internal' not in values
+        assert '_preds' in values
+        assert '_probs' in values
+
+    def test_handles_scalar_values(self) -> None:
+        '''Passes through plain int/float values.'''
+
+        result: dict[str, Any] = {
+            '_preds': np.array([0]),
+            'confidence': 0.75,
+        }
+
+        values = _extract_values(result)
+
+        assert values['confidence'] == 0.75
+
+    def test_multi_element_array_takes_last(self) -> None:
+        '''Multi-element array extracts last value.'''
+
+        result: dict[str, Any] = {
+            '_preds': np.array([0, 1, 1]),
+        }
+
+        values = _extract_values(result)
+
+        assert values['_preds'] == 1.0

--- a/tests/test_signal_producer.py
+++ b/tests/test_signal_producer.py
@@ -32,13 +32,13 @@ def _find_limen_root() -> Path | None:
 _LIMEN_ROOT = _find_limen_root()
 _HAS_LIMEN_DATA = _LIMEN_ROOT is not None
 
-pytestmark = pytest.mark.skipif(
+_needs_limen = pytest.mark.skipif(
     not _HAS_LIMEN_DATA,
     reason='Limen datasets not found adjacent to installed limen package',
 )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def _limen_cwd() -> None:
     '''Run tests from Limen root so Trainer can find datasets.'''
 
@@ -90,9 +90,10 @@ def _make_wired_sensor(tmp_path: Path) -> tuple[WiredSensor, pl.DataFrame]:
     return wired, trainer._data
 
 
+@_needs_limen
 class TestProduceSignal:
 
-    def test_produces_valid_signal(self, tmp_path: Path) -> None:
+    def test_produces_valid_signal(self, tmp_path: Path, _limen_cwd: None) -> None:
         '''produce_signal returns a Signal with correct fields.'''
 
         wired, market_data = _make_wired_sensor(tmp_path)
@@ -103,7 +104,7 @@ class TestProduceSignal:
         assert '_preds' in signal.values
         assert '_probs' in signal.values
 
-    def test_signal_values_are_scalars(self, tmp_path: Path) -> None:
+    def test_signal_values_are_scalars(self, tmp_path: Path, _limen_cwd: None) -> None:
         '''Signal values are Python scalars, not numpy types.'''
 
         wired, market_data = _make_wired_sensor(tmp_path)
@@ -112,7 +113,7 @@ class TestProduceSignal:
         for val in signal.values.values():
             assert isinstance(val, (int, float))
 
-    def test_empty_market_data_raises(self, tmp_path: Path) -> None:
+    def test_empty_market_data_raises(self, tmp_path: Path, _limen_cwd: None) -> None:
         '''Empty market data raises ValueError.'''
 
         wired, _ = _make_wired_sensor(tmp_path)

--- a/tests/test_signal_producer.py
+++ b/tests/test_signal_producer.py
@@ -34,7 +34,7 @@ _HAS_LIMEN_DATA = _LIMEN_ROOT is not None
 
 pytestmark = pytest.mark.skipif(
     not _HAS_LIMEN_DATA,
-    reason='Limen datasets not available',
+    reason='Limen datasets not found adjacent to installed limen package',
 )
 
 

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -4,12 +4,28 @@ from __future__ import annotations
 
 from decimal import Decimal
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from nexus.infrastructure.state_store import StateStore
 from nexus.startup import StartupError, StartupSequencer
+
+
+@pytest.fixture(autouse=True)
+def _mock_trainer() -> None:
+    '''Patch Limen Trainer so startup tests skip real training.'''
+
+    mock_sensor = MagicMock()
+    mock_sensor.permutation_id = 1
+    mock_sensor.round_params = {}
+
+    mock_trainer = MagicMock()
+    mock_trainer.return_value.train.return_value = [mock_sensor]
+    mock_trainer.return_value._manifest = MagicMock()
+
+    with patch('nexus.startup.sequencer.Trainer', mock_trainer):
+        yield
 
 
 def _make_mock_state_store() -> MagicMock:
@@ -295,10 +311,11 @@ class TestExternalIntegrationStubs:
         with pytest.raises(StartupError, match='replay_strategy_events'):
             sequencer._replay_strategy_events()
 
-    def test_wire_sensors_does_not_raise(self) -> None:
+    def test_wire_sensors_without_manifest_raises(self) -> None:
         sequencer = _make_sequencer()
 
-        sequencer._wire_sensors()
+        with pytest.raises(StartupError, match='manifest not loaded'):
+            sequencer._wire_sensors()
 
     def test_register_timers_does_not_raise(self) -> None:
         sequencer = _make_sequencer()

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -17,6 +17,17 @@ def _make_mock_state_store() -> MagicMock:
     return mock
 
 
+def _sensors_yaml(tmp_path: Path) -> str:
+    exp_dir = tmp_path / 'experiment'
+    exp_dir.mkdir(exist_ok=True)
+    return (
+        f'    sensors:\n'
+        f'      - experiment: {exp_dir}\n'
+        f'        permutation_ids: [1]\n'
+        f'        interval_seconds: 60\n'
+    )
+
+
 _PLACEHOLDER_MANIFEST = Path('/placeholder/manifest.yaml')
 _PLACEHOLDER_STRATEGIES = Path('/placeholder/strategies')
 
@@ -119,7 +130,7 @@ class TestStartupSequencerStart:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -151,7 +162,7 @@ class TestStartupSequencerStart:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -178,7 +189,7 @@ class TestStartupSequencerStart:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -284,10 +295,10 @@ class TestExternalIntegrationStubs:
         with pytest.raises(StartupError, match='replay_strategy_events'):
             sequencer._replay_strategy_events()
 
-    def test_wire_predictor_fns_does_not_raise(self) -> None:
+    def test_wire_sensors_does_not_raise(self) -> None:
         sequencer = _make_sequencer()
 
-        sequencer._wire_predictor_fns()
+        sequencer._wire_sensors()
 
     def test_register_timers_does_not_raise(self) -> None:
         sequencer = _make_sequencer()
@@ -319,7 +330,7 @@ class TestStrategyStateRestoration:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -348,7 +359,7 @@ class TestStrategyStateRestoration:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -390,7 +401,7 @@ class TestStrategyStateRestoration:
             'strategies:\n'
             '  - id: ../evil\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -421,7 +432,7 @@ class TestEventReplay:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -450,7 +461,7 @@ class TestEventReplay:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -488,7 +499,7 @@ class TestEventReplay:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -526,7 +537,7 @@ class TestStartupDispatch:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         sequencer = _make_sequencer(
@@ -570,7 +581,7 @@ class TestStartupDispatch:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         sequencer = _make_sequencer(
@@ -594,7 +605,7 @@ class TestStartupDispatch:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         sequencer = _make_sequencer(
@@ -653,7 +664,7 @@ class TestManifestLoading:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         sequencer = _make_sequencer(
@@ -687,7 +698,7 @@ class TestStrategyInstantiation:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         sequencer = _make_sequencer(
@@ -719,7 +730,7 @@ class TestStrategyInstantiation:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: bad_import.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         sequencer = _make_sequencer(
@@ -756,7 +767,7 @@ class TestCrashOnlyDesign:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -785,7 +796,7 @@ class TestCrashOnlyDesign:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -820,7 +831,7 @@ class TestCrashOnlyDesign:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         state_store = _make_mock_state_store()
@@ -854,7 +865,7 @@ class TestCrashOnlyDesign:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
         event = StrategyEvent(
@@ -892,7 +903,7 @@ class TestCrashOnlyDesign:
             'strategies:\n'
             '  - id: test_strat\n'
             '    file: strat.py\n'
-            '    permutation_ids: [p1]\n'
+            f'{_sensors_yaml(tmp_path)}'
             '    capital_pct: 50\n'
         )
 

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -394,7 +394,7 @@ class TestRecoverWithEvents:
         assert recovered.risk.per_strategy['strat_a'].rolling_loss_24h == Decimal('10')
         assert recovered.risk.per_strategy['strat_b'].rolling_loss_24h == Decimal('20')
 
-    def test_checkpoint_truncates_pre_checkpoint_events(self, tmp_path: Path) -> None:
+    def test_checkpoint_preserves_events_for_rolling_windows(self, tmp_path: Path) -> None:
         store = StateStore(tmp_path / 'state')
         state = _make_state_with_risk()
         store.append_mutation(state)
@@ -422,7 +422,7 @@ class TestRecoverWithEvents:
         store2 = StateStore(tmp_path / 'state')
         recovered = store2.recover()
         assert recovered is not None
-        assert recovered.risk.per_strategy['strat_a'].rolling_loss_24h == Decimal('25')
+        assert recovered.risk.per_strategy['strat_a'].rolling_loss_24h == Decimal('125')
 
 
 class TestReadEvents:

--- a/tests/test_strategy_event.py
+++ b/tests/test_strategy_event.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 from typing import Any
@@ -74,5 +74,10 @@ class TestValidation:
             _make_event(realized_pnl=Decimal('NaN'))
 
     def test_naive_timestamp_rejected(self) -> None:
-        with pytest.raises(ValueError, match='timezone-aware'):
+        with pytest.raises(ValueError, match='must be UTC'):
             _make_event(timestamp=datetime(2026, 3, 19, 12, 0, 0))
+
+    def test_non_utc_timestamp_rejected(self) -> None:
+        non_utc = datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+        with pytest.raises(ValueError, match='must be UTC'):
+            _make_event(timestamp=non_utc)

--- a/tests/test_strategy_event_types.py
+++ b/tests/test_strategy_event_types.py
@@ -213,11 +213,24 @@ class TestSignal:
 
         from datetime import datetime as dt
 
-        with pytest.raises(ValueError, match='timezone-aware'):
+        with pytest.raises(ValueError, match='must be UTC'):
             Signal(
                 predictor_fn_id='test',
                 values={'CAN_ENTER': 1},
                 timestamp=dt.now(),
+            )
+
+    def test_non_utc_timestamp_rejected(self) -> None:
+        '''Non-UTC timezone raises ValueError.'''
+
+        from datetime import datetime as dt, timedelta, timezone as tz
+
+        non_utc = dt(2024, 1, 1, 12, 0, 0, tzinfo=tz(timedelta(hours=5)))
+        with pytest.raises(ValueError, match='must be UTC'):
+            Signal(
+                predictor_fn_id='test',
+                values={'CAN_ENTER': 1},
+                timestamp=non_utc,
             )
 
 

--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -237,7 +237,8 @@ class TestLoadStrategyClass:
                 load_strategy_class(Path('bad.py'), tmp_path)
 
 
-_EXP_DIR = Path(tempfile.mkdtemp())
+_EXP_DIR_HANDLE = tempfile.TemporaryDirectory()
+_EXP_DIR = Path(_EXP_DIR_HANDLE.name)
 
 
 def _make_spec(

--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from nexus.infrastructure.manifest import StrategySpec
+from nexus.infrastructure.manifest import SensorSpec, StrategySpec
 from nexus.strategy import Strategy
 from nexus.strategy.loader import instantiate_strategy, load_strategy_class
 
@@ -237,16 +237,24 @@ class TestLoadStrategyClass:
                 load_strategy_class(Path('bad.py'), tmp_path)
 
 
+_EXP_DIR = Path(tempfile.mkdtemp())
+
+
 def _make_spec(
     strategy_id: str = 'test_strategy',
     file: str = 'strategies/momentum.py',
 ) -> StrategySpec:
     '''Create a StrategySpec for testing.'''
 
+    pfn = SensorSpec(
+        experiment_dir=_EXP_DIR,
+        permutation_ids=(1,),
+        interval_seconds=60,
+    )
     return StrategySpec(
         strategy_id=strategy_id,
         file=file,
-        permutation_ids=('pred1',),
+        sensors=(pfn,),
         capital_pct=Decimal('50'),
     )
 

--- a/tests/test_strategy_spec.py
+++ b/tests/test_strategy_spec.py
@@ -1,0 +1,291 @@
+'''Tests for StrategySpec dataclass.'''
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from nexus.infrastructure.manifest import SensorSpec, StrategySpec
+
+
+def _pfn(tmp_path: Path) -> SensorSpec:
+    '''Create a valid SensorSpec for testing.'''
+
+    exp_dir = tmp_path / 'experiment'
+    exp_dir.mkdir(exist_ok=True)
+    return SensorSpec(
+        experiment_dir=exp_dir,
+        permutation_ids=(1,),
+        interval_seconds=60,
+    )
+
+
+class TestStrategySpec:
+
+    def test_valid_strategy_spec(self, tmp_path: Path) -> None:
+        '''Valid StrategySpec creates successfully.'''
+
+        pfn = _pfn(tmp_path)
+        spec = StrategySpec(
+            strategy_id='momentum_v1',
+            file='strategies/momentum.py',
+            sensors=(pfn,),
+            capital_pct=Decimal('25'),
+        )
+
+        assert spec.strategy_id == 'momentum_v1'
+        assert spec.file == 'strategies/momentum.py'
+        assert spec.sensors == (pfn,)
+        assert spec.capital_pct == Decimal('25')
+
+    def test_strategy_spec_is_frozen(self, tmp_path: Path) -> None:
+        '''StrategySpec is immutable.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            sensors=(_pfn(tmp_path),),
+            capital_pct=Decimal('10'),
+        )
+
+        with pytest.raises(AttributeError):
+            spec.strategy_id = 'changed'  # type: ignore[misc]
+
+    def test_empty_strategy_id_raises(self, tmp_path: Path) -> None:
+        '''Empty strategy_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategy_id must be a non-empty string'):
+            StrategySpec(
+                strategy_id='',
+                file='test.py',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_whitespace_strategy_id_raises(self, tmp_path: Path) -> None:
+        '''Whitespace-only strategy_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='strategy_id must be a non-empty string'):
+            StrategySpec(
+                strategy_id='   ',
+                file='test.py',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_padded_whitespace_strategy_id_raises(self, tmp_path: Path) -> None:
+        '''Strategy_id with surrounding whitespace raises ValueError.'''
+
+        with pytest.raises(
+            ValueError, match='strategy_id must be a non-empty string without surrounding whitespace'
+        ):
+            StrategySpec(
+                strategy_id=' s1 ',
+                file='test.py',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_leading_whitespace_strategy_id_raises(self, tmp_path: Path) -> None:
+        '''Strategy_id with leading whitespace raises ValueError.'''
+
+        with pytest.raises(
+            ValueError, match='strategy_id must be a non-empty string without surrounding whitespace'
+        ):
+            StrategySpec(
+                strategy_id=' s1',
+                file='test.py',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_trailing_whitespace_strategy_id_raises(self, tmp_path: Path) -> None:
+        '''Strategy_id with trailing whitespace raises ValueError.'''
+
+        with pytest.raises(
+            ValueError, match='strategy_id must be a non-empty string without surrounding whitespace'
+        ):
+            StrategySpec(
+                strategy_id='s1 ',
+                file='test.py',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_empty_file_raises(self, tmp_path: Path) -> None:
+        '''Empty file raises ValueError.'''
+
+        with pytest.raises(ValueError, match='file must be a non-empty string'):
+            StrategySpec(
+                strategy_id='test',
+                file='',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_whitespace_file_raises(self, tmp_path: Path) -> None:
+        '''Whitespace-only file raises ValueError.'''
+
+        with pytest.raises(ValueError, match='file must be a non-empty string'):
+            StrategySpec(
+                strategy_id='test',
+                file='  ',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_padded_whitespace_file_raises(self, tmp_path: Path) -> None:
+        '''File with surrounding whitespace raises ValueError.'''
+
+        with pytest.raises(ValueError, match='file must be a non-empty string without surrounding whitespace'):
+            StrategySpec(
+                strategy_id='test',
+                file=' strategies/foo.py ',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_empty_sensors_raises(self) -> None:
+        '''Empty sensors raises ValueError.'''
+
+        with pytest.raises(ValueError, match='sensors must be a non-empty tuple'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                sensors=(),
+                capital_pct=Decimal('10'),
+            )
+
+    def test_sensors_not_tuple_raises(self, tmp_path: Path) -> None:
+        '''Non-tuple sensors raises ValueError.'''
+
+        with pytest.raises(ValueError, match='sensors must be a non-empty tuple'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                sensors=[_pfn(tmp_path)],  # type: ignore[arg-type]
+                capital_pct=Decimal('10'),
+            )
+
+    def test_sensors_with_non_spec_raises(self, tmp_path: Path) -> None:
+        '''sensors containing non-SensorSpec raises ValueError.'''
+
+        with pytest.raises(ValueError, match='sensors must contain SensorSpec'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                sensors=(_pfn(tmp_path), 'not a spec'),  # type: ignore[arg-type]
+                capital_pct=Decimal('10'),
+            )
+
+    def test_non_decimal_capital_pct_raises(self, tmp_path: Path) -> None:
+        '''Non-Decimal capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=25,  # type: ignore[arg-type]
+            )
+
+    def test_infinite_capital_pct_raises(self, tmp_path: Path) -> None:
+        '''Infinite capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('inf'),
+            )
+
+    def test_nan_capital_pct_raises(self, tmp_path: Path) -> None:
+        '''NaN capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be a finite Decimal'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('nan'),
+            )
+
+    def test_zero_capital_pct_raises(self, tmp_path: Path) -> None:
+        '''Zero capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be in'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('0'),
+            )
+
+    def test_negative_capital_pct_raises(self, tmp_path: Path) -> None:
+        '''Negative capital_pct raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be in'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('-5'),
+            )
+
+    def test_capital_pct_over_100_raises(self, tmp_path: Path) -> None:
+        '''capital_pct > 100 raises ValueError.'''
+
+        with pytest.raises(ValueError, match='capital_pct must be in'):
+            StrategySpec(
+                strategy_id='test',
+                file='test.py',
+                sensors=(_pfn(tmp_path),),
+                capital_pct=Decimal('101'),
+            )
+
+    def test_capital_pct_exactly_100_allowed(self, tmp_path: Path) -> None:
+        '''capital_pct of exactly 100 is allowed.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            sensors=(_pfn(tmp_path),),
+            capital_pct=Decimal('100'),
+        )
+
+        assert spec.capital_pct == Decimal('100')
+
+    def test_capital_pct_fractional_allowed(self, tmp_path: Path) -> None:
+        '''Fractional capital_pct is allowed.'''
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            sensors=(_pfn(tmp_path),),
+            capital_pct=Decimal('12.5'),
+        )
+
+        assert spec.capital_pct == Decimal('12.5')
+
+    def test_multiple_sensors_allowed(self, tmp_path: Path) -> None:
+        '''Multiple sensors are allowed.'''
+
+        exp1 = tmp_path / 'exp1'
+        exp1.mkdir()
+        exp2 = tmp_path / 'exp2'
+        exp2.mkdir()
+
+        pfn1 = SensorSpec(experiment_dir=exp1, permutation_ids=(1,), interval_seconds=60)
+        pfn2 = SensorSpec(experiment_dir=exp2, permutation_ids=(2, 3), interval_seconds=300)
+
+        spec = StrategySpec(
+            strategy_id='test',
+            file='test.py',
+            sensors=(pfn1, pfn2),
+            capital_pct=Decimal('50'),
+        )
+
+        assert len(spec.sensors) == 2

--- a/tests/test_tracked_order.py
+++ b/tests/test_tracked_order.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any
 
@@ -164,5 +164,10 @@ class TestValidation:
 
     def test_naive_datetime_rejected(self) -> None:
         naive = datetime(2024, 1, 1)
-        with pytest.raises(ValueError, match='timezone-aware'):
+        with pytest.raises(ValueError, match='must be UTC'):
             _make_order(created_at=naive)
+
+    def test_non_utc_datetime_rejected(self) -> None:
+        non_utc = datetime(2024, 1, 1, tzinfo=timezone(timedelta(hours=5)))
+        with pytest.raises(ValueError, match='must be UTC'):
+            _make_order(created_at=non_utc)

--- a/tests/test_trade_outcome.py
+++ b/tests/test_trade_outcome.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -160,12 +160,22 @@ class TestTradeOutcomeTimestampValidation:
             )
 
     def test_naive_timestamp_rejected(self) -> None:
-        with pytest.raises(ValueError, match='timestamp must be timezone-aware'):
+        with pytest.raises(ValueError, match='must be UTC'):
             TradeOutcome(
                 outcome_id='out_001',
                 command_id='cmd_001',
                 outcome_type=TradeOutcomeType.ACK,
                 timestamp=datetime.now(),
+            )
+
+    def test_non_utc_timestamp_rejected(self) -> None:
+        non_utc = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+        with pytest.raises(ValueError, match='must be UTC'):
+            TradeOutcome(
+                outcome_id='out_001',
+                command_id='cmd_001',
+                outcome_type=TradeOutcomeType.ACK,
+                timestamp=non_utc,
             )
 
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -211,8 +211,18 @@ def test_naive_datetime_rejected() -> None:
     config = _config()
     now = datetime.now()
 
-    with pytest.raises(ValueError, match='timezone-aware'):
+    with pytest.raises(ValueError, match='requires UTC'):
         translate_to_trade_command(context, decision, config, now)
+
+
+def test_non_utc_datetime_rejected() -> None:
+    context = _enter_context()
+    decision = ValidationDecision(allowed=True, reservation=_reservation())
+    config = _config()
+    non_utc = datetime(2026, 3, 25, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+
+    with pytest.raises(ValueError, match='requires UTC'):
+        translate_to_trade_command(context, decision, config, non_utc)
 
 
 def test_deterministic_output() -> None:

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -273,14 +273,23 @@ class TestCodecVersioning:
         with pytest.raises(ValueError, match='Unsupported WAL codec version'):
             deserialize_state(bad_data)
 
-    def test_missing_version_rejected(self) -> None:
-        '''Verify deserialize rejects payload with no version field.'''
+    def test_missing_version_defaults_to_v1(self) -> None:
+        '''Verify deserialize treats missing _v as v1 for backward compatibility.'''
 
         import msgpack
 
-        bad_data = cast(bytes, msgpack.packb({'capital': {}}))
-        with pytest.raises(ValueError, match='Unsupported WAL codec version'):
-            deserialize_state(bad_data)
+        from nexus.core.domain.capital_state import CapitalState
+        from nexus.core.domain.instance_state import InstanceState
+
+        state = InstanceState(capital=CapitalState(capital_pool=Decimal('10000')))
+        v1_data = cast(bytes, serialize_state(state))
+
+        d = msgpack.unpackb(v1_data, raw=False)
+        del d['_v']
+        no_version_data = cast(bytes, msgpack.packb(d))
+
+        recovered = deserialize_state(no_version_data)
+        assert recovered.capital.capital_pool == Decimal('10000')
 
 
 class TestRiskDecodeDefaults:

--- a/tests/test_wire_sensors.py
+++ b/tests/test_wire_sensors.py
@@ -1,0 +1,252 @@
+'''Tests for StartupSequencer._wire_sensors with real Limen Trainer.'''
+
+from __future__ import annotations
+
+import json
+import os
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.infrastructure.state_store import StateStore
+from nexus.startup import StartupError, StartupSequencer
+
+def _find_limen_root() -> Path | None:
+    try:
+        import limen
+        root = Path(limen.__file__).parent.parent
+        if (root / 'datasets').is_dir():
+            return root
+    except ImportError:
+        pass
+    return None
+
+
+_LIMEN_ROOT = _find_limen_root()
+_HAS_LIMEN_DATA = _LIMEN_ROOT is not None
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_LIMEN_DATA,
+    reason='Limen datasets not available at ~/Limen/datasets',
+)
+
+
+@pytest.fixture(autouse=True)
+def _limen_cwd() -> None:
+    '''Run tests from Limen root so Trainer can find datasets.'''
+
+    original = Path.cwd()
+    os.chdir(_LIMEN_ROOT)
+    os.environ['LOOP_ENV'] = 'test'
+    try:
+        yield
+    finally:
+        os.chdir(original)
+        os.environ.pop('LOOP_ENV', None)
+
+
+VALID_STRATEGY = '''
+from nexus.strategy import Action, Strategy, StrategyContext, StrategyParams
+from nexus.strategy.signal import Signal
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+
+class Strategy(Strategy):
+    def on_save(self) -> bytes:
+        return b""
+
+    def on_load(self, data: bytes) -> None:
+        pass
+
+    def on_startup(self, params: StrategyParams, context: StrategyContext) -> list[Action]:
+        return []
+
+    def on_signal(self, signal: Signal, params: StrategyParams, context: StrategyContext) -> list[Action]:
+        return []
+
+    def on_outcome(self, outcome: TradeOutcome, params: StrategyParams, context: StrategyContext) -> list[Action]:
+        return []
+
+    def on_timer(self, timer_id: str, params: StrategyParams, context: StrategyContext) -> list[Action]:
+        return []
+
+    def on_shutdown(self, params: StrategyParams, context: StrategyContext) -> list[Action]:
+        return []
+'''
+
+
+def _make_experiment_dir(tmp_path: Path, name: str = 'experiment') -> Path:
+    '''Create a minimal Limen experiment directory with random_binary SFD.'''
+
+    exp_dir = tmp_path / name
+    exp_dir.mkdir()
+
+    metadata = {
+        'sfd_module': 'limen.sfd.foundational_sfd.random_binary',
+        'limen_version': '1.52.0',
+        'created_at': '2026-01-01T00:00:00+00:00',
+    }
+    (exp_dir / 'metadata.json').write_text(json.dumps(metadata))
+
+    round_entry = {
+        'round_id': 1,
+        'round_params': {
+            'random_weights': 0.5,
+            'breakout_threshold': 0.1,
+            'shift': -1,
+        },
+    }
+    (exp_dir / 'round_data.jsonl').write_text(json.dumps(round_entry) + '\n')
+
+    return exp_dir
+
+
+def _make_mock_state_store() -> MagicMock:
+    mock = MagicMock(spec=StateStore)
+    mock.recover.return_value = None
+    mock.read_events.return_value = []
+    return mock
+
+
+def _make_manifest_yaml(
+    tmp_path: Path,
+    exp_dir: Path,
+    permutation_ids: list[int] | None = None,
+) -> Path:
+    pids = permutation_ids or [1]
+    manifest_path = tmp_path / 'manifest.yaml'
+    strategy_file = tmp_path / 'strat.py'
+    strategy_file.write_text(VALID_STRATEGY)
+
+    pid_str = ', '.join(str(p) for p in pids)
+    manifest_path.write_text(
+        f'capital_pool: 10000\n'
+        f'strategies:\n'
+        f'  - id: test_strat\n'
+        f'    file: strat.py\n'
+        f'    sensors:\n'
+        f'      - experiment: {exp_dir}\n'
+        f'        permutation_ids: [{pid_str}]\n'
+        f'        interval_seconds: 60\n'
+        f'    capital_pct: 50\n'
+    )
+    return manifest_path
+
+
+class TestWireSensors:
+
+    def test_trains_sensor_from_experiment(self, tmp_path: Path) -> None:
+        '''_wire_sensors trains a Sensor from a valid experiment directory.'''
+
+        exp_dir = _make_experiment_dir(tmp_path)
+        manifest_path = _make_manifest_yaml(tmp_path, exp_dir)
+
+        sequencer = StartupSequencer(
+            state_store=_make_mock_state_store(),
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            allocated_capital=Decimal('10000'),
+        )
+
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+        sequencer._wire_sensors()
+
+        assert len(sequencer.wired_sensors) == 1
+        wired = sequencer.wired_sensors[0]
+        assert wired.strategy_id == 'test_strat'
+        assert wired.interval_seconds == 60
+        assert wired.sensor is not None
+        assert 'experiment:1' in wired.sensor_id
+
+    def test_sensor_is_callable(self, tmp_path: Path) -> None:
+        '''Trained Sensor can call predict().'''
+
+        exp_dir = _make_experiment_dir(tmp_path)
+        manifest_path = _make_manifest_yaml(tmp_path, exp_dir)
+
+        sequencer = StartupSequencer(
+            state_store=_make_mock_state_store(),
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            allocated_capital=Decimal('10000'),
+        )
+
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+        sequencer._wire_sensors()
+
+        import numpy as np
+
+        wired = sequencer.wired_sensors[0]
+        result = wired.sensor.predict({'x_test': np.array([[1, 2, 3]])})
+
+        assert '_preds' in result
+
+    def test_missing_experiment_dir_raises(self, tmp_path: Path) -> None:
+        '''Missing experiment directory raises StartupError.'''
+
+        fake_dir = tmp_path / 'nonexistent'
+        fake_dir.mkdir()
+
+        manifest_path = _make_manifest_yaml(tmp_path, fake_dir)
+
+        sequencer = StartupSequencer(
+            state_store=_make_mock_state_store(),
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            allocated_capital=Decimal('10000'),
+        )
+
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+
+        with pytest.raises(StartupError, match='wire_sensors'):
+            sequencer._wire_sensors()
+
+    def test_invalid_permutation_id_raises(self, tmp_path: Path) -> None:
+        '''Permutation ID not in round_data raises StartupError.'''
+
+        exp_dir = _make_experiment_dir(tmp_path)
+        manifest_path = _make_manifest_yaml(tmp_path, exp_dir, permutation_ids=[999])
+
+        sequencer = StartupSequencer(
+            state_store=_make_mock_state_store(),
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            allocated_capital=Decimal('10000'),
+        )
+
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+
+        with pytest.raises(StartupError, match='wire_sensors'):
+            sequencer._wire_sensors()
+
+    def test_stores_limen_manifest_and_round_params(self, tmp_path: Path) -> None:
+        '''WiredSensor contains limen_manifest and round_params.'''
+
+        exp_dir = _make_experiment_dir(tmp_path)
+        manifest_path = _make_manifest_yaml(tmp_path, exp_dir)
+
+        sequencer = StartupSequencer(
+            state_store=_make_mock_state_store(),
+            manifest_path=manifest_path,
+            strategies_base_path=tmp_path,
+            allocated_capital=Decimal('10000'),
+        )
+
+        sequencer._recover_state()
+        sequencer._load_manifest()
+        sequencer._instantiate_strategies()
+        sequencer._wire_sensors()
+
+        wired = sequencer.wired_sensors[0]
+        assert wired.limen_manifest is not None
+        assert isinstance(wired.round_params, dict)
+        assert 'random_weights' in wired.round_params

--- a/tests/test_wire_sensors.py
+++ b/tests/test_wire_sensors.py
@@ -29,7 +29,7 @@ _HAS_LIMEN_DATA = _LIMEN_ROOT is not None
 
 pytestmark = pytest.mark.skipif(
     not _HAS_LIMEN_DATA,
-    reason='Limen datasets not available at ~/Limen/datasets',
+    reason='Limen datasets not found adjacent to installed limen package',
 )
 
 
@@ -186,10 +186,10 @@ class TestWireSensors:
 
         assert '_preds' in result
 
-    def test_missing_experiment_dir_raises(self, tmp_path: Path) -> None:
-        '''Missing experiment directory raises StartupError.'''
+    def test_invalid_experiment_dir_raises(self, tmp_path: Path) -> None:
+        '''Experiment directory without Limen artifacts raises StartupError.'''
 
-        fake_dir = tmp_path / 'nonexistent'
+        fake_dir = tmp_path / 'empty_experiment'
         fake_dir.mkdir()
 
         manifest_path = _make_manifest_yaml(tmp_path, fake_dir)

--- a/tests/test_wire_sensors.py
+++ b/tests/test_wire_sensors.py
@@ -159,7 +159,8 @@ class TestWireSensors:
         assert wired.strategy_id == 'test_strat'
         assert wired.interval_seconds == 60
         assert wired.sensor is not None
-        assert 'experiment:1' in wired.sensor_id
+        assert ':1' in wired.sensor_id
+        assert len(wired.sensor_id.split(':')[0]) == 12
 
     def test_sensor_is_callable(self, tmp_path: Path) -> None:
         '''Trained Sensor can call predict().'''


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements all MMVP-X.1 pipeline integration blockers — the work needed for end-to-end signal-to-trade flow between Limen, Nexus, and Praxis.

**Internal state integrity (X.1.1):**
- UTC-only timestamp enforcement across all domain types (TD-004)
- Whitespace-padded strategy_id rejection in StrategySpec (TD-017)
- Version-dispatched WAL codec deserialization (TD-001)
- Strategy event retention across checkpoint for rolling loss windows (TD-002)

**Lifecycle observability (X.1.6):**
- Replace bare bool returns with `LifecycleResult` + `FailureCategory` enum in CapitalController (TD-003)
- OutcomeProcessor invariant breaches now raise RuntimeError instead of silent False

**Signal flow (X.1.2):**
- New `SensorSpec` manifest schema replacing flat `permutation_ids`
- `_wire_sensors()` trains Limen Sensors via `Trainer(experiment_dir).train(permutation_ids)` (TD-009)
- `signal_producer.produce_signal()` for live feature preparation and predict-to-Signal translation
- `PredictLoop` timer-based signal generation with thread-safe scheduling
- `_stop_signals()` via PredictLoop.stop in ShutdownSequencer (TD-013)

**Command flow (X.1.3):**
- `PraxisOutbound` sync-to-async bridge via `asyncio.run_coroutine_threadsafe`
- Account registration/deregistration via PraxisOutbound (TD-005, TD-012)
- `_submit_actions()` wired with PraxisOutbound for shutdown EXIT/ABORT (TD-015)

**Outcome flow (X.1.4):**
- `PraxisInbound` queue-based TradeOutcome consumption
- `_wait_terminal()` polling PraxisInbound with configurable timeout (TD-016)

**Capital reconciliation (X.1.5):**
- `_reconcile_capital()` pulls Praxis positions, compares by trade_id, syncs position_notional (TD-006)
- Reconciled state persisted to WAL immediately

**Deferred to technical debt (TD-019 through TD-024):**
- TD-019: Cohort support (Limen Cohort not ready)
- TD-020: Experiment directory sandboxing per account
- TD-021: Market data provider (depends on Praxis TD-016 #3)
- TD-022: Sensor hot reload (depends on manifest watcher)
- TD-023: Action dataclass trade fields (blocks full command submission)
- TD-024: Praxis-only position import (no strategy_id mapping)

944 tests passing (up from 891). Adds `vaquum_limen>=1.52.0` as dependency. Bumps to v0.25.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (944 passing)
- [x] I updated `/docs` (TechnicalDebt.md updated with TD-019 through TD-024)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable