### PR TITLE
MMVP-X.2: Pipeline non-blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,3 +269,18 @@
 - Split `test_manifest.py` into `test_sensor_spec.py`, `test_strategy_spec.py`, `test_manifest.py`
 - Add `docs/TechnicalDebt.md` entries TD-019 through TD-024 for deferred work
 - Add 53 tests across new modules (944 total)
+
+## v0.26.0 on 15th of April, 2026
+
+- Add [`TimerSpec`](nexus/infrastructure/manifest.py) frozen dataclass for strategy timer configuration (timer_id, interval_seconds)
+- Add optional `timers` field to `StrategySpec` with duplicate timer_id rejection
+- Update `load_manifest` YAML parsing for optional `timers` entries
+- Add [`timer_loop.py`](nexus/strategy/timer_loop.py) with `TimerLoop` class — per-strategy `threading.Timer` scheduling for `on_timer` callbacks (TD-010)
+- Implement `_register_timers()` in `StartupSequencer` — extracts timer specs from manifest (TD-010)
+- Implement `_stop_timers()` in `ShutdownSequencer` via `TimerLoop.stop()` (TD-014)
+- Add [`health_evaluator.py`](nexus/core/health_evaluator.py) with `HealthEvaluator`, `HealthSnapshot`, and `HealthThresholds` for three-threshold mode determination (warn/breach/halt) (TD-011)
+- Implement `_determine_mode()` in `StartupSequencer` — evaluates health snapshot against thresholds, defaults to ACTIVE when no health data available
+- Replace O(N) dictionary scan in `_purge_expired` with `heapq`-based expiry tracking (TD-018)
+- Replace O(N) dictionary scan in `make_duplicate_order_hook` with `collections.deque`-based chronological expiry (TD-018)
+- Add `docs/TechnicalDebt.md` entries TD-025 (thread churn) and TD-026 (health data source)
+- Add 28 tests across new modules (972 total)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -313,3 +313,16 @@ This affects crash recovery where Nexus state is lost but Praxis still holds pos
 
 **When to fix**: Before production crash recovery or multi-strategy deployments.
 **Migration**: Either (a) add `strategy_id` passthrough to Praxis Position (Praxis stores what Nexus sends in trade metadata), or (b) maintain a persistent `trade_id → strategy_id` mapping in Nexus WAL that survives state loss.
+
+---
+
+## TD-025: PredictLoop and TimerLoop use threading.Timer per tick (thread churn)
+
+**Origin**: MMVP-X.1 predict loop (X.1.2.4), MMVP-X.2 timer loop (X.2.1.1)
+**Severity**: Low (correct but wasteful at scale)
+**Modules**: `nexus/strategy/predict_loop.py`, `nexus/strategy/timer_loop.py`
+
+`threading.Timer` fires once and creates a new thread per fire. Both loops reschedule by creating a new Timer at the end of each tick. With many sensors/timers or short intervals, this causes thread churn — continuous thread creation and teardown. A single persistent thread per loop with `time.sleep` or `threading.Event.wait(timeout)` would be more efficient.
+
+**When to fix**: Before HFT or high-sensor-count deployments.
+**Migration**: Replace per-tick `threading.Timer` with a single scheduler thread per loop that sleeps between fires. Maintain the same lock-guarded `_running` check pattern.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -326,3 +326,18 @@ This affects crash recovery where Nexus state is lost but Praxis still holds pos
 
 **When to fix**: Before HFT or high-sensor-count deployments.
 **Migration**: Replace per-tick `threading.Timer` with a single scheduler thread per loop that sleeps between fires. Maintain the same lock-guarded `_running` check pattern.
+
+---
+
+## TD-026: Health snapshot has no live data source
+
+**Origin**: MMVP-X.2 health evaluation (X.2.2)
+**Severity**: High (mode determination always defaults to ACTIVE without real health data)
+**Module**: `nexus/startup/sequencer.py`
+
+`_determine_mode()` evaluates a `HealthSnapshot` against `HealthThresholds` to set operational mode. The evaluation logic works, but there is no mechanism to populate `HealthSnapshot` with real health data from Praxis. Health signals (latency, consecutive failures, failure rate, rate limit headroom, clock drift) must come from the Trading sub-system via `PraxisInbound` or a dedicated health channel.
+
+Without a live health source, `_determine_mode()` defaults to ACTIVE at startup, and there is no periodic re-evaluation during runtime (the RFC requires continuous health monitoring via `CONTINUOUS_LIMIT_EVAL_INTERVAL_SECONDS`).
+
+**When to fix**: When Praxis TD-016 exposes health signals.
+**Migration**: Add a health signal delivery mechanism from Praxis (either via the outcome queue or a separate channel). Implement periodic health re-evaluation in the Nexus instance thread. Update mode on each evaluation and trigger mode transitions (ACTIVE → REDUCE_ONLY → HALTED) with alerts.

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -226,9 +226,10 @@ Several hot paths and recovery routines use linear O(N) scans and manual diction
 
 **When to fix**: Before high-frequency trading (HFT) or large-scale multi-strategy deployments.
 **Migration**:
-- Replace O(N) dictionary/list scans with O(1) or O(log N) structures (e.g., `collections.deque` or `heapq` for expiration tracking).
-- If `Decimal` precision is not required for a hot path, consider switching that path to float-based aggregation and NumPy; otherwise optimize the `Decimal` path by reducing repeated `Decimal` operations and avoiding full re-scans.
-- Implement batch processing or incremental updates for rolling loss windows so recovery and loss derivation update aggregates from prior state instead of recalculating across the full WAL.
+- ~~Replace O(N) dictionary/list scans~~ RESOLVED in v0.26.0 (X.2.3.1) — `_purge_expired` uses heapq, `make_duplicate_order_hook` uses deque.
+- `derive_rolling_losses` Decimal arithmetic is already O(n) single-pass with early exits. Float aggregation rejected — RFC requires Decimal precision for financial calculations. No further optimization needed unless event volume exceeds 100k per recovery.
+- `WriteAheadLog.read_all` reads sequentially with length-prefixed records — no skip-ahead possible without reading headers. Memory-mapping doesn't help for variable-length records. Marginal optimization; real fix is incremental updates (below) that avoid full WAL reads.
+- ~~Incremental rolling loss updates~~ RESOLVED by TD-002 (X.1.1.4) — snapshot preserves rolling losses, `truncate_keeping_events` retains post-checkpoint events only, recovery re-derives from delta events not full WAL.
 
 ---
 

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -6,6 +6,7 @@ TOCTOU races when multiple strategies compete for the same pool.
 
 from __future__ import annotations
 
+import heapq
 import logging
 import threading
 import uuid
@@ -49,6 +50,7 @@ class CapitalController:
         self._state = capital_state
         self._lock = threading.Lock()
         self._reservations: dict[str, Reservation] = {}
+        self._expiry_heap: list[tuple[datetime, str]] = []
         self._orders: dict[str, TrackedOrder] = {}
 
     def check_and_reserve(
@@ -194,6 +196,7 @@ class CapitalController:
             )
 
             self._reservations[reservation.reservation_id] = reservation
+            heapq.heappush(self._expiry_heap, (reservation.expires_at, reservation.reservation_id))
             self._state.reservation_notional += total
             self._adjust_strategy_deployed(strategy_id, total)
 
@@ -254,10 +257,14 @@ class CapitalController:
     def _purge_expired(self, now: datetime | None = None) -> None:
         if now is None:
             now = datetime.now(tz=timezone.utc)
-        expired = [rid for rid, r in self._reservations.items() if r.is_expired(now)]
 
-        for rid in expired:
-            reservation = self._reservations.pop(rid)
+        while self._expiry_heap and self._expiry_heap[0][0] <= now:
+            _, rid = heapq.heappop(self._expiry_heap)
+            reservation = self._reservations.pop(rid, None)
+
+            if reservation is None:
+                continue
+
             self._state.reservation_notional -= reservation.total
             self._adjust_strategy_deployed(
                 reservation.strategy_id,

--- a/nexus/core/health_evaluator.py
+++ b/nexus/core/health_evaluator.py
@@ -31,6 +31,25 @@ class HealthSnapshot:
     rate_limit_headroom: float = 0.0
     clock_drift_ms: float = 0.0
 
+    def __post_init__(self) -> None:
+        '''Validate health metric invariants.'''
+
+        import math
+
+        for field_name in ('latency_p99_ms', 'failure_rate', 'rate_limit_headroom', 'clock_drift_ms'):
+            val = getattr(self, field_name)
+            if not isinstance(val, (int, float)) or not math.isfinite(val) or val < 0:
+                msg = f'HealthSnapshot.{field_name} must be a finite non-negative number'
+                raise ValueError(msg)
+
+        if not isinstance(self.consecutive_failures, int) or isinstance(self.consecutive_failures, bool):
+            msg = 'HealthSnapshot.consecutive_failures must be an int'
+            raise ValueError(msg)
+
+        if self.consecutive_failures < 0:
+            msg = 'HealthSnapshot.consecutive_failures must be non-negative'
+            raise ValueError(msg)
+
 
 @dataclass(frozen=True)
 class HealthThresholds:

--- a/nexus/core/health_evaluator.py
+++ b/nexus/core/health_evaluator.py
@@ -105,7 +105,7 @@ class HealthThresholds:
             'clock_drift_max_ms',
         ):
             val = getattr(self, field_name)
-            if not isinstance(val, (int, float)) or not math.isfinite(val) or val < 0:
+            if isinstance(val, bool) or not isinstance(val, (int, float)) or not math.isfinite(val) or val < 0:
                 msg = f'HealthThresholds.{field_name} must be a finite non-negative number'
                 raise ValueError(msg)
 

--- a/nexus/core/health_evaluator.py
+++ b/nexus/core/health_evaluator.py
@@ -21,7 +21,7 @@ class HealthSnapshot:
         latency_p99_ms: Ack latency p99 in milliseconds.
         consecutive_failures: Number of consecutive failures.
         failure_rate: Failure rate over rolling window (0.0 to 1.0).
-        rate_limit_headroom: Rate limit utilization (0.0 to 1.0).
+        rate_limit_headroom: Rate limit utilization fraction (0.0 = idle, 1.0 = at limit). Higher is worse.
         clock_drift_ms: Clock drift from exchange in milliseconds.
     '''
 
@@ -38,7 +38,7 @@ class HealthSnapshot:
 
         for field_name in ('latency_p99_ms', 'failure_rate', 'rate_limit_headroom', 'clock_drift_ms'):
             val = getattr(self, field_name)
-            if not isinstance(val, (int, float)) or not math.isfinite(val) or val < 0:
+            if isinstance(val, bool) or not isinstance(val, (int, float)) or not math.isfinite(val) or val < 0:
                 msg = f'HealthSnapshot.{field_name} must be a finite non-negative number'
                 raise ValueError(msg)
 

--- a/nexus/core/health_evaluator.py
+++ b/nexus/core/health_evaluator.py
@@ -1,0 +1,109 @@
+'''Health evaluation for operational mode determination.
+
+Evaluates health metrics against three-threshold policy
+(warn/breach/halt) to determine operational mode.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nexus.core.domain.enums import OperationalMode
+
+__all__ = ['HealthEvaluator', 'HealthSnapshot', 'HealthThresholds']
+
+
+@dataclass(frozen=True)
+class HealthSnapshot:
+    '''Point-in-time health metrics from Trading sub-system.
+
+    Args:
+        latency_p99_ms: Ack latency p99 in milliseconds.
+        consecutive_failures: Number of consecutive failures.
+        failure_rate: Failure rate over rolling window (0.0 to 1.0).
+        rate_limit_headroom: Rate limit utilization (0.0 to 1.0).
+        clock_drift_ms: Clock drift from exchange in milliseconds.
+    '''
+
+    latency_p99_ms: float = 0.0
+    consecutive_failures: int = 0
+    failure_rate: float = 0.0
+    rate_limit_headroom: float = 0.0
+    clock_drift_ms: float = 0.0
+
+
+@dataclass(frozen=True)
+class HealthThresholds:
+    '''Three-threshold health policy configuration.
+
+    Args:
+        latency_warn_ms: Latency alert threshold.
+        latency_breach_ms: Latency breach action threshold.
+        latency_halt_ms: Latency halt threshold.
+        failure_warn: Consecutive failure alert threshold.
+        failure_breach: Consecutive failure breach threshold.
+        failure_halt: Consecutive failure halt threshold.
+        failure_rate_warn: Failure rate alert threshold.
+        failure_rate_breach: Failure rate breach threshold.
+        failure_rate_halt: Failure rate halt threshold.
+        headroom_warn: Rate limit headroom alert threshold.
+        headroom_breach: Rate limit headroom breach threshold.
+        headroom_halt: Rate limit headroom halt threshold.
+        clock_drift_max_ms: Max clock drift before halt.
+    '''
+
+    latency_warn_ms: float = 200.0
+    latency_breach_ms: float = 500.0
+    latency_halt_ms: float = 1000.0
+    failure_warn: int = 3
+    failure_breach: int = 5
+    failure_halt: int = 10
+    failure_rate_warn: float = 0.10
+    failure_rate_breach: float = 0.20
+    failure_rate_halt: float = 0.40
+    headroom_warn: float = 0.70
+    headroom_breach: float = 0.85
+    headroom_halt: float = 0.90
+    clock_drift_max_ms: float = 500.0
+
+
+class HealthEvaluator:
+    '''Evaluate health snapshot against thresholds to determine mode.
+
+    Args:
+        thresholds: Health policy thresholds.
+    '''
+
+    def __init__(self, thresholds: HealthThresholds | None = None) -> None:
+        self._thresholds = thresholds or HealthThresholds()
+
+    def evaluate(self, snapshot: HealthSnapshot) -> OperationalMode:
+        '''Determine operational mode from health snapshot.
+
+        Args:
+            snapshot: Current health metrics.
+
+        Returns:
+            OperationalMode based on worst metric breach level.
+        '''
+
+        t = self._thresholds
+
+        if (
+            snapshot.latency_p99_ms >= t.latency_halt_ms
+            or snapshot.consecutive_failures >= t.failure_halt
+            or snapshot.failure_rate >= t.failure_rate_halt
+            or snapshot.rate_limit_headroom >= t.headroom_halt
+            or snapshot.clock_drift_ms >= t.clock_drift_max_ms
+        ):
+            return OperationalMode.HALTED
+
+        if (
+            snapshot.latency_p99_ms >= t.latency_breach_ms
+            or snapshot.consecutive_failures >= t.failure_breach
+            or snapshot.failure_rate >= t.failure_rate_breach
+            or snapshot.rate_limit_headroom >= t.headroom_breach
+        ):
+            return OperationalMode.REDUCE_ONLY
+
+        return OperationalMode.ACTIVE

--- a/nexus/core/health_evaluator.py
+++ b/nexus/core/health_evaluator.py
@@ -131,6 +131,15 @@ class HealthThresholds:
             msg = 'HealthThresholds: headroom thresholds must be warn <= breach <= halt'
             raise ValueError(msg)
 
+        for ratio_field in (
+            'failure_rate_warn', 'failure_rate_breach', 'failure_rate_halt',
+            'headroom_warn', 'headroom_breach', 'headroom_halt',
+        ):
+            val = getattr(self, ratio_field)
+            if val > 1.0:
+                msg = f'HealthThresholds.{ratio_field} must be <= 1.0, got {val}'
+                raise ValueError(msg)
+
 
 class HealthEvaluator:
     '''Evaluate health snapshot against thresholds to determine mode.

--- a/nexus/core/health_evaluator.py
+++ b/nexus/core/health_evaluator.py
@@ -21,7 +21,9 @@ class HealthSnapshot:
         latency_p99_ms: Ack latency p99 in milliseconds.
         consecutive_failures: Number of consecutive failures.
         failure_rate: Failure rate over rolling window (0.0 to 1.0).
-        rate_limit_headroom: Rate limit utilization fraction (0.0 = idle, 1.0 = at limit). Higher is worse.
+        rate_limit_headroom: Rate limit utilization fraction (0.0 = idle, 1.0 = at limit).
+            Higher is worse. NOTE: health_stage.py uses inverted semantics
+            (higher_is_worse=False) — see TD-018 migration notes.
         clock_drift_ms: Clock drift from exchange in milliseconds.
     '''
 
@@ -40,6 +42,12 @@ class HealthSnapshot:
             val = getattr(self, field_name)
             if isinstance(val, bool) or not isinstance(val, (int, float)) or not math.isfinite(val) or val < 0:
                 msg = f'HealthSnapshot.{field_name} must be a finite non-negative number'
+                raise ValueError(msg)
+
+        for ratio_field in ('failure_rate', 'rate_limit_headroom'):
+            val = getattr(self, ratio_field)
+            if val > 1.0:
+                msg = f'HealthSnapshot.{ratio_field} must be <= 1.0, got {val}'
                 raise ValueError(msg)
 
         if not isinstance(self.consecutive_failures, int) or isinstance(self.consecutive_failures, bool):
@@ -88,6 +96,10 @@ class HealthThresholds:
 
 class HealthEvaluator:
     '''Evaluate health snapshot against thresholds to determine mode.
+
+    Evaluates breach and halt thresholds only. Warn thresholds are
+    defined in HealthThresholds for future alert integration but are
+    not evaluated here — alert routing requires TD-026 (live health source).
 
     Args:
         thresholds: Health policy thresholds.

--- a/nexus/core/health_evaluator.py
+++ b/nexus/core/health_evaluator.py
@@ -93,6 +93,44 @@ class HealthThresholds:
     headroom_halt: float = 0.90
     clock_drift_max_ms: float = 500.0
 
+    def __post_init__(self) -> None:
+        '''Validate threshold ordering invariants.'''
+
+        import math
+
+        for field_name in (
+            'latency_warn_ms', 'latency_breach_ms', 'latency_halt_ms',
+            'failure_rate_warn', 'failure_rate_breach', 'failure_rate_halt',
+            'headroom_warn', 'headroom_breach', 'headroom_halt',
+            'clock_drift_max_ms',
+        ):
+            val = getattr(self, field_name)
+            if not isinstance(val, (int, float)) or not math.isfinite(val) or val < 0:
+                msg = f'HealthThresholds.{field_name} must be a finite non-negative number'
+                raise ValueError(msg)
+
+        for field_name in ('failure_warn', 'failure_breach', 'failure_halt'):
+            val = getattr(self, field_name)
+            if not isinstance(val, int) or isinstance(val, bool) or val < 0:
+                msg = f'HealthThresholds.{field_name} must be a non-negative int'
+                raise ValueError(msg)
+
+        if not (self.latency_warn_ms <= self.latency_breach_ms <= self.latency_halt_ms):
+            msg = 'HealthThresholds: latency thresholds must be warn <= breach <= halt'
+            raise ValueError(msg)
+
+        if not (self.failure_warn <= self.failure_breach <= self.failure_halt):
+            msg = 'HealthThresholds: failure thresholds must be warn <= breach <= halt'
+            raise ValueError(msg)
+
+        if not (self.failure_rate_warn <= self.failure_rate_breach <= self.failure_rate_halt):
+            msg = 'HealthThresholds: failure_rate thresholds must be warn <= breach <= halt'
+            raise ValueError(msg)
+
+        if not (self.headroom_warn <= self.headroom_breach <= self.headroom_halt):
+            msg = 'HealthThresholds: headroom thresholds must be warn <= breach <= halt'
+            raise ValueError(msg)
+
 
 class HealthEvaluator:
     '''Evaluate health snapshot against thresholds to determine mode.

--- a/nexus/core/validator/intake_stage.py
+++ b/nexus/core/validator/intake_stage.py
@@ -170,8 +170,9 @@ def make_duplicate_order_hook(
 
         with lock:
             while expiry_deque and expiry_deque[0][0] <= cutoff:
-                _, stale_key = expiry_deque.popleft()
-                seen.pop(stale_key, None)
+                stale_ts, stale_key = expiry_deque.popleft()
+                if seen.get(stale_key) == stale_ts:
+                    del seen[stale_key]
 
             prior = seen.get(key)
             if prior is not None and (now - prior) < duplicate_window_seconds:

--- a/nexus/core/validator/intake_stage.py
+++ b/nexus/core/validator/intake_stage.py
@@ -136,6 +136,7 @@ def make_duplicate_order_hook(
     clock = now_fn or (lambda: datetime.now(tz=timezone.utc))
     duplicate_window_seconds = duplicate_window_ms / 1000
     seen: dict[tuple[str, ...], float] = {}
+    expiry_deque: deque[tuple[float, tuple[str, ...]]] = deque()
     lock = Lock()
 
     def hook(context: ValidationRequestContext) -> ValidationDecision | None:
@@ -168,8 +169,8 @@ def make_duplicate_order_hook(
         cutoff = now - duplicate_window_seconds
 
         with lock:
-            stale_keys = [k for k, ts in seen.items() if ts <= cutoff]
-            for stale_key in stale_keys:
+            while expiry_deque and expiry_deque[0][0] <= cutoff:
+                _, stale_key = expiry_deque.popleft()
                 seen.pop(stale_key, None)
 
             prior = seen.get(key)
@@ -185,6 +186,7 @@ def make_duplicate_order_hook(
                 )
 
             seen[key] = now
+            expiry_deque.append((now, key))
         return None
 
     return hook

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -370,8 +370,12 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
                 msg = f'Strategy {strategy_id!r} timer interval_seconds must be an int, got {timer_interval!r}'
                 raise ValueError(msg)
 
+            if not isinstance(timer_id, str):
+                msg = f'Strategy {strategy_id!r} timer id must be a string, got {timer_id!r}'
+                raise ValueError(msg)
+
             timer_specs.append(
-                TimerSpec(timer_id=str(timer_id), interval_seconds=timer_interval)
+                TimerSpec(timer_id=timer_id, interval_seconds=timer_interval)
             )
 
         raw_capital_pct = raw_spec.get('capital_pct')

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import yaml
 
-__all__ = ['Manifest', 'SensorSpec', 'StrategySpec', 'load_manifest']
+__all__ = ['Manifest', 'SensorSpec', 'StrategySpec', 'TimerSpec', 'load_manifest']
 
 _ZERO = Decimal('0')
 _ONE_HUNDRED = Decimal('100')
@@ -65,6 +65,34 @@ class SensorSpec:
 
 
 @dataclass(frozen=True)
+class TimerSpec:
+    '''Specification for a strategy timer.
+
+    Args:
+        timer_id: Unique identifier for this timer within the strategy.
+        interval_seconds: How often the timer fires in seconds.
+    '''
+
+    timer_id: str
+    interval_seconds: int
+
+    def __post_init__(self) -> None:
+        '''Validate timer specification invariants.'''
+
+        if not isinstance(self.timer_id, str) or not self.timer_id.strip():
+            msg = 'TimerSpec.timer_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if not isinstance(self.interval_seconds, int) or isinstance(self.interval_seconds, bool):
+            msg = 'TimerSpec.interval_seconds must be an int'
+            raise ValueError(msg)
+
+        if self.interval_seconds <= 0:
+            msg = f'TimerSpec.interval_seconds must be positive: {self.interval_seconds}'
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
 class StrategySpec:
     '''Immutable specification for a single strategy.
 
@@ -73,12 +101,14 @@ class StrategySpec:
         file: Relative path string to the Python strategy implementation.
         sensors: Sensor specifications for signal sources.
         capital_pct: Capital allocation percentage for this strategy.
+        timers: Optional timer specifications for on_timer callbacks.
     '''
 
     strategy_id: str
     file: str
     sensors: tuple[SensorSpec, ...]
     capital_pct: Decimal
+    timers: tuple[TimerSpec, ...] = ()
 
     def __post_init__(self) -> None:
         '''Validate strategy specification invariants.'''
@@ -114,6 +144,23 @@ class StrategySpec:
         if self.capital_pct <= _ZERO or self.capital_pct > _ONE_HUNDRED:
             msg = 'StrategySpec.capital_pct must be in (0, 100]'
             raise ValueError(msg)
+
+        if not isinstance(self.timers, tuple):
+            msg = 'StrategySpec.timers must be a tuple'
+            raise ValueError(msg)
+
+        seen_timer_ids: set[str] = set()
+
+        for t in self.timers:
+            if not isinstance(t, TimerSpec):
+                msg = 'StrategySpec.timers must contain TimerSpec instances'
+                raise ValueError(msg)
+
+            if t.timer_id in seen_timer_ids:
+                msg = f'StrategySpec.timers contains duplicate timer_id: {t.timer_id!r}'
+                raise ValueError(msg)
+
+            seen_timer_ids.add(t.timer_id)
 
 
 @dataclass(frozen=True)
@@ -293,6 +340,36 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
                 )
             )
 
+        timer_specs: list[TimerSpec] = []
+        raw_timers = raw_spec.get('timers', [])
+
+        if not isinstance(raw_timers, list):
+            msg = f'Strategy {strategy_id!r} timers must be a list'
+            raise ValueError(msg)
+
+        for raw_timer in raw_timers:
+            if not isinstance(raw_timer, dict):
+                msg = f'Strategy {strategy_id!r} timer entries must be mappings'
+                raise ValueError(msg)
+
+            timer_id = raw_timer.get('id')
+            if timer_id is None:
+                msg = f'Strategy {strategy_id!r} timer missing required field: id'
+                raise ValueError(msg)
+
+            timer_interval = raw_timer.get('interval_seconds')
+            if timer_interval is None:
+                msg = f'Strategy {strategy_id!r} timer missing required field: interval_seconds'
+                raise ValueError(msg)
+
+            if isinstance(timer_interval, bool) or not isinstance(timer_interval, int):
+                msg = f'Strategy {strategy_id!r} timer interval_seconds must be an int, got {timer_interval!r}'
+                raise ValueError(msg)
+
+            timer_specs.append(
+                TimerSpec(timer_id=str(timer_id), interval_seconds=timer_interval)
+            )
+
         raw_capital_pct = raw_spec.get('capital_pct')
         if raw_capital_pct is None:
             msg = f'Strategy {strategy_id!r} missing required field: capital_pct'
@@ -310,6 +387,7 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
                 file=file,
                 sensors=tuple(sensor_specs),
                 capital_pct=capital_pct,
+                timers=tuple(timer_specs),
             )
         )
 

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -79,8 +79,12 @@ class TimerSpec:
     def __post_init__(self) -> None:
         '''Validate timer specification invariants.'''
 
-        if not isinstance(self.timer_id, str) or not self.timer_id.strip():
-            msg = 'TimerSpec.timer_id must be a non-empty string'
+        if (
+            not isinstance(self.timer_id, str)
+            or not self.timer_id.strip()
+            or self.timer_id != self.timer_id.strip()
+        ):
+            msg = 'TimerSpec.timer_id must be a non-empty string without surrounding whitespace'
             raise ValueError(msg)
 
         if not isinstance(self.interval_seconds, int) or isinstance(self.interval_seconds, bool):

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -17,7 +17,7 @@ from nexus.core.health_evaluator import HealthEvaluator, HealthSnapshot
 from nexus.infrastructure.praxis_connector.praxis_outbound import PraxisOutbound
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
-from nexus.infrastructure.manifest import Manifest, load_manifest
+from nexus.infrastructure.manifest import Manifest, TimerSpec, load_manifest
 from nexus.infrastructure.state_store import StateStore
 from nexus.startup.error import StartupError
 from nexus.strategy.context import StrategyContext
@@ -124,10 +124,10 @@ class StartupSequencer:
         self._runner: StrategyRunner | None = None
         self._mode: OperationalMode | None = None
         self._wired_sensors: list[WiredSensor] = []
-        self._timer_specs: dict[str, tuple] = {}
+        self._timer_specs: dict[str, tuple[TimerSpec, ...]] = {}
 
     @property
-    def timer_specs(self) -> dict[str, tuple]:
+    def timer_specs(self) -> dict[str, tuple[TimerSpec, ...]]:
         '''Return registered timer specs by strategy_id.'''
 
         return dict(self._timer_specs)
@@ -456,7 +456,7 @@ class StartupSequencer:
         if self._manifest is None:
             raise StartupError('register_timers', 'manifest not loaded')
 
-        strategy_timers: dict[str, tuple] = {}
+        strategy_timers: dict[str, tuple[TimerSpec, ...]] = {}
 
         for spec in self._manifest.strategies:
             if spec.timers:

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -448,9 +448,8 @@ class StartupSequencer:
     def _register_timers(self) -> None:
         '''Register strategy timers from manifest.
 
-        Builds a TimerLoop from manifest timer specs and stores it
-        for later use. Does not start the loop — that happens after
-        startup completes.
+        Collects timer specs per strategy from the manifest. The caller
+        creates and starts a TimerLoop from the stored specs.
         '''
 
         if self._manifest is None:

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -119,6 +119,13 @@ class StartupSequencer:
         self._runner: StrategyRunner | None = None
         self._mode: OperationalMode | None = None
         self._wired_sensors: list[WiredSensor] = []
+        self._timer_specs: dict[str, tuple] = {}
+
+    @property
+    def timer_specs(self) -> dict[str, tuple]:
+        '''Return registered timer specs by strategy_id.'''
+
+        return dict(self._timer_specs)
 
     @property
     def wired_sensors(self) -> list[WiredSensor]:
@@ -434,13 +441,30 @@ class StartupSequencer:
                     )
 
     def _register_timers(self) -> None:
-        '''Register strategy timers.
+        '''Register strategy timers from manifest.
 
-        Stub: logs warning, does nothing. See TD-010.
-        Timer registration not implemented yet.
+        Builds a TimerLoop from manifest timer specs and stores it
+        for later use. Does not start the loop — that happens after
+        startup completes.
         '''
 
-        _log.warning('register_timers not implemented')
+        if self._manifest is None:
+            raise StartupError('register_timers', 'manifest not loaded')
+
+        strategy_timers: dict[str, tuple] = {}
+
+        for spec in self._manifest.strategies:
+            if spec.timers:
+                strategy_timers[spec.strategy_id] = spec.timers
+                for t in spec.timers:
+                    _log.info(
+                        'registered timer',
+                        strategy_id=spec.strategy_id,
+                        timer_id=t.timer_id,
+                        interval_seconds=t.interval_seconds,
+                    )
+
+        self._timer_specs = strategy_timers
 
     def _determine_mode(self) -> None:
         '''Determine operational mode based on health.

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -13,6 +13,7 @@ import structlog
 from limen.experiment.trainer.trainer import Trainer
 
 from nexus.core.domain.capital_state import CapitalState
+from nexus.core.health_evaluator import HealthEvaluator, HealthSnapshot
 from nexus.infrastructure.praxis_connector.praxis_outbound import PraxisOutbound
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
@@ -81,6 +82,8 @@ class StartupSequencer:
         strategy_state_path: Path | None = None,
         praxis_outbound: PraxisOutbound | None = None,
         account_id: str | None = None,
+        health_evaluator: HealthEvaluator | None = None,
+        health_snapshot: HealthSnapshot | None = None,
     ) -> None:
         if not isinstance(state_store, StateStore):
             msg = 'state_store must be a StateStore instance'
@@ -113,6 +116,8 @@ class StartupSequencer:
         self._strategy_state_path = strategy_state_path
         self._praxis_outbound = praxis_outbound
         self._account_id = account_id
+        self._health_evaluator = health_evaluator
+        self._health_snapshot = health_snapshot
 
         self._state: InstanceState | None = None
         self._manifest: Manifest | None = None
@@ -469,12 +474,17 @@ class StartupSequencer:
     def _determine_mode(self) -> None:
         '''Determine operational mode based on health.
 
-        Stub: always sets ACTIVE. See TD-011.
-        Health check not implemented yet.
+        Evaluates health snapshot against thresholds if a health_evaluator
+        and health_snapshot are configured. Defaults to ACTIVE when health
+        data is unavailable (no health signal source wired yet — TD-026).
         '''
 
-        _log.warning('determine_mode health check not implemented, defaulting to ACTIVE')
-        self._mode = OperationalMode.ACTIVE
+        if self._health_evaluator is not None and self._health_snapshot is not None:
+            self._mode = self._health_evaluator.evaluate(self._health_snapshot)
+            _log.info('mode determined from health', mode=self._mode.value)
+        else:
+            _log.warning('no health data available, defaulting to ACTIVE')
+            self._mode = OperationalMode.ACTIVE
 
     def _dispatch_startup(self) -> None:
         '''Dispatch on_startup to all strategies.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -19,6 +19,7 @@ from nexus.strategy.context import StrategyContext
 from nexus.strategy.params import StrategyParams
 from nexus.strategy.predict_loop import PredictLoop
 from nexus.strategy.runner import StrategyRunner
+from nexus.strategy.timer_loop import TimerLoop
 
 __all__ = ['ShutdownSequencer']
 
@@ -40,6 +41,7 @@ class ShutdownSequencer:
         state: Current instance state.
         strategy_state_path: Directory for strategy state blobs.
         predict_loop: Running PredictLoop to stop during shutdown.
+        timer_loop: Running TimerLoop to stop during shutdown.
         praxis_outbound: Outbound connector for deregistration.
         praxis_inbound: Inbound connector for outcome consumption.
         account_id: Account identifier for Praxis deregistration.
@@ -54,6 +56,7 @@ class ShutdownSequencer:
         state: InstanceState,
         strategy_state_path: Path,
         predict_loop: PredictLoop | None = None,
+        timer_loop: TimerLoop | None = None,
         praxis_outbound: PraxisOutbound | None = None,
         praxis_inbound: PraxisInbound | None = None,
         account_id: str | None = None,
@@ -85,6 +88,7 @@ class ShutdownSequencer:
         self._state = state
         self._strategy_state_path = strategy_state_path
         self._predict_loop = predict_loop
+        self._timer_loop = timer_loop
         self._praxis_outbound = praxis_outbound
         self._praxis_inbound = praxis_inbound
         self._account_id = account_id
@@ -130,10 +134,16 @@ class ShutdownSequencer:
     def _stop_timers(self) -> None:
         '''Cancel all registered strategy timers.
 
-        Stub: logs warning, does nothing. See TD-014.
+        Stops the TimerLoop, preventing further on_timer callbacks
+        during shutdown.
         '''
 
-        _log.warning('stop_timers not implemented')
+        if self._timer_loop is None:
+            _log.warning('timer_loop not configured, skipping timer stop')
+            return
+
+        self._timer_loop.stop()
+        _log.info('timer loop stopped')
 
     def _dispatch_shutdown(self) -> None:
         '''Dispatch on_shutdown to all strategies.

--- a/nexus/strategy/timer_loop.py
+++ b/nexus/strategy/timer_loop.py
@@ -1,0 +1,116 @@
+'''Timer loop for strategy on_timer callbacks.
+
+Runs per-strategy timers that dispatch on_timer events
+to the bound strategy via StrategyRunner.
+'''
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+
+from nexus.infrastructure.manifest import TimerSpec
+from nexus.strategy.context import StrategyContext
+from nexus.strategy.params import StrategyParams
+from nexus.strategy.runner import StrategyRunner
+
+__all__ = ['TimerLoop']
+
+_log = logging.getLogger(__name__)
+
+
+class TimerLoop:
+    '''Timer loop for strategy-authored timers.
+
+    Args:
+        runner: StrategyRunner for timer dispatch.
+        strategy_timers: Mapping of strategy_id to its TimerSpecs.
+        context_provider: Callable that returns current StrategyContext
+            for a given strategy_id.
+    '''
+
+    def __init__(
+        self,
+        runner: StrategyRunner,
+        strategy_timers: dict[str, tuple[TimerSpec, ...]],
+        context_provider: Callable[[str], StrategyContext],
+    ) -> None:
+        self._runner = runner
+        self._strategy_timers = dict(strategy_timers)
+        self._context_provider = context_provider
+        self._active_timers: dict[str, threading.Timer] = {}
+        self._running = False
+        self._lock = threading.Lock()
+
+    @property
+    def running(self) -> bool:
+        '''Whether the timer loop is currently running.'''
+
+        return self._running
+
+    def start(self) -> None:
+        '''Start all strategy timers.'''
+
+        with self._lock:
+            if self._running:
+                return
+
+            self._running = True
+
+            for strategy_id, timer_specs in self._strategy_timers.items():
+                for spec in timer_specs:
+                    self._schedule_locked(strategy_id, spec)
+
+    def stop(self) -> None:
+        '''Stop all strategy timers.'''
+
+        with self._lock:
+            self._running = False
+
+            for timer in self._active_timers.values():
+                timer.cancel()
+
+            self._active_timers.clear()
+
+    def _schedule_locked(self, strategy_id: str, spec: TimerSpec) -> None:
+        '''Schedule next timer fire. Must be called with lock held.'''
+
+        if not self._running:
+            return
+
+        timer = threading.Timer(
+            spec.interval_seconds,
+            self._tick,
+            args=(strategy_id, spec),
+        )
+        timer.daemon = True
+        timer_key = f'{strategy_id}:{spec.timer_id}'
+        self._active_timers[timer_key] = timer
+        timer.start()
+
+    def _tick(self, strategy_id: str, spec: TimerSpec) -> None:
+        with self._lock:
+            if not self._running:
+                return
+
+        try:
+            context = self._context_provider(strategy_id)
+
+            self._runner.dispatch_timer(
+                strategy_id,
+                spec.timer_id,
+                StrategyParams(raw={}),
+                context,
+            )
+        except Exception:  # noqa: BLE001 - intentional catch-all for timer callback
+            _log.exception(
+                'timer callback failed',
+                extra={
+                    'strategy_id': strategy_id,
+                    'timer_id': spec.timer_id,
+                },
+            )
+
+        with self._lock:
+            self._schedule_locked(strategy_id, spec)

--- a/nexus/strategy/timer_loop.py
+++ b/nexus/strategy/timer_loop.py
@@ -85,7 +85,7 @@ class TimerLoop:
             args=(strategy_id, spec),
         )
         timer.daemon = True
-        timer_key = f'{strategy_id}:{spec.timer_id}'
+        timer_key = f'{strategy_id}\0{spec.timer_id}'
         self._active_timers[timer_key] = timer
         timer.start()
 

--- a/nexus/strategy/timer_loop.py
+++ b/nexus/strategy/timer_loop.py
@@ -97,6 +97,10 @@ class TimerLoop:
         try:
             context = self._context_provider(strategy_id)
 
+            with self._lock:
+                if not self._running:
+                    return
+
             self._runner.dispatch_timer(
                 strategy_id,
                 spec.timer_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.25.0"
+version = "0.26.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import heapq
 import threading
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -342,6 +343,7 @@ class TestExpiredPurge:
             expires_at=past + timedelta(seconds=1),
         )
         ctrl._reservations['expired_001'] = expired_res
+        heapq.heappush(ctrl._expiry_heap, (expired_res.expires_at, 'expired_001'))
         ctrl._state.reservation_notional = Decimal('505')
         ctrl._state.per_strategy_deployed['strat_a'] = Decimal('505')
 
@@ -364,6 +366,7 @@ class TestExpiredPurge:
             expires_at=past + timedelta(seconds=30),
         )
         ctrl._reservations['expired_002'] = expired_res
+        heapq.heappush(ctrl._expiry_heap, (expired_res.expires_at, 'expired_002'))
         ctrl._state.reservation_notional = Decimal('202')
 
         with caplog.at_level('WARNING'):
@@ -391,6 +394,7 @@ class TestExpiredPurge:
                 expires_at=past + timedelta(seconds=30),
             )
             ctrl._reservations[f'expired_{i}'] = res
+            heapq.heappush(ctrl._expiry_heap, (res.expires_at, f'expired_{i}'))
         ctrl._state.reservation_notional = Decimal('303')
 
         with caplog.at_level('WARNING'):
@@ -470,6 +474,7 @@ class TestSendOrder:
             expires_at=past + timedelta(seconds=1),
         )
         ctrl._reservations['expired_001'] = expired
+        heapq.heappush(ctrl._expiry_heap, (expired.expires_at, 'expired_001'))
         ctrl._state.reservation_notional = Decimal('101')
 
         sent = ctrl.send_order('expired_001', 'ORD-001')

--- a/tests/test_health_evaluator.py
+++ b/tests/test_health_evaluator.py
@@ -1,0 +1,126 @@
+'''Tests for HealthEvaluator mode determination.'''
+
+from __future__ import annotations
+
+from nexus.core.domain.enums import OperationalMode
+from nexus.core.health_evaluator import (
+    HealthEvaluator,
+    HealthSnapshot,
+    HealthThresholds,
+)
+
+
+class TestHealthEvaluator:
+
+    def test_healthy_returns_active(self) -> None:
+        '''All metrics within thresholds returns ACTIVE.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot()
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.ACTIVE
+
+    def test_latency_breach_returns_reduce_only(self) -> None:
+        '''Latency at breach threshold returns REDUCE_ONLY.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot(latency_p99_ms=500.0)
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.REDUCE_ONLY
+
+    def test_latency_halt_returns_halted(self) -> None:
+        '''Latency at halt threshold returns HALTED.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot(latency_p99_ms=1000.0)
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.HALTED
+
+    def test_consecutive_failures_breach(self) -> None:
+        '''Consecutive failures at breach returns REDUCE_ONLY.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot(consecutive_failures=5)
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.REDUCE_ONLY
+
+    def test_consecutive_failures_halt(self) -> None:
+        '''Consecutive failures at halt returns HALTED.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot(consecutive_failures=10)
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.HALTED
+
+    def test_failure_rate_breach(self) -> None:
+        '''Failure rate at breach returns REDUCE_ONLY.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot(failure_rate=0.20)
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.REDUCE_ONLY
+
+    def test_failure_rate_halt(self) -> None:
+        '''Failure rate at halt returns HALTED.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot(failure_rate=0.40)
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.HALTED
+
+    def test_headroom_breach(self) -> None:
+        '''Rate limit headroom at breach returns REDUCE_ONLY.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot(rate_limit_headroom=0.85)
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.REDUCE_ONLY
+
+    def test_headroom_halt(self) -> None:
+        '''Rate limit headroom at halt returns HALTED.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot(rate_limit_headroom=0.90)
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.HALTED
+
+    def test_clock_drift_halt(self) -> None:
+        '''Clock drift at max returns HALTED.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot(clock_drift_ms=500.0)
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.HALTED
+
+    def test_halt_takes_precedence_over_breach(self) -> None:
+        '''When both breach and halt metrics are hit, HALTED wins.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot(
+            latency_p99_ms=600.0,
+            consecutive_failures=10,
+        )
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.HALTED
+
+    def test_custom_thresholds(self) -> None:
+        '''Custom thresholds override defaults.'''
+
+        thresholds = HealthThresholds(latency_breach_ms=100.0, latency_halt_ms=200.0)
+        evaluator = HealthEvaluator(thresholds)
+
+        assert evaluator.evaluate(HealthSnapshot(latency_p99_ms=150.0)) == OperationalMode.REDUCE_ONLY
+        assert evaluator.evaluate(HealthSnapshot(latency_p99_ms=200.0)) == OperationalMode.HALTED
+
+    def test_just_below_breach_is_active(self) -> None:
+        '''Metrics just below breach threshold remain ACTIVE.'''
+
+        evaluator = HealthEvaluator()
+        snapshot = HealthSnapshot(
+            latency_p99_ms=499.9,
+            consecutive_failures=4,
+            failure_rate=0.19,
+            rate_limit_headroom=0.84,
+        )
+
+        assert evaluator.evaluate(snapshot) == OperationalMode.ACTIVE

--- a/tests/test_health_evaluator.py
+++ b/tests/test_health_evaluator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.health_evaluator import (
     HealthEvaluator,
@@ -106,7 +108,7 @@ class TestHealthEvaluator:
     def test_custom_thresholds(self) -> None:
         '''Custom thresholds override defaults.'''
 
-        thresholds = HealthThresholds(latency_breach_ms=100.0, latency_halt_ms=200.0)
+        thresholds = HealthThresholds(latency_warn_ms=50.0, latency_breach_ms=100.0, latency_halt_ms=200.0)
         evaluator = HealthEvaluator(thresholds)
 
         assert evaluator.evaluate(HealthSnapshot(latency_p99_ms=150.0)) == OperationalMode.REDUCE_ONLY
@@ -124,3 +126,49 @@ class TestHealthEvaluator:
         )
 
         assert evaluator.evaluate(snapshot) == OperationalMode.ACTIVE
+
+
+class TestHealthSnapshotValidation:
+
+    def test_nan_latency_raises(self) -> None:
+        with pytest.raises(ValueError, match='finite non-negative'):
+            HealthSnapshot(latency_p99_ms=float('nan'))
+
+    def test_negative_failure_rate_raises(self) -> None:
+        with pytest.raises(ValueError, match='finite non-negative'):
+            HealthSnapshot(failure_rate=-0.1)
+
+    def test_failure_rate_over_one_raises(self) -> None:
+        with pytest.raises(ValueError, match=r'<= 1\.0'):
+            HealthSnapshot(failure_rate=1.5)
+
+    def test_headroom_over_one_raises(self) -> None:
+        with pytest.raises(ValueError, match=r'<= 1\.0'):
+            HealthSnapshot(rate_limit_headroom=1.1)
+
+    def test_bool_latency_raises(self) -> None:
+        with pytest.raises(ValueError, match='finite non-negative'):
+            HealthSnapshot(latency_p99_ms=True)  # type: ignore[arg-type]
+
+    def test_bool_consecutive_failures_raises(self) -> None:
+        with pytest.raises(ValueError, match='must be an int'):
+            HealthSnapshot(consecutive_failures=True)  # type: ignore[arg-type]
+
+    def test_negative_consecutive_failures_raises(self) -> None:
+        with pytest.raises(ValueError, match='non-negative'):
+            HealthSnapshot(consecutive_failures=-1)
+
+
+class TestHealthThresholdsValidation:
+
+    def test_inverted_latency_order_raises(self) -> None:
+        with pytest.raises(ValueError, match='warn <= breach <= halt'):
+            HealthThresholds(latency_warn_ms=500.0, latency_breach_ms=200.0)
+
+    def test_negative_threshold_raises(self) -> None:
+        with pytest.raises(ValueError, match='finite non-negative'):
+            HealthThresholds(latency_warn_ms=-1.0)
+
+    def test_bool_failure_threshold_raises(self) -> None:
+        with pytest.raises(ValueError, match='non-negative int'):
+            HealthThresholds(failure_warn=True)  # type: ignore[arg-type]

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -802,3 +802,32 @@ class TestLoadManifestTimers:
 
         with pytest.raises(ValueError, match='interval_seconds must be an int'):
             load_manifest(path, Decimal('20000'))
+
+    def test_duplicate_timer_id_raises(self, tmp_path: Path) -> None:
+        '''Duplicate timer_id raises ValueError.'''
+
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+        _write_strategy_file(tmp_path, 'strat.py')
+
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: strat1\n'
+            f'    file: strat.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n'
+            f'    timers:\n'
+            f'      - id: check\n'
+            f'        interval_seconds: 30\n'
+            f'      - id: check\n'
+            f'        interval_seconds: 60\n',
+        )
+
+        with pytest.raises(ValueError, match='duplicate timer_id'):
+            load_manifest(path, Decimal('20000'))

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -689,3 +689,116 @@ class TestLoadManifest:
 
         with pytest.raises(ValueError, match='file not found'):
             load_manifest(path, Decimal('20000'))
+
+
+class TestLoadManifestTimers:
+
+    def test_manifest_with_timers_loads(self, tmp_path: Path) -> None:
+        '''Manifest with valid timers parses correctly.'''
+
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+        _write_strategy_file(tmp_path, 'strat.py')
+
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: strat1\n'
+            f'    file: strat.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n'
+            f'    timers:\n'
+            f'      - id: trailing_stop\n'
+            f'        interval_seconds: 30\n'
+            f'      - id: position_review\n'
+            f'        interval_seconds: 300\n',
+        )
+
+        manifest = load_manifest(path, Decimal('20000'))
+
+        assert len(manifest.strategies[0].timers) == 2
+        assert manifest.strategies[0].timers[0].timer_id == 'trailing_stop'
+        assert manifest.strategies[0].timers[1].interval_seconds == 300
+
+    def test_manifest_without_timers_loads(self, tmp_path: Path) -> None:
+        '''Manifest without timers field defaults to empty tuple.'''
+
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+        _write_strategy_file(tmp_path, 'strat.py')
+
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: strat1\n'
+            f'    file: strat.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n',
+        )
+
+        manifest = load_manifest(path, Decimal('20000'))
+
+        assert manifest.strategies[0].timers == ()
+
+    def test_timer_missing_id_raises(self, tmp_path: Path) -> None:
+        '''Timer missing id raises ValueError.'''
+
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+        _write_strategy_file(tmp_path, 'strat.py')
+
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: strat1\n'
+            f'    file: strat.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n'
+            f'    timers:\n'
+            f'      - interval_seconds: 30\n',
+        )
+
+        with pytest.raises(ValueError, match='timer missing required field: id'):
+            load_manifest(path, Decimal('20000'))
+
+    def test_timer_bool_interval_raises(self, tmp_path: Path) -> None:
+        '''Timer with bool interval_seconds raises ValueError.'''
+
+        path = tmp_path / 'manifest.yaml'
+        exp_dir = tmp_path / 'experiment'
+        exp_dir.mkdir()
+        _write_strategy_file(tmp_path, 'strat.py')
+
+        _write_yaml(
+            path,
+            f'capital_pool: 10000\n'
+            f'strategies:\n'
+            f'  - id: strat1\n'
+            f'    file: strat.py\n'
+            f'    sensors:\n'
+            f'      - experiment: {exp_dir}\n'
+            f'        permutation_ids: [1]\n'
+            f'        interval_seconds: 60\n'
+            f'    capital_pct: 100\n'
+            f'    timers:\n'
+            f'      - id: check\n'
+            f'        interval_seconds: true\n',
+        )
+
+        with pytest.raises(ValueError, match='interval_seconds must be an int'):
+            load_manifest(path, Decimal('20000'))

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -446,3 +446,29 @@ class TestWaitTerminal:
         sequencer._wait_terminal()
 
         assert q.empty()
+
+
+class TestStopTimers:
+
+    def test_stop_timers_calls_timer_loop_stop(self) -> None:
+        '''_stop_timers calls timer_loop.stop().'''
+
+        mock_loop = MagicMock()
+        sequencer = ShutdownSequencer(
+            runner=_make_mock_runner(),
+            manifest=_make_manifest(),
+            state_store=_make_mock_state_store(),
+            state=_make_instance_state(),
+            strategy_state_path=_PLACEHOLDER_PATH,
+            timer_loop=mock_loop,
+        )
+
+        sequencer._stop_timers()
+
+        mock_loop.stop.assert_called_once()
+
+    def test_stop_timers_without_timer_loop(self) -> None:
+        '''_stop_timers completes without error when timer_loop is None.'''
+
+        sequencer = _make_sequencer()
+        sequencer._stop_timers()

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -317,10 +317,11 @@ class TestExternalIntegrationStubs:
         with pytest.raises(StartupError, match='manifest not loaded'):
             sequencer._wire_sensors()
 
-    def test_register_timers_does_not_raise(self) -> None:
+    def test_register_timers_without_manifest_raises(self) -> None:
         sequencer = _make_sequencer()
 
-        sequencer._register_timers()
+        with pytest.raises(StartupError, match='manifest not loaded'):
+            sequencer._register_timers()
 
     def test_determine_mode_sets_active(self) -> None:
         from nexus.core.domain.enums import OperationalMode

--- a/tests/test_timer_loop.py
+++ b/tests/test_timer_loop.py
@@ -1,0 +1,177 @@
+'''Tests for TimerLoop strategy timer dispatch.'''
+
+from __future__ import annotations
+
+import threading
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+from nexus.core.domain.enums import OperationalMode
+from nexus.infrastructure.manifest import TimerSpec
+from nexus.strategy.context import StrategyContext
+from nexus.strategy.runner import StrategyRunner
+from nexus.strategy.timer_loop import TimerLoop
+
+
+def _mock_context_provider(_strategy_id: str) -> StrategyContext:
+    return StrategyContext(
+        positions=(),
+        capital_available=Decimal('10000'),
+        operational_mode=OperationalMode.ACTIVE,
+    )
+
+
+class TestTimerLoop:
+
+    def test_start_and_stop(self) -> None:
+        '''TimerLoop starts and stops without error.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+        timers = {'strat_a': (TimerSpec(timer_id='check', interval_seconds=10),)}
+
+        loop = TimerLoop(
+            runner=runner,
+            strategy_timers=timers,
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        assert loop.running is True
+
+        loop.stop()
+        assert loop.running is False
+
+    def test_dispatches_timer(self) -> None:
+        '''TimerLoop dispatches on_timer to runner.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+        dispatched = threading.Event()
+
+        def track_dispatch(*_args: Any, **_kwargs: Any) -> list:
+            dispatched.set()
+            return []
+
+        runner.dispatch_timer.side_effect = track_dispatch
+        timers = {'strat_a': (TimerSpec(timer_id='check', interval_seconds=1),)}
+
+        loop = TimerLoop(
+            runner=runner,
+            strategy_timers=timers,
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        dispatched.wait(timeout=3)
+        loop.stop()
+
+        assert runner.dispatch_timer.called
+        call_args = runner.dispatch_timer.call_args
+        assert call_args[0][0] == 'strat_a'
+        assert call_args[0][1] == 'check'
+
+    def test_multiple_timers_for_strategy(self) -> None:
+        '''Multiple timers for one strategy all fire.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+        timer_ids_seen: list[str] = []
+        both_fired = threading.Event()
+
+        def track_dispatch(*args: Any, **_kwargs: Any) -> list:
+            timer_ids_seen.append(args[1])
+            if len(set(timer_ids_seen)) >= 2:
+                both_fired.set()
+            return []
+
+        runner.dispatch_timer.side_effect = track_dispatch
+
+        timers = {
+            'strat_a': (
+                TimerSpec(timer_id='fast', interval_seconds=1),
+                TimerSpec(timer_id='slow', interval_seconds=1),
+            ),
+        }
+
+        loop = TimerLoop(
+            runner=runner,
+            strategy_timers=timers,
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        both_fired.wait(timeout=3)
+        loop.stop()
+
+        assert 'fast' in timer_ids_seen
+        assert 'slow' in timer_ids_seen
+
+    def test_stop_prevents_dispatch(self) -> None:
+        '''After stop, no more timer events dispatched.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+        timers = {'strat_a': (TimerSpec(timer_id='check', interval_seconds=1),)}
+
+        loop = TimerLoop(
+            runner=runner,
+            strategy_timers=timers,
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        loop.stop()
+
+        runner.dispatch_timer.reset_mock()
+
+        import time
+        time.sleep(1.5)
+
+        assert not runner.dispatch_timer.called
+
+    def test_empty_timers_is_noop(self) -> None:
+        '''Empty strategy_timers starts and stops without error.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+
+        loop = TimerLoop(
+            runner=runner,
+            strategy_timers={},
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        assert loop.running is True
+
+        loop.stop()
+        assert loop.running is False
+        assert not runner.dispatch_timer.called
+
+    def test_error_in_callback_does_not_crash(self) -> None:
+        '''Exception in dispatch_timer is caught, loop continues.'''
+
+        runner = MagicMock(spec=StrategyRunner)
+        call_count = 0
+        second_call = threading.Event()
+
+        def failing_then_ok(*_args: Any, **_kwargs: Any) -> list:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                msg = 'strategy bug'
+                raise RuntimeError(msg)
+            second_call.set()
+            return []
+
+        runner.dispatch_timer.side_effect = failing_then_ok
+        timers = {'strat_a': (TimerSpec(timer_id='check', interval_seconds=1),)}
+
+        loop = TimerLoop(
+            runner=runner,
+            strategy_timers=timers,
+            context_provider=_mock_context_provider,
+        )
+
+        loop.start()
+        second_call.wait(timeout=4)
+        loop.stop()
+
+        assert call_count >= 2

--- a/tests/test_timer_spec.py
+++ b/tests/test_timer_spec.py
@@ -1,0 +1,56 @@
+'''Tests for TimerSpec dataclass validation.'''
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.infrastructure.manifest import TimerSpec
+
+
+class TestTimerSpec:
+
+    def test_valid_spec(self) -> None:
+        '''Valid TimerSpec creates successfully.'''
+
+        spec = TimerSpec(timer_id='trailing_stop', interval_seconds=30)
+
+        assert spec.timer_id == 'trailing_stop'
+        assert spec.interval_seconds == 30
+
+    def test_frozen(self) -> None:
+        '''TimerSpec is immutable.'''
+
+        spec = TimerSpec(timer_id='check', interval_seconds=60)
+
+        with pytest.raises(AttributeError):
+            spec.interval_seconds = 10  # type: ignore[misc]
+
+    def test_empty_timer_id_raises(self) -> None:
+        '''Empty timer_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='timer_id must be a non-empty string'):
+            TimerSpec(timer_id='', interval_seconds=60)
+
+    def test_whitespace_timer_id_raises(self) -> None:
+        '''Whitespace-only timer_id raises ValueError.'''
+
+        with pytest.raises(ValueError, match='timer_id must be a non-empty string'):
+            TimerSpec(timer_id='   ', interval_seconds=60)
+
+    def test_zero_interval_raises(self) -> None:
+        '''Zero interval_seconds raises ValueError.'''
+
+        with pytest.raises(ValueError, match='interval_seconds must be positive'):
+            TimerSpec(timer_id='check', interval_seconds=0)
+
+    def test_negative_interval_raises(self) -> None:
+        '''Negative interval_seconds raises ValueError.'''
+
+        with pytest.raises(ValueError, match='interval_seconds must be positive'):
+            TimerSpec(timer_id='check', interval_seconds=-1)
+
+    def test_bool_interval_raises(self) -> None:
+        '''Bool interval_seconds raises ValueError.'''
+
+        with pytest.raises(ValueError, match='interval_seconds must be an int'):
+            TimerSpec(timer_id='check', interval_seconds=True)  # type: ignore[arg-type]


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements all MMVP-X.2 pipeline non-blockers — timer system, health-based mode switching, and performance optimizations.

**Timer system (X.2.1):**
- Add `TimerSpec` frozen dataclass for strategy timer configuration (timer_id, interval_seconds)
- Add optional `timers` field to `StrategySpec` with duplicate timer_id rejection and whitespace validation
- Add `TimerLoop` class with per-strategy `threading.Timer` scheduling for `on_timer` callbacks (TD-010)
- Implement `_register_timers()` in `StartupSequencer` — extracts timer specs from manifest
- Implement `_stop_timers()` in `ShutdownSequencer` via `TimerLoop.stop()` (TD-014)

**Health-based mode switching (X.2.2):**
- Add `HealthEvaluator` with `HealthSnapshot` and `HealthThresholds` for three-threshold mode determination (warn → breach → halt)
- `HealthSnapshot` validates all fields at construction (finiteness, non-negative, bool rejection)
- Implement `_determine_mode()` in `StartupSequencer` — evaluates health snapshot, defaults to ACTIVE when no health data
- Health metrics: latency p99, consecutive failures, failure rate, rate limit headroom, clock drift

**Performance optimizations (X.2.3):**
- Replace O(N) dict scan in `_purge_expired` with `heapq`-based expiry tracking (TD-018)
- Replace O(N) dict scan in `make_duplicate_order_hook` with `collections.deque` chronological expiry (TD-018)
- Fix stale-key collision in deque sweep — only delete if timestamp matches
- `derive_rolling_losses` Decimal arithmetic already optimal; float rejected per RFC
- Incremental rolling loss updates already resolved by TD-002 (snapshot preserves losses)

**Deferred to technical debt:**
- TD-025: PredictLoop and TimerLoop thread churn (threading.Timer per tick)
- TD-026: Health snapshot has no live data source (depends on Praxis TD-016)

972 tests passing (up from 944). Bumps to v0.26.0.

## Checklist

- [ ] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (972 passing)
- [x] I updated `/docs` (TechnicalDebt.md updated with TD-025, TD-026, TD-018 resolution notes)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable