### PR TITLE
feat: TD-023 / TD-024 / TD-026 — strategy submission, position import, health consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,3 +284,20 @@
 - Replace O(N) dictionary scan in `make_duplicate_order_hook` with `collections.deque`-based chronological expiry (TD-018)
 - Add `docs/TechnicalDebt.md` entries TD-025 (thread churn) and TD-026 (health data source)
 - Add 28 tests across new modules (972 total)
+
+## v0.27.0 on 18th of April, 2026
+
+- Promote all inline imports across `nexus/` and `tests/` to top-of-file (`health_evaluator.py`, test files for `wal_codec`, `signal_producer`, `wire_sensors`, `instance_state`, `timer_loop`, `startup_sequencer`, `strategy_event_types`, `strategy_base`)
+- Add Action trade fields per RFC §Action Parameters in [`action.py`](nexus/strategy/action.py): `direction`, `size`, `execution_mode`, `order_type`, `execution_params`, `deadline`, `trade_id`, `command_id`, `maker_preference`, `reference_price`; per-action_type required-field validation in `__post_init__` via `_validate_action_type_requirements()` (TD-023.1)
+- Split Action reference fields per RFC-3001 Stage 1: EXIT requires `trade_id`; MODIFY/ABORT require `command_id` (was `trade_id`) (TD-023.2)
+- Mirror Praxis enums in [`order_types.py`](nexus/core/domain/order_types.py): `ExecutionMode`, `OrderType`, `MakerPreference`. Retype `Action.execution_mode/order_type/maker_preference` from free strings to these enums (TD-023.3)
+- Extend [`TradeCommand`](nexus/infrastructure/praxis_connector/trade_command.py) with `execution_mode`, `order_type`, `execution_params`, `deadline`, `maker_preference`, `reference_price`; AMEND/CANCEL invariants enforce these are absent. Update `translate_to_trade_command` to take an `Action` and populate these on NEW_ORDER (TD-023.3)
+- Wire real fields through [`PraxisOutbound.send_command`](nexus/infrastructure/praxis_connector/praxis_outbound.py): `order_type`, `execution_mode`, `execution_params`, `maker_preference`, `reference_price` flow from the TradeCommand instead of placeholder `None` values (TD-023.4)
+- Add `PraxisOutbound.send_abort` wrapping Praxis `Trading.submit_abort` via `asyncio.run_coroutine_threadsafe` (new `submit_abort_fn` parameter)
+- Wire [`ShutdownSequencer._submit_actions`](nexus/startup/shutdown_sequencer.py): EXIT actions translate through `translate_to_trade_command` and submit via `send_command`; ABORT actions submit via `send_abort` with reason `'shutdown'`; returned command_ids stored in `_submitted_command_ids`. Optional `config: InstanceConfig` parameter on `ShutdownSequencer` (TD-023.5)
+- Wire ABORT escalation in `_wait_terminal`: on first-round timeout, send ABORT for each pending command (reason `'shutdown_escalation'`) and re-poll with half the original `shutdown_timeout` before giving up. Refactor poll loop into `_poll_until_terminal` and abort fan-out into `_escalate_abort_pending` (TD-023.6)
+- Import Praxis-only positions during reconciliation: [`StartupSequencer._reconcile_capital`](nexus/startup/sequencer.py) now constructs a Nexus `Position` (strategy_id / symbol / side / size / entry_price) and inserts it into `instance_state.positions` when a Praxis position has no Nexus counterpart, provided required fields are present (TD-024)
+- Add `PraxisOutbound.get_health_snapshot(account_id)` wrapping Praxis `Trading.get_health_snapshot` via `asyncio.run_coroutine_threadsafe` (new `get_health_snapshot_fn` parameter) (TD-026.1)
+- Add [`health_loop.py`](nexus/core/health_loop.py) with `HealthLoop` — periodic timer pulls a `HealthSnapshot` from a configurable provider, evaluates via `HealthEvaluator`, and updates `instance_state.mode` on transition. Provider/evaluator exceptions are logged-and-swallowed; `start` is idempotent; `tick_once()` exposed for synchronous callers (TD-026.2)
+- Rename `_validate_required_fields` to `_validate_action_type_requirements` in `Action` (existing per-action_type checks; the rename reflects that field-shape validation already happened earlier in `__post_init__`)
+- Add 62 tests across new and updated modules (1034 total)

--- a/nexus/core/domain/order_types.py
+++ b/nexus/core/domain/order_types.py
@@ -1,0 +1,45 @@
+'''Order-related enums mirrored from the Trading sub-system.
+
+These enums mirror the Praxis domain contract so the Strategy layer can
+express typed intents without depending on the Trading sub-system package.
+String values must stay identical to the Trading sub-system definitions.
+'''
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = ['ExecutionMode', 'MakerPreference', 'OrderType']
+
+
+class ExecutionMode(Enum):
+    '''Execution mode for an order submission.'''
+
+    SINGLE_SHOT = 'SINGLE_SHOT'
+    BRACKET = 'BRACKET'
+    TWAP = 'TWAP'
+    SCHEDULED_VWAP = 'SCHEDULED_VWAP'
+    ICEBERG = 'ICEBERG'
+    TIME_DCA = 'TIME_DCA'
+    LADDER_DCA = 'LADDER_DCA'
+
+
+class OrderType(Enum):
+    '''Order type accepted by the venue adapter.'''
+
+    MARKET = 'MARKET'
+    LIMIT = 'LIMIT'
+    LIMIT_IOC = 'LIMIT_IOC'
+    STOP = 'STOP'
+    STOP_LIMIT = 'STOP_LIMIT'
+    TAKE_PROFIT = 'TAKE_PROFIT'
+    TP_LIMIT = 'TP_LIMIT'
+    OCO = 'OCO'
+
+
+class MakerPreference(Enum):
+    '''Maker/taker preference for order placement.'''
+
+    MAKER_ONLY = 'MAKER_ONLY'
+    MAKER_PREFERRED = 'MAKER_PREFERRED'
+    NO_PREFERENCE = 'NO_PREFERENCE'

--- a/nexus/core/health_evaluator.py
+++ b/nexus/core/health_evaluator.py
@@ -6,6 +6,7 @@ Evaluates health metrics against three-threshold policy
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 from nexus.core.domain.enums import OperationalMode
@@ -35,8 +36,6 @@ class HealthSnapshot:
 
     def __post_init__(self) -> None:
         '''Validate health metric invariants.'''
-
-        import math
 
         for field_name in ('latency_p99_ms', 'failure_rate', 'rate_limit_headroom', 'clock_drift_ms'):
             val = getattr(self, field_name)
@@ -95,8 +94,6 @@ class HealthThresholds:
 
     def __post_init__(self) -> None:
         '''Validate threshold ordering invariants.'''
-
-        import math
 
         for field_name in (
             'latency_warn_ms', 'latency_breach_ms', 'latency_halt_ms',

--- a/nexus/core/health_loop.py
+++ b/nexus/core/health_loop.py
@@ -1,0 +1,130 @@
+'''Periodic health re-evaluation loop.
+
+Pulls a HealthSnapshot via the configured source on each tick, evaluates
+it through HealthEvaluator, and updates instance_state.mode on transition.
+'''
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+from datetime import datetime, timezone
+
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.health_evaluator import HealthEvaluator, HealthSnapshot
+
+__all__ = ['HealthLoop']
+
+_log = logging.getLogger(__name__)
+_HEALTH_TRIGGER = 'health'
+
+
+class HealthLoop:
+    '''Periodically pull a HealthSnapshot and update operational mode.
+
+    Args:
+        snapshot_provider: Callable returning a HealthSnapshot. Invoked once
+            per tick from a daemon timer thread.
+        evaluator: HealthEvaluator that maps snapshot to OperationalMode.
+        state: InstanceState whose mode is mutated on transition.
+        interval_seconds: Seconds between ticks. Must be positive.
+    '''
+
+    def __init__(
+        self,
+        snapshot_provider: Callable[[], HealthSnapshot],
+        evaluator: HealthEvaluator,
+        state: InstanceState,
+        interval_seconds: float = 5.0,
+    ) -> None:
+        if (
+            isinstance(interval_seconds, bool)
+            or not isinstance(interval_seconds, (int, float))
+            or interval_seconds <= 0
+        ):
+            msg = 'HealthLoop.interval_seconds must be a positive number'
+            raise ValueError(msg)
+
+        self._snapshot_provider = snapshot_provider
+        self._evaluator = evaluator
+        self._state = state
+        self._interval_seconds = float(interval_seconds)
+        self._timer: threading.Timer | None = None
+        self._running = False
+        self._lock = threading.Lock()
+
+    @property
+    def running(self) -> bool:
+        '''Whether the loop is currently scheduling ticks.'''
+
+        return self._running
+
+    def start(self) -> None:
+        '''Start the periodic re-evaluation loop.'''
+
+        with self._lock:
+            if self._running:
+                return
+            self._running = True
+            self._schedule_locked()
+
+    def stop(self) -> None:
+        '''Stop the loop and cancel any pending tick.'''
+
+        with self._lock:
+            self._running = False
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+
+    def tick_once(self) -> None:
+        '''Pull a snapshot and apply it without scheduling another tick.
+
+        Useful for tests and for immediate-sync paths where the caller
+        controls the cadence.
+        '''
+
+        self._apply_snapshot()
+
+    def _schedule_locked(self) -> None:
+        if not self._running:
+            return
+        self._timer = threading.Timer(self._interval_seconds, self._tick)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def _tick(self) -> None:
+        with self._lock:
+            if not self._running:
+                return
+
+        self._apply_snapshot()
+
+        with self._lock:
+            self._schedule_locked()
+
+    def _apply_snapshot(self) -> None:
+        try:
+            snapshot = self._snapshot_provider()
+        except Exception:  # noqa: BLE001 - intentional catch-all for provider
+            _log.exception('health snapshot fetch failed')
+            return
+
+        try:
+            new_mode = self._evaluator.evaluate(snapshot)
+        except Exception:  # noqa: BLE001 - intentional catch-all for evaluator
+            _log.exception('health evaluation failed')
+            return
+
+        current_mode = self._state.mode.mode
+        if new_mode == current_mode:
+            return
+
+        self._state.mode.mode = new_mode
+        self._state.mode.trigger = _HEALTH_TRIGGER
+        self._state.mode.transitioned_at = datetime.now(tz=timezone.utc)
+        _log.info(
+            'operational mode transition (health)',
+            extra={'from': current_mode.value, 'to': new_mode.value},
+        )

--- a/nexus/core/health_loop.py
+++ b/nexus/core/health_loop.py
@@ -2,6 +2,11 @@
 
 Pulls a HealthSnapshot via the configured source on each tick, evaluates
 it through HealthEvaluator, and updates instance_state.mode on transition.
+
+Note on `rate_limit_headroom` semantics: the field carries utilisation
+semantics (higher is worse) for parity with the Praxis-side HealthSnapshot.
+The misnomer is intentional and predates this loop; HealthEvaluator
+already evaluates it as higher-is-worse.
 '''
 
 from __future__ import annotations
@@ -12,6 +17,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.operational_mode import ModeState
 from nexus.core.health_evaluator import HealthEvaluator, HealthSnapshot
 
 __all__ = ['HealthLoop']
@@ -121,9 +127,11 @@ class HealthLoop:
         if new_mode == current_mode:
             return
 
-        self._state.mode.mode = new_mode
-        self._state.mode.trigger = _HEALTH_TRIGGER
-        self._state.mode.transitioned_at = datetime.now(tz=timezone.utc)
+        self._state.mode = ModeState(
+            mode=new_mode,
+            trigger=_HEALTH_TRIGGER,
+            transitioned_at=datetime.now(tz=timezone.utc),
+        )
         _log.info(
             'operational mode transition (health)',
             extra={'from': current_mode.value, 'to': new_mode.value},

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -63,8 +63,6 @@ class PraxisOutbound:
             Exception: Propagates the original exception raised by submit_fn.
         '''
 
-        # NOTE: execution_mode and execution_params require Action fields (TD-023).
-        # Placeholder values used until full Action → TradeCommand translation is built.
         future: concurrent.futures.Future[str] = asyncio.run_coroutine_threadsafe(
             self._submit_fn(
                 trade_id=command.trade_id or command.command_id,
@@ -72,12 +70,12 @@ class PraxisOutbound:
                 symbol=command.symbol,
                 side=command.side,
                 qty=command.size,
-                order_type=command.command_type,
-                execution_mode=None,
-                execution_params=None,
+                order_type=command.order_type,
+                execution_mode=command.execution_mode,
+                execution_params=command.execution_params,
                 timeout=max(1, round(self._timeout)),
-                reference_price=None,
-                maker_preference=None,
+                reference_price=command.reference_price,
+                maker_preference=command.maker_preference,
                 stp_mode=command.stp_mode,
                 created_at=command.created_at,
             ),

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -10,6 +10,7 @@ import asyncio
 import concurrent.futures
 import logging
 from collections.abc import Callable, Coroutine
+from datetime import datetime
 from typing import Any
 
 from nexus.infrastructure.praxis_connector.trade_command import TradeCommand
@@ -29,6 +30,7 @@ class PraxisOutbound:
         register_fn: Sync callable matching Praxis Trading.register_account.
         unregister_fn: Async callable matching Praxis Trading.unregister_account.
         pull_positions_fn: Sync callable matching Praxis Trading.pull_positions.
+        submit_abort_fn: Async callable wrapping Praxis Trading.submit_abort.
         loop: Asyncio event loop running in the Praxis thread.
         timeout: Seconds to wait for async calls to complete.
     '''
@@ -40,6 +42,7 @@ class PraxisOutbound:
         register_fn: Callable[[str], None] | None = None,
         unregister_fn: Callable[[str], Coroutine[Any, Any, None]] | None = None,
         pull_positions_fn: Callable[[str], dict[tuple[str, str], Any]] | None = None,
+        submit_abort_fn: Callable[..., Coroutine[Any, Any, None]] | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
     ) -> None:
         self._submit_fn = submit_fn
@@ -47,6 +50,7 @@ class PraxisOutbound:
         self._register_fn = register_fn
         self._unregister_fn = unregister_fn
         self._pull_positions_fn = pull_positions_fn
+        self._submit_abort_fn = submit_abort_fn
         self._timeout = timeout
 
     def send_command(self, command: TradeCommand) -> str:
@@ -101,6 +105,51 @@ class PraxisOutbound:
         )
 
         return str(command_id)
+
+    def send_abort(
+        self,
+        *,
+        command_id: str,
+        account_id: str,
+        reason: str,
+        created_at: datetime,
+    ) -> None:
+        '''Submit trade abort to Praxis via async bridge.
+
+        Args:
+            command_id: Command to abort.
+            account_id: Owning account for the command.
+            reason: Reason for the abort (e.g. 'shutdown').
+            created_at: Abort creation timestamp (UTC, timezone-aware).
+
+        Raises:
+            RuntimeError: If submit_abort_fn is not configured.
+            TimeoutError: If Praxis does not respond within timeout.
+            Exception: Propagates the original exception raised by submit_abort_fn.
+        '''
+
+        if self._submit_abort_fn is None:
+            msg = 'submit_abort_fn not configured'
+            raise RuntimeError(msg)
+
+        future: concurrent.futures.Future[None] = asyncio.run_coroutine_threadsafe(
+            self._submit_abort_fn(
+                command_id=command_id,
+                account_id=account_id,
+                reason=reason,
+                created_at=created_at,
+            ),
+            self._loop,
+        )
+
+        try:
+            future.result(timeout=self._timeout)
+        except (TimeoutError, concurrent.futures.TimeoutError):
+            future.cancel()
+            _log.error('submit_abort timed out: command_id=%s', command_id)
+            raise
+
+        _log.info('abort submitted', extra={'command_id': command_id, 'reason': reason})
 
     def register_account(self, account_id: str) -> None:
         '''Register account with Praxis Trading.

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -205,6 +205,11 @@ class PraxisOutbound:
     def get_health_snapshot(self, account_id: str) -> HealthSnapshot:
         '''Pull a HealthSnapshot from Praxis via async bridge.
 
+        Unlike send_command and send_abort, this does not require the
+        account to be ready: Praxis intentionally serves a default zeroed
+        snapshot for unknown accounts so a Manager can poll across the
+        whole lifecycle.
+
         Args:
             account_id: Account whose snapshot is requested.
 

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -10,7 +10,7 @@ import asyncio
 import concurrent.futures
 import logging
 from collections.abc import Callable, Coroutine
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from nexus.core.health_evaluator import HealthSnapshot
@@ -71,6 +71,11 @@ class PraxisOutbound:
             Exception: Propagates the original exception raised by submit_fn.
         '''
 
+        order_timeout = (
+            command.deadline
+            if command.deadline is not None
+            else max(1, round(self._timeout))
+        )
         future: concurrent.futures.Future[str] = asyncio.run_coroutine_threadsafe(
             self._submit_fn(
                 trade_id=command.trade_id or command.command_id,
@@ -81,7 +86,7 @@ class PraxisOutbound:
                 order_type=command.order_type,
                 execution_mode=command.execution_mode,
                 execution_params=command.execution_params,
-                timeout=max(1, round(self._timeout)),
+                timeout=order_timeout,
                 reference_price=command.reference_price,
                 maker_preference=command.maker_preference,
                 stp_mode=command.stp_mode,
@@ -135,6 +140,10 @@ class PraxisOutbound:
         if self._submit_abort_fn is None:
             msg = 'submit_abort_fn not configured'
             raise RuntimeError(msg)
+
+        if created_at.tzinfo is None or created_at.utcoffset() != timezone.utc.utcoffset(None):
+            msg = 'send_abort.created_at must be timezone-aware UTC'
+            raise ValueError(msg)
 
         future: concurrent.futures.Future[None] = asyncio.run_coroutine_threadsafe(
             self._submit_abort_fn(

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -13,6 +13,7 @@ from collections.abc import Callable, Coroutine
 from datetime import datetime
 from typing import Any
 
+from nexus.core.health_evaluator import HealthSnapshot
 from nexus.infrastructure.praxis_connector.trade_command import TradeCommand
 
 __all__ = ['PraxisOutbound']
@@ -31,6 +32,7 @@ class PraxisOutbound:
         unregister_fn: Async callable matching Praxis Trading.unregister_account.
         pull_positions_fn: Sync callable matching Praxis Trading.pull_positions.
         submit_abort_fn: Async callable wrapping Praxis Trading.submit_abort.
+        get_health_snapshot_fn: Async callable wrapping Praxis Trading.get_health_snapshot.
         loop: Asyncio event loop running in the Praxis thread.
         timeout: Seconds to wait for async calls to complete.
     '''
@@ -43,6 +45,7 @@ class PraxisOutbound:
         unregister_fn: Callable[[str], Coroutine[Any, Any, None]] | None = None,
         pull_positions_fn: Callable[[str], dict[tuple[str, str], Any]] | None = None,
         submit_abort_fn: Callable[..., Coroutine[Any, Any, None]] | None = None,
+        get_health_snapshot_fn: Callable[[str], Coroutine[Any, Any, HealthSnapshot]] | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
     ) -> None:
         self._submit_fn = submit_fn
@@ -51,6 +54,7 @@ class PraxisOutbound:
         self._unregister_fn = unregister_fn
         self._pull_positions_fn = pull_positions_fn
         self._submit_abort_fn = submit_abort_fn
+        self._get_health_snapshot_fn = get_health_snapshot_fn
         self._timeout = timeout
 
     def send_command(self, command: TradeCommand) -> str:
@@ -197,6 +201,40 @@ class PraxisOutbound:
             raise
 
         _log.info('account deregistered', extra={'account_id': account_id})
+
+    def get_health_snapshot(self, account_id: str) -> HealthSnapshot:
+        '''Pull a HealthSnapshot from Praxis via async bridge.
+
+        Args:
+            account_id: Account whose snapshot is requested.
+
+        Returns:
+            HealthSnapshot composed by the Trading sub-system. Returns
+            default-valued snapshot when Praxis has no samples yet.
+
+        Raises:
+            RuntimeError: If get_health_snapshot_fn is not configured.
+            TimeoutError: If Praxis does not respond within timeout.
+            Exception: Propagates the original exception raised by the fn.
+        '''
+
+        if self._get_health_snapshot_fn is None:
+            msg = 'get_health_snapshot_fn not configured'
+            raise RuntimeError(msg)
+
+        future: concurrent.futures.Future[HealthSnapshot] = (
+            asyncio.run_coroutine_threadsafe(
+                self._get_health_snapshot_fn(account_id),
+                self._loop,
+            )
+        )
+
+        try:
+            return future.result(timeout=self._timeout)
+        except (TimeoutError, concurrent.futures.TimeoutError):
+            future.cancel()
+            _log.error('get_health_snapshot timed out: account_id=%s', account_id)
+            raise
 
     def pull_positions(self, account_id: str) -> dict[tuple[str, str], Any]:
         '''Pull positions snapshot from Praxis Trading.

--- a/nexus/infrastructure/praxis_connector/trade_command.py
+++ b/nexus/infrastructure/praxis_connector/trade_command.py
@@ -33,12 +33,19 @@ class TradeCommand:
         stp_mode: Self-trade prevention; required for NEW_ORDER, None otherwise.
         trade_id: Position reference for EXIT actions.
         reservation_id: Capital lock reference for ENTER and size-increasing MODIFY.
-        execution_mode: How to execute; required for NEW_ORDER, None otherwise.
-        order_type: Order type; required for NEW_ORDER, None otherwise.
-        execution_params: Mode-specific parameters; only meaningful for NEW_ORDER.
-        deadline: Timeout in seconds; required for NEW_ORDER, None otherwise.
-        maker_preference: Maker/taker preference; only meaningful for NEW_ORDER.
-        reference_price: Strategy reference price; only meaningful for NEW_ORDER.
+        execution_mode: How to execute; populated for NEW_ORDER from Action.execution_mode,
+            None for AMEND/CANCEL. May be None on a NEW_ORDER built from an EXIT Action,
+            which currently does not carry execution_mode.
+        order_type: Order type; populated for NEW_ORDER from Action.order_type, None for
+            AMEND/CANCEL. May be None on a NEW_ORDER built from an EXIT Action.
+        execution_params: Mode-specific parameters; populated for NEW_ORDER from
+            Action.execution_params, None for AMEND/CANCEL.
+        deadline: Timeout in seconds; populated for NEW_ORDER from Action.deadline, None
+            for AMEND/CANCEL. May be None on a NEW_ORDER built from an EXIT Action.
+        maker_preference: Maker/taker preference; populated for NEW_ORDER from
+            Action.maker_preference, None for AMEND/CANCEL.
+        reference_price: Strategy reference price; populated for NEW_ORDER from
+            Action.reference_price, None for AMEND/CANCEL.
     '''
 
     command_id: str

--- a/nexus/infrastructure/praxis_connector/trade_command.py
+++ b/nexus/infrastructure/praxis_connector/trade_command.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
+from types import MappingProxyType
 
 from nexus.core.domain.enums import OrderSide
 from nexus.core.domain.order_types import ExecutionMode, MakerPreference, OrderType
@@ -33,15 +35,18 @@ class TradeCommand:
         stp_mode: Self-trade prevention; required for NEW_ORDER, None otherwise.
         trade_id: Position reference for EXIT actions.
         reservation_id: Capital lock reference for ENTER and size-increasing MODIFY.
-        execution_mode: How to execute; populated for NEW_ORDER from Action.execution_mode,
-            None for AMEND/CANCEL. May be None on a NEW_ORDER built from an EXIT Action,
-            which currently does not carry execution_mode.
-        order_type: Order type; populated for NEW_ORDER from Action.order_type, None for
-            AMEND/CANCEL. May be None on a NEW_ORDER built from an EXIT Action.
+        execution_mode: How to execute; populated for NEW_ORDER from
+            Action.execution_mode when provided. For EXIT actions, the Action may
+            omit this value and translation fills a safe default before submission.
+            None for AMEND/CANCEL.
+        order_type: Order type; populated for NEW_ORDER from Action.order_type when
+            provided. For EXIT actions, the Action may omit this value and
+            translation fills a safe default before submission. None for AMEND/CANCEL.
         execution_params: Mode-specific parameters; populated for NEW_ORDER from
             Action.execution_params, None for AMEND/CANCEL.
-        deadline: Timeout in seconds; populated for NEW_ORDER from Action.deadline, None
-            for AMEND/CANCEL. May be None on a NEW_ORDER built from an EXIT Action.
+        deadline: Timeout in seconds; populated for NEW_ORDER from Action.deadline
+            when provided. For EXIT actions, the Action may omit this value and
+            translation fills a safe default before submission. None for AMEND/CANCEL.
         maker_preference: Maker/taker preference; populated for NEW_ORDER from
             Action.maker_preference, None for AMEND/CANCEL.
         reference_price: Strategy reference price; populated for NEW_ORDER from
@@ -62,7 +67,7 @@ class TradeCommand:
     reservation_id: str | None = None
     execution_mode: ExecutionMode | None = None
     order_type: OrderType | None = None
-    execution_params: dict[str, object] | None = None
+    execution_params: Mapping[str, object] | None = None
     deadline: int | None = None
     maker_preference: MakerPreference | None = None
     reference_price: Decimal | None = None
@@ -144,11 +149,15 @@ class TradeCommand:
             msg = 'TradeCommand.order_type must be an OrderType member or None'
             raise ValueError(msg)
 
-        if self.execution_params is not None and not isinstance(
-            self.execution_params, dict
-        ):
-            msg = 'TradeCommand.execution_params must be a dict or None'
-            raise ValueError(msg)
+        if self.execution_params is not None:
+            if not isinstance(self.execution_params, Mapping):
+                msg = 'TradeCommand.execution_params must be a Mapping or None'
+                raise ValueError(msg)
+            object.__setattr__(
+                self,
+                'execution_params',
+                MappingProxyType(dict(self.execution_params)),
+            )
 
         if self.deadline is not None and (
             isinstance(self.deadline, bool)

--- a/nexus/infrastructure/praxis_connector/trade_command.py
+++ b/nexus/infrastructure/praxis_connector/trade_command.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 
 from nexus.core.domain.enums import OrderSide
+from nexus.core.domain.order_types import ExecutionMode, MakerPreference, OrderType
 from nexus.core.stp_mode import STPMode
 from nexus.infrastructure.praxis_connector.trade_command_type import TradeCommandType
 
@@ -32,6 +33,12 @@ class TradeCommand:
         stp_mode: Self-trade prevention; required for NEW_ORDER, None otherwise.
         trade_id: Position reference for EXIT actions.
         reservation_id: Capital lock reference for ENTER and size-increasing MODIFY.
+        execution_mode: How to execute; required for NEW_ORDER, None otherwise.
+        order_type: Order type; required for NEW_ORDER, None otherwise.
+        execution_params: Mode-specific parameters; only meaningful for NEW_ORDER.
+        deadline: Timeout in seconds; required for NEW_ORDER, None otherwise.
+        maker_preference: Maker/taker preference; only meaningful for NEW_ORDER.
+        reference_price: Strategy reference price; only meaningful for NEW_ORDER.
     '''
 
     command_id: str
@@ -46,6 +53,12 @@ class TradeCommand:
     stp_mode: STPMode | None = None
     trade_id: str | None = None
     reservation_id: str | None = None
+    execution_mode: ExecutionMode | None = None
+    order_type: OrderType | None = None
+    execution_params: dict[str, object] | None = None
+    deadline: int | None = None
+    maker_preference: MakerPreference | None = None
+    reference_price: Decimal | None = None
 
     def __post_init__(self) -> None:
         '''Validate command invariants at construction time.'''
@@ -114,6 +127,44 @@ class TradeCommand:
             msg = 'TradeCommand.reservation_id must be a non-empty string or None'
             raise ValueError(msg)
 
+        if self.execution_mode is not None and not isinstance(
+            self.execution_mode, ExecutionMode
+        ):
+            msg = 'TradeCommand.execution_mode must be an ExecutionMode member or None'
+            raise ValueError(msg)
+
+        if self.order_type is not None and not isinstance(self.order_type, OrderType):
+            msg = 'TradeCommand.order_type must be an OrderType member or None'
+            raise ValueError(msg)
+
+        if self.execution_params is not None and not isinstance(
+            self.execution_params, dict
+        ):
+            msg = 'TradeCommand.execution_params must be a dict or None'
+            raise ValueError(msg)
+
+        if self.deadline is not None and (
+            isinstance(self.deadline, bool)
+            or not isinstance(self.deadline, int)
+            or self.deadline <= 0
+        ):
+            msg = 'TradeCommand.deadline must be a positive int or None'
+            raise ValueError(msg)
+
+        if self.maker_preference is not None and not isinstance(
+            self.maker_preference, MakerPreference
+        ):
+            msg = 'TradeCommand.maker_preference must be a MakerPreference member or None'
+            raise ValueError(msg)
+
+        if self.reference_price is not None and (
+            not isinstance(self.reference_price, Decimal)
+            or not self.reference_price.is_finite()
+            or self.reference_price <= _ZERO
+        ):
+            msg = 'TradeCommand.reference_price must be a finite positive Decimal or None'
+            raise ValueError(msg)
+
         self._validate_command_type_invariants()
 
     def _validate_command_type_invariants(self) -> None:
@@ -140,6 +191,24 @@ class TradeCommand:
             if self.stp_mode is not None:
                 msg = 'TradeCommand: AMEND_ORDER must not have stp_mode'
                 raise ValueError(msg)
+            if self.execution_mode is not None:
+                msg = 'TradeCommand: AMEND_ORDER must not have execution_mode'
+                raise ValueError(msg)
+            if self.order_type is not None:
+                msg = 'TradeCommand: AMEND_ORDER must not have order_type'
+                raise ValueError(msg)
+            if self.execution_params is not None:
+                msg = 'TradeCommand: AMEND_ORDER must not have execution_params'
+                raise ValueError(msg)
+            if self.deadline is not None:
+                msg = 'TradeCommand: AMEND_ORDER must not have deadline'
+                raise ValueError(msg)
+            if self.maker_preference is not None:
+                msg = 'TradeCommand: AMEND_ORDER must not have maker_preference'
+                raise ValueError(msg)
+            if self.reference_price is not None:
+                msg = 'TradeCommand: AMEND_ORDER must not have reference_price'
+                raise ValueError(msg)
 
         elif self.command_type == TradeCommandType.CANCEL_ORDER:
             if self.side is not None:
@@ -150,4 +219,22 @@ class TradeCommand:
                 raise ValueError(msg)
             if self.stp_mode is not None:
                 msg = 'TradeCommand: CANCEL_ORDER must not have stp_mode'
+                raise ValueError(msg)
+            if self.execution_mode is not None:
+                msg = 'TradeCommand: CANCEL_ORDER must not have execution_mode'
+                raise ValueError(msg)
+            if self.order_type is not None:
+                msg = 'TradeCommand: CANCEL_ORDER must not have order_type'
+                raise ValueError(msg)
+            if self.execution_params is not None:
+                msg = 'TradeCommand: CANCEL_ORDER must not have execution_params'
+                raise ValueError(msg)
+            if self.deadline is not None:
+                msg = 'TradeCommand: CANCEL_ORDER must not have deadline'
+                raise ValueError(msg)
+            if self.maker_preference is not None:
+                msg = 'TradeCommand: CANCEL_ORDER must not have maker_preference'
+                raise ValueError(msg)
+            if self.reference_price is not None:
+                msg = 'TradeCommand: CANCEL_ORDER must not have reference_price'
                 raise ValueError(msg)

--- a/nexus/infrastructure/praxis_connector/translate.py
+++ b/nexus/infrastructure/praxis_connector/translate.py
@@ -12,6 +12,7 @@ from nexus.core.validator.pipeline_models import (
 from nexus.infrastructure.praxis_connector.trade_command import TradeCommand
 from nexus.infrastructure.praxis_connector.trade_command_type import TradeCommandType
 from nexus.instance_config import InstanceConfig
+from nexus.strategy.action import Action
 
 __all__ = ['translate_to_trade_command']
 
@@ -25,6 +26,7 @@ _ACTION_TO_COMMAND_TYPE: dict[ValidationAction, TradeCommandType] = {
 
 
 def translate_to_trade_command(
+    action: Action,
     context: ValidationRequestContext,
     decision: ValidationDecision,
     config: InstanceConfig,
@@ -33,6 +35,9 @@ def translate_to_trade_command(
     '''Translate validated action to TradeCommand for Trading sub-system.
 
     Args:
+        action: Strategy-layer action being translated. Execution-mode,
+            order-type, maker-preference, deadline, execution-params, and
+            reference-price flow from this source.
         context: Validated action request context.
         decision: Validation pipeline decision (must be allowed).
         config: Instance configuration for account/venue/stp_mode.
@@ -78,4 +83,10 @@ def translate_to_trade_command(
         stp_mode=config.stp_mode if is_new_order else None,
         trade_id=context.trade_id,
         reservation_id=reservation_id,
+        execution_mode=action.execution_mode if is_new_order else None,
+        order_type=action.order_type if is_new_order else None,
+        execution_params=action.execution_params if is_new_order else None,
+        deadline=action.deadline if is_new_order else None,
+        maker_preference=action.maker_preference if is_new_order else None,
+        reference_price=action.reference_price if is_new_order else None,
     )

--- a/nexus/infrastructure/praxis_connector/translate.py
+++ b/nexus/infrastructure/praxis_connector/translate.py
@@ -42,9 +42,9 @@ def translate_to_trade_command(
     Args:
         action: Strategy-layer action being translated. Execution-mode,
             order-type, maker-preference, deadline, execution-params, and
-            reference-price flow from this source for ENTER. For EXIT
-            (which carries only trade_id + size per TD-023.1), the
-            translate layer fills `execution_mode=SINGLE_SHOT`,
+            reference-price flow from this source for ENTER. For EXIT,
+            the translate layer honors any provided execution fields and
+            fills missing values with `execution_mode=SINGLE_SHOT`,
             `order_type=MARKET`, and `deadline=60s` so submission to
             Praxis cannot pass `None` to required parameters.
         context: Validated action request context.

--- a/nexus/infrastructure/praxis_connector/translate.py
+++ b/nexus/infrastructure/praxis_connector/translate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from nexus.core.domain.order_types import ExecutionMode, OrderType
 from nexus.core.validator.pipeline_models import (
     ValidationAction,
     ValidationDecision,
@@ -24,6 +25,10 @@ _ACTION_TO_COMMAND_TYPE: dict[ValidationAction, TradeCommandType] = {
     ValidationAction.CANCEL: TradeCommandType.CANCEL_ORDER,
 }
 
+_EXIT_DEFAULT_EXECUTION_MODE = ExecutionMode.SINGLE_SHOT
+_EXIT_DEFAULT_ORDER_TYPE = OrderType.MARKET
+_EXIT_DEFAULT_DEADLINE_SECONDS = 60
+
 
 def translate_to_trade_command(
     action: Action,
@@ -37,7 +42,11 @@ def translate_to_trade_command(
     Args:
         action: Strategy-layer action being translated. Execution-mode,
             order-type, maker-preference, deadline, execution-params, and
-            reference-price flow from this source.
+            reference-price flow from this source for ENTER. For EXIT
+            (which carries only trade_id + size per TD-023.1), the
+            translate layer fills `execution_mode=SINGLE_SHOT`,
+            `order_type=MARKET`, and `deadline=60s` so submission to
+            Praxis cannot pass `None` to required parameters.
         context: Validated action request context.
         decision: Validation pipeline decision (must be allowed).
         config: Instance configuration for account/venue/stp_mode.
@@ -65,10 +74,27 @@ def translate_to_trade_command(
 
     command_type = _ACTION_TO_COMMAND_TYPE[context.action]
     is_new_order = command_type == TradeCommandType.NEW_ORDER
+    is_exit = context.action == ValidationAction.EXIT
 
     reservation_id = None
     if decision.reservation is not None:
         reservation_id = decision.reservation.reservation_id
+
+    if not is_new_order:
+        execution_mode = None
+        order_type = None
+        deadline = None
+    else:
+        execution_mode = action.execution_mode
+        order_type = action.order_type
+        deadline = action.deadline
+        if is_exit:
+            if execution_mode is None:
+                execution_mode = _EXIT_DEFAULT_EXECUTION_MODE
+            if order_type is None:
+                order_type = _EXIT_DEFAULT_ORDER_TYPE
+            if deadline is None:
+                deadline = _EXIT_DEFAULT_DEADLINE_SECONDS
 
     return TradeCommand(
         command_id=context.command_id,
@@ -83,10 +109,10 @@ def translate_to_trade_command(
         stp_mode=config.stp_mode if is_new_order else None,
         trade_id=context.trade_id,
         reservation_id=reservation_id,
-        execution_mode=action.execution_mode if is_new_order else None,
-        order_type=action.order_type if is_new_order else None,
+        execution_mode=execution_mode,
+        order_type=order_type,
         execution_params=action.execution_params if is_new_order else None,
-        deadline=action.deadline if is_new_order else None,
+        deadline=deadline,
         maker_preference=action.maker_preference if is_new_order else None,
         reference_price=action.reference_price if is_new_order else None,
     )

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -13,10 +13,11 @@ import structlog
 from limen.experiment.trainer.trainer import Trainer
 
 from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OperationalMode, OrderSide
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.position import Position
 from nexus.core.health_evaluator import HealthEvaluator, HealthSnapshot
 from nexus.infrastructure.praxis_connector.praxis_outbound import PraxisOutbound
-from nexus.core.domain.enums import OperationalMode
-from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.manifest import Manifest, TimerSpec, load_manifest
 from nexus.infrastructure.state_store import StateStore
 from nexus.startup.error import StartupError
@@ -195,6 +196,74 @@ class StartupSequencer:
         except Exception as e:
             raise StartupError('register_with_trading', str(e)) from e
 
+    def _import_praxis_position(
+        self,
+        trade_id: str,
+        praxis_pos: Any,
+        qty: Decimal,
+        price: Decimal,
+    ) -> Position | None:
+        '''Build a Nexus Position from a Praxis-only position when possible.
+
+        Returns the imported Position, or None if the Praxis position lacks
+        the fields Nexus requires (e.g. strategy_id, symbol, side).
+        '''
+
+        strategy_id = getattr(praxis_pos, 'strategy_id', None)
+        if not isinstance(strategy_id, str) or not strategy_id.strip():
+            _log.warning(
+                'cannot import Praxis-only position without strategy_id',
+                trade_id=trade_id,
+                praxis_qty=str(qty),
+            )
+            return None
+
+        symbol = getattr(praxis_pos, 'symbol', None)
+        if not isinstance(symbol, str) or not symbol.strip():
+            _log.warning(
+                'cannot import Praxis-only position without symbol',
+                trade_id=trade_id,
+            )
+            return None
+
+        praxis_side = getattr(praxis_pos, 'side', None)
+        side_value = getattr(praxis_side, 'value', None)
+        try:
+            side = OrderSide(side_value)
+        except ValueError:
+            _log.warning(
+                'cannot import Praxis-only position with invalid side',
+                trade_id=trade_id,
+                side=repr(praxis_side),
+            )
+            return None
+
+        try:
+            imported = Position(
+                trade_id=trade_id,
+                strategy_id=strategy_id,
+                symbol=symbol,
+                side=side,
+                size=qty,
+                entry_price=price,
+            )
+        except ValueError as e:
+            _log.warning(
+                'cannot import Praxis-only position with invalid fields',
+                trade_id=trade_id,
+                error=str(e),
+            )
+            return None
+
+        _log.info(
+            'imported Praxis-only position',
+            trade_id=trade_id,
+            strategy_id=strategy_id,
+            symbol=symbol,
+            size=str(qty),
+        )
+        return imported
+
     def _reconcile_capital(self) -> None:
         '''Reconcile capital state against Trading positions.
 
@@ -247,11 +316,9 @@ class StartupSequencer:
             nexus_pos = self._state.positions.get(trade_id)
 
             if nexus_pos is None:
-                _log.warning(
-                    'position in Praxis but not in Nexus',
-                    trade_id=trade_id,
-                    praxis_qty=str(praxis_pos.qty),
-                )
+                imported = self._import_praxis_position(trade_id, praxis_pos, qty, price)
+                if imported is not None:
+                    self._state.positions[trade_id] = imported
                 continue
 
             if nexus_pos.size != qty:

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -209,6 +209,45 @@ class StartupSequencer:
         the fields Nexus requires (e.g. strategy_id, symbol, side).
         '''
 
+        resolved = self._resolve_imported_position_fields(trade_id, praxis_pos, qty)
+        if resolved is None:
+            return None
+        strategy_id, symbol, side = resolved
+
+        try:
+            imported = Position(
+                trade_id=trade_id,
+                strategy_id=strategy_id,
+                symbol=symbol,
+                side=side,
+                size=qty,
+                entry_price=price,
+            )
+        except ValueError as e:
+            _log.warning(
+                'cannot import Praxis-only position with invalid fields',
+                trade_id=trade_id,
+                error=str(e),
+            )
+            return None
+
+        _log.info(
+            'imported Praxis-only position',
+            trade_id=trade_id,
+            strategy_id=strategy_id,
+            symbol=symbol,
+            size=str(qty),
+        )
+        return imported
+
+    def _resolve_imported_position_fields(
+        self,
+        trade_id: str,
+        praxis_pos: Any,
+        qty: Decimal,
+    ) -> tuple[str, str, OrderSide] | None:
+        '''Extract and validate strategy_id / symbol / side from a Praxis position.'''
+
         strategy_id = getattr(praxis_pos, 'strategy_id', None)
         if not isinstance(strategy_id, str) or not strategy_id.strip():
             _log.warning(
@@ -238,31 +277,7 @@ class StartupSequencer:
             )
             return None
 
-        try:
-            imported = Position(
-                trade_id=trade_id,
-                strategy_id=strategy_id,
-                symbol=symbol,
-                side=side,
-                size=qty,
-                entry_price=price,
-            )
-        except ValueError as e:
-            _log.warning(
-                'cannot import Praxis-only position with invalid fields',
-                trade_id=trade_id,
-                error=str(e),
-            )
-            return None
-
-        _log.info(
-            'imported Praxis-only position',
-            trade_id=trade_id,
-            strategy_id=strategy_id,
-            symbol=symbol,
-            size=str(qty),
-        )
-        return imported
+        return strategy_id, symbol, side
 
     def _reconcile_capital(self) -> None:
         '''Reconcile capital state against Trading positions.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -37,6 +37,8 @@ _log = structlog.get_logger()
 _HUNDRED = Decimal('100')
 _ZERO = Decimal(0)
 _SHUTDOWN_ABORT_REASON = 'shutdown'
+_ESCALATION_ABORT_REASON = 'shutdown_escalation'
+_ESCALATION_TIMEOUT_RATIO = 0.5
 
 
 class ShutdownSequencer:
@@ -341,8 +343,9 @@ class ShutdownSequencer:
         '''Wait for all submitted commands to reach terminal state.
 
         Polls PraxisInbound for outcomes matching submitted commands.
-        Returns when all commands are terminal or timeout expires.
-        Full ABORT escalation requires Action fields (TD-023).
+        On first-round timeout, escalates by issuing ABORT for each still-
+        pending command via PraxisOutbound, then polls again with a shorter
+        deadline before giving up.
         '''
 
         if not self._submitted_command_ids:
@@ -355,29 +358,86 @@ class ShutdownSequencer:
             )
             return
 
-        deadline = time.monotonic() + self._shutdown_timeout
-        pending = set(self._submitted_command_ids)
+        pending = self._poll_until_terminal(
+            set(self._submitted_command_ids),
+            self._shutdown_timeout,
+        )
 
-        while pending and time.monotonic() < deadline:
+        if not pending:
+            return
+
+        self._escalate_abort_pending(pending)
+
+        pending = self._poll_until_terminal(
+            pending,
+            self._shutdown_timeout * _ESCALATION_TIMEOUT_RATIO,
+        )
+
+        if pending:
+            _log.warning(
+                'shutdown timeout after escalation: commands still pending',
+                pending_count=len(pending),
+                pending_ids=sorted(pending),
+            )
+
+    def _poll_until_terminal(
+        self,
+        pending: set[str],
+        timeout: float,
+    ) -> set[str]:
+        '''Poll PraxisInbound until pending is empty or deadline expires.'''
+
+        if self._praxis_inbound is None or timeout <= 0:
+            return pending
+
+        remaining = set(pending)
+        deadline = time.monotonic() + timeout
+
+        while remaining and time.monotonic() < deadline:
             outcome = self._praxis_inbound.receive_outcome()
 
             if outcome is None:
                 continue
 
-            if outcome.command_id in pending and outcome.outcome_type.is_terminal:
-                pending.discard(outcome.command_id)
+            if outcome.command_id in remaining and outcome.outcome_type.is_terminal:
+                remaining.discard(outcome.command_id)
                 _log.info(
                     'command reached terminal state',
                     command_id=outcome.command_id,
                     outcome_type=outcome.outcome_type.value,
                 )
 
-        if pending:
+        return remaining
+
+    def _escalate_abort_pending(self, pending: set[str]) -> None:
+        '''Send ABORT for each still-pending command and log outcomes.'''
+
+        if self._praxis_outbound is None or self._config is None:
             _log.warning(
-                'shutdown timeout: commands still pending',
+                'praxis_outbound or config not configured, cannot escalate aborts',
                 pending_count=len(pending),
-                pending_ids=sorted(pending),
             )
+            return
+
+        _log.warning(
+            'shutdown timeout: escalating aborts for pending commands',
+            pending_count=len(pending),
+            pending_ids=sorted(pending),
+        )
+
+        for command_id in sorted(pending):
+            try:
+                self._praxis_outbound.send_abort(
+                    command_id=command_id,
+                    account_id=self._config.account_id,
+                    reason=_ESCALATION_ABORT_REASON,
+                    created_at=datetime.now(tz=timezone.utc),
+                )
+            except Exception:  # noqa: BLE001 - outbound failure must not abort shutdown
+                _log.exception(
+                    'escalation abort failed',
+                    command_id=command_id,
+                )
 
     def _dispatch_save(self) -> None:
         '''Dispatch on_save to all strategies.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -4,16 +4,26 @@ from __future__ import annotations
 
 import os
 import time
+import uuid
+from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 
 import structlog
 
+from nexus.core.domain.enums import OrderSide
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.validator.pipeline_models import (
+    ValidationAction,
+    ValidationDecision,
+    ValidationRequestContext,
+)
 from nexus.infrastructure.manifest import Manifest
-from nexus.infrastructure.state_store import StateStore
 from nexus.infrastructure.praxis_connector.praxis_inbound import PraxisInbound
 from nexus.infrastructure.praxis_connector.praxis_outbound import PraxisOutbound
+from nexus.infrastructure.praxis_connector.translate import translate_to_trade_command
+from nexus.infrastructure.state_store import StateStore
+from nexus.instance_config import InstanceConfig
 from nexus.strategy.action import Action, ActionType
 from nexus.strategy.context import StrategyContext
 from nexus.strategy.params import StrategyParams
@@ -25,6 +35,8 @@ __all__ = ['ShutdownSequencer']
 
 _log = structlog.get_logger()
 _HUNDRED = Decimal('100')
+_ZERO = Decimal(0)
+_SHUTDOWN_ABORT_REASON = 'shutdown'
 
 
 class ShutdownSequencer:
@@ -61,6 +73,7 @@ class ShutdownSequencer:
         praxis_inbound: PraxisInbound | None = None,
         account_id: str | None = None,
         shutdown_timeout: float = 120.0,
+        config: InstanceConfig | None = None,
     ) -> None:
         if not isinstance(runner, StrategyRunner):
             msg = 'runner must be a StrategyRunner instance'
@@ -82,6 +95,10 @@ class ShutdownSequencer:
             msg = 'strategy_state_path must be a Path'
             raise ValueError(msg)
 
+        if config is not None and not isinstance(config, InstanceConfig):
+            msg = 'config must be an InstanceConfig instance or None'
+            raise ValueError(msg)
+
         self._runner = runner
         self._manifest = manifest
         self._state_store = state_store
@@ -93,6 +110,7 @@ class ShutdownSequencer:
         self._praxis_inbound = praxis_inbound
         self._account_id = account_id
         self._shutdown_timeout = shutdown_timeout
+        self._config = config
         self._shutdown_actions: dict[str, list[Action]] = {}
         self._submitted_command_ids: list[str] = []
         self._save_blobs: dict[str, bytes] = {}
@@ -179,11 +197,14 @@ class ShutdownSequencer:
                 _log.exception('on_shutdown failed', strategy_id=strategy_id)
 
     def _submit_actions(self) -> None:
-        '''Submit EXIT/ABORT actions through Validator to Praxis.
+        '''Submit EXIT/ABORT actions to Praxis.
 
         Filters actions returned by strategies from _dispatch_shutdown.
         Only EXIT/ABORT are allowed during shutdown; ENTER/MODIFY skipped.
-        Filtered actions are submitted via PraxisOutbound when available.
+        EXIT goes through translate → PraxisOutbound.send_command.
+        ABORT goes through PraxisOutbound.send_abort.
+        Returned command_ids are collected in _submitted_command_ids for
+        _wait_terminal to poll.
         '''
 
         allowed_types = (ActionType.EXIT, ActionType.ABORT)
@@ -218,11 +239,103 @@ class ShutdownSequencer:
             )
             return
 
-        _log.warning(
-            'shutdown action submission not yet functional — '
-            'Action fields (TD-023) required for TradeCommand translation',
-            action_count=len(filtered),
+        if self._config is None:
+            _log.warning(
+                'config not configured, cannot submit shutdown actions',
+                action_count=len(filtered),
+            )
+            return
+
+        for strategy_id, action in filtered:
+            if action.action_type == ActionType.EXIT:
+                self._submit_exit(strategy_id, action)
+            else:
+                self._submit_abort(action)
+
+    def _submit_exit(self, strategy_id: str, action: Action) -> None:
+        '''Translate an EXIT Action and submit it as a NEW_ORDER.'''
+
+        if self._praxis_outbound is None or self._config is None:
+            return
+
+        if action.trade_id is None:
+            _log.warning('exit action missing trade_id', strategy_id=strategy_id)
+            return
+
+        position = self._state.positions.get(action.trade_id)
+        if position is None:
+            _log.warning(
+                'exit action references unknown trade_id',
+                strategy_id=strategy_id,
+                trade_id=action.trade_id,
+            )
+            return
+
+        command_id = f'shutdown-{strategy_id}-{uuid.uuid4().hex[:8]}'
+        context = ValidationRequestContext(
+            strategy_id=strategy_id,
+            action=ValidationAction.EXIT,
+            symbol=position.symbol,
+            order_side=OrderSide.SELL,
+            order_size=action.size,
+            command_id=command_id,
+            trade_id=action.trade_id,
+            order_notional=_ZERO,
+            estimated_fees=_ZERO,
+            strategy_budget=_ZERO,
+            state=self._state,
+            config=self._config,
         )
+        decision = ValidationDecision(allowed=True)
+        cmd = translate_to_trade_command(
+            action,
+            context,
+            decision,
+            self._config,
+            datetime.now(tz=timezone.utc),
+        )
+
+        try:
+            returned_id = self._praxis_outbound.send_command(cmd)
+        except Exception:  # noqa: BLE001 - outbound failure must not abort shutdown
+            _log.exception(
+                'exit submission failed',
+                strategy_id=strategy_id,
+                trade_id=action.trade_id,
+            )
+            return
+
+        self._submitted_command_ids.append(returned_id)
+        _log.info(
+            'exit submitted',
+            strategy_id=strategy_id,
+            trade_id=action.trade_id,
+            command_id=returned_id,
+        )
+
+    def _submit_abort(self, action: Action) -> None:
+        '''Submit an ABORT Action via PraxisOutbound.send_abort.'''
+
+        if self._praxis_outbound is None or self._config is None:
+            return
+
+        if action.command_id is None:
+            _log.warning('abort action missing command_id')
+            return
+
+        try:
+            self._praxis_outbound.send_abort(
+                command_id=action.command_id,
+                account_id=self._config.account_id,
+                reason=_SHUTDOWN_ABORT_REASON,
+                created_at=datetime.now(tz=timezone.utc),
+            )
+        except Exception:  # noqa: BLE001 - outbound failure must not abort shutdown
+            _log.exception('abort submission failed', command_id=action.command_id)
+            return
+
+        self._submitted_command_ids.append(action.command_id)
+        _log.info('abort submitted', command_id=action.command_id)
 
     def _wait_terminal(self) -> None:
         '''Wait for all submitted commands to reach terminal state.

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -313,12 +313,15 @@ class ShutdownSequencer:
         if self._config is None:
             return None
 
+        exit_side = (
+            OrderSide.SELL if position.side == OrderSide.BUY else OrderSide.BUY
+        )
         command_id = f'shutdown-{strategy_id}-{uuid.uuid4().hex[:8]}'
         return ValidationRequestContext(
             strategy_id=strategy_id,
             action=ValidationAction.EXIT,
             symbol=position.symbol,
-            order_side=OrderSide.SELL,
+            order_side=exit_side,
             order_size=action.size,
             command_id=command_id,
             trade_id=action.trade_id,

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -260,39 +260,14 @@ class ShutdownSequencer:
         if self._praxis_outbound is None or self._config is None:
             return
 
-        if action.trade_id is None:
-            _log.warning('exit action missing trade_id', strategy_id=strategy_id)
+        context = self._build_exit_context(strategy_id, action)
+        if context is None:
             return
 
-        position = self._state.positions.get(action.trade_id)
-        if position is None:
-            _log.warning(
-                'exit action references unknown trade_id',
-                strategy_id=strategy_id,
-                trade_id=action.trade_id,
-            )
-            return
-
-        command_id = f'shutdown-{strategy_id}-{uuid.uuid4().hex[:8]}'
-        context = ValidationRequestContext(
-            strategy_id=strategy_id,
-            action=ValidationAction.EXIT,
-            symbol=position.symbol,
-            order_side=OrderSide.SELL,
-            order_size=action.size,
-            command_id=command_id,
-            trade_id=action.trade_id,
-            order_notional=_ZERO,
-            estimated_fees=_ZERO,
-            strategy_budget=_ZERO,
-            state=self._state,
-            config=self._config,
-        )
-        decision = ValidationDecision(allowed=True)
         cmd = translate_to_trade_command(
             action,
             context,
-            decision,
+            ValidationDecision(allowed=True),
             self._config,
             datetime.now(tz=timezone.utc),
         )
@@ -313,6 +288,45 @@ class ShutdownSequencer:
             strategy_id=strategy_id,
             trade_id=action.trade_id,
             command_id=returned_id,
+        )
+
+    def _build_exit_context(
+        self,
+        strategy_id: str,
+        action: Action,
+    ) -> ValidationRequestContext | None:
+        '''Build a ValidationRequestContext for an EXIT action or return None.'''
+
+        if action.trade_id is None:
+            _log.warning('exit action missing trade_id', strategy_id=strategy_id)
+            return None
+
+        position = self._state.positions.get(action.trade_id)
+        if position is None:
+            _log.warning(
+                'exit action references unknown trade_id',
+                strategy_id=strategy_id,
+                trade_id=action.trade_id,
+            )
+            return None
+
+        if self._config is None:
+            return None
+
+        command_id = f'shutdown-{strategy_id}-{uuid.uuid4().hex[:8]}'
+        return ValidationRequestContext(
+            strategy_id=strategy_id,
+            action=ValidationAction.EXIT,
+            symbol=position.symbol,
+            order_side=OrderSide.SELL,
+            order_size=action.size,
+            command_id=command_id,
+            trade_id=action.trade_id,
+            order_notional=_ZERO,
+            estimated_fees=_ZERO,
+            strategy_budget=_ZERO,
+            state=self._state,
+            config=self._config,
         )
 
     def _submit_abort(self, action: Action) -> None:

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -58,8 +58,12 @@ class ShutdownSequencer:
         timer_loop: Running TimerLoop to stop during shutdown.
         praxis_outbound: Outbound connector for deregistration.
         praxis_inbound: Inbound connector for outcome consumption.
-        account_id: Account identifier for Praxis deregistration.
+        account_id: Account identifier for Praxis deregistration. When config
+            is also provided, account_id must equal config.account_id.
         shutdown_timeout: Seconds to wait for commands to reach terminal state.
+        config: Instance configuration carrying account_id, venue, stp_mode
+            for shutdown command translation. When provided alongside
+            account_id, the two account_ids must match.
     '''
 
     def __init__(
@@ -99,6 +103,17 @@ class ShutdownSequencer:
 
         if config is not None and not isinstance(config, InstanceConfig):
             msg = 'config must be an InstanceConfig instance or None'
+            raise ValueError(msg)
+
+        if (
+            config is not None
+            and account_id is not None
+            and account_id != config.account_id
+        ):
+            msg = (
+                'account_id and config.account_id must match: '
+                f'{account_id!r} vs {config.account_id!r}'
+            )
             raise ValueError(msg)
 
         self._runner = runner

--- a/nexus/strategy/action.py
+++ b/nexus/strategy/action.py
@@ -41,7 +41,8 @@ class Action:
         order_type: Order type (e.g. Market, Limit). Required for ENTER.
         execution_params: Mode-specific parameters. Optional.
         deadline: Timeout in seconds. Required for ENTER.
-        trade_id: Existing trade reference. Required for EXIT, MODIFY, ABORT.
+        trade_id: Existing trade reference. Required for EXIT.
+        command_id: Existing command reference. Required for MODIFY, ABORT.
         maker_preference: Maker/taker preference. Optional.
         reference_price: Strategy reference price for slippage measurement. Optional.
     '''
@@ -54,6 +55,7 @@ class Action:
     execution_params: dict[str, object] | None = None
     deadline: int | None = None
     trade_id: str | None = None
+    command_id: str | None = None
     maker_preference: str | None = None
     reference_price: Decimal | None = None
 
@@ -109,6 +111,13 @@ class Action:
             msg = 'trade_id must be a non-empty string or None'
             raise ValueError(msg)
 
+        if self.command_id is not None and (
+            not isinstance(self.command_id, str)
+            or not self.command_id.strip()
+        ):
+            msg = 'command_id must be a non-empty string or None'
+            raise ValueError(msg)
+
         if self.maker_preference is not None and (
             not isinstance(self.maker_preference, str)
             or not self.maker_preference.strip()
@@ -156,11 +165,11 @@ class Action:
                 raise ValueError(msg)
 
         elif self.action_type == ActionType.MODIFY:
-            if self.trade_id is None:
-                msg = 'MODIFY requires: trade_id'
+            if self.command_id is None:
+                msg = 'MODIFY requires: command_id'
                 raise ValueError(msg)
 
         elif self.action_type == ActionType.ABORT:
-            if self.trade_id is None:
-                msg = 'ABORT requires: trade_id'
+            if self.command_id is None:
+                msg = 'ABORT requires: command_id'
                 raise ValueError(msg)

--- a/nexus/strategy/action.py
+++ b/nexus/strategy/action.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from enum import Enum
 
 from nexus.core.domain.enums import OrderSide
+from nexus.core.domain.order_types import ExecutionMode, MakerPreference, OrderType
 
 __all__ = ['Action', 'ActionType']
 
@@ -50,13 +51,13 @@ class Action:
     action_type: ActionType
     direction: OrderSide | None = None
     size: Decimal | None = None
-    execution_mode: str | None = None
-    order_type: str | None = None
+    execution_mode: ExecutionMode | None = None
+    order_type: OrderType | None = None
     execution_params: dict[str, object] | None = None
     deadline: int | None = None
     trade_id: str | None = None
     command_id: str | None = None
-    maker_preference: str | None = None
+    maker_preference: MakerPreference | None = None
     reference_price: Decimal | None = None
 
     def __post_init__(self) -> None:
@@ -76,18 +77,14 @@ class Action:
             msg = 'size must be a finite positive Decimal or None'
             raise ValueError(msg)
 
-        if self.execution_mode is not None and (
-            not isinstance(self.execution_mode, str)
-            or not self.execution_mode.strip()
+        if self.execution_mode is not None and not isinstance(
+            self.execution_mode, ExecutionMode
         ):
-            msg = 'execution_mode must be a non-empty string or None'
+            msg = 'execution_mode must be an ExecutionMode member or None'
             raise ValueError(msg)
 
-        if self.order_type is not None and (
-            not isinstance(self.order_type, str)
-            or not self.order_type.strip()
-        ):
-            msg = 'order_type must be a non-empty string or None'
+        if self.order_type is not None and not isinstance(self.order_type, OrderType):
+            msg = 'order_type must be an OrderType member or None'
             raise ValueError(msg)
 
         if self.execution_params is not None and not isinstance(
@@ -118,11 +115,10 @@ class Action:
             msg = 'command_id must be a non-empty string or None'
             raise ValueError(msg)
 
-        if self.maker_preference is not None and (
-            not isinstance(self.maker_preference, str)
-            or not self.maker_preference.strip()
+        if self.maker_preference is not None and not isinstance(
+            self.maker_preference, MakerPreference
         ):
-            msg = 'maker_preference must be a non-empty string or None'
+            msg = 'maker_preference must be a MakerPreference member or None'
             raise ValueError(msg)
 
         if self.reference_price is not None and (

--- a/nexus/strategy/action.py
+++ b/nexus/strategy/action.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
+from types import MappingProxyType
 
 from nexus.core.domain.enums import OrderSide
 from nexus.core.domain.order_types import ExecutionMode, MakerPreference, OrderType
@@ -53,7 +55,7 @@ class Action:
     size: Decimal | None = None
     execution_mode: ExecutionMode | None = None
     order_type: OrderType | None = None
-    execution_params: dict[str, object] | None = None
+    execution_params: Mapping[str, object] | None = None
     deadline: int | None = None
     trade_id: str | None = None
     command_id: str | None = None
@@ -87,11 +89,15 @@ class Action:
             msg = 'order_type must be an OrderType member or None'
             raise ValueError(msg)
 
-        if self.execution_params is not None and not isinstance(
-            self.execution_params, dict
-        ):
-            msg = 'execution_params must be a dict or None'
-            raise ValueError(msg)
+        if self.execution_params is not None:
+            if not isinstance(self.execution_params, Mapping):
+                msg = 'execution_params must be a Mapping or None'
+                raise ValueError(msg)
+            object.__setattr__(
+                self,
+                'execution_params',
+                MappingProxyType(dict(self.execution_params)),
+            )
 
         if self.deadline is not None and (
             isinstance(self.deadline, bool)

--- a/nexus/strategy/action.py
+++ b/nexus/strategy/action.py
@@ -36,7 +36,7 @@ class Action:
 
     Args:
         action_type: Type of action requested.
-        direction: BUY or SELL. Required for ENTER and EXIT.
+        direction: BUY or SELL. Required for ENTER.
         size: Base asset quantity. Required for ENTER and EXIT.
         execution_mode: How to execute (e.g. SingleShot). Required for ENTER.
         order_type: Order type (e.g. Market, Limit). Required for ENTER.

--- a/nexus/strategy/action.py
+++ b/nexus/strategy/action.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 from enum import Enum
+
+from nexus.core.domain.enums import OrderSide
+
+__all__ = ['Action', 'ActionType']
+
+_ZERO = Decimal(0)
 
 
 class ActionType(Enum):
@@ -28,11 +35,132 @@ class Action:
 
     Args:
         action_type: Type of action requested.
+        direction: BUY or SELL. Required for ENTER and EXIT.
+        size: Base asset quantity. Required for ENTER and EXIT.
+        execution_mode: How to execute (e.g. SingleShot). Required for ENTER.
+        order_type: Order type (e.g. Market, Limit). Required for ENTER.
+        execution_params: Mode-specific parameters. Optional.
+        deadline: Timeout in seconds. Required for ENTER.
+        trade_id: Existing trade reference. Required for EXIT, MODIFY, ABORT.
+        maker_preference: Maker/taker preference. Optional.
+        reference_price: Strategy reference price for slippage measurement. Optional.
     '''
 
     action_type: ActionType
+    direction: OrderSide | None = None
+    size: Decimal | None = None
+    execution_mode: str | None = None
+    order_type: str | None = None
+    execution_params: dict[str, object] | None = None
+    deadline: int | None = None
+    trade_id: str | None = None
+    maker_preference: str | None = None
+    reference_price: Decimal | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.action_type, ActionType):
             msg = 'action_type must be an ActionType'
             raise ValueError(msg)
+
+        if self.direction is not None and not isinstance(self.direction, OrderSide):
+            msg = 'direction must be an OrderSide member or None'
+            raise ValueError(msg)
+
+        if self.size is not None and (
+            not isinstance(self.size, Decimal)
+            or not self.size.is_finite()
+            or self.size <= _ZERO
+        ):
+            msg = 'size must be a finite positive Decimal or None'
+            raise ValueError(msg)
+
+        if self.execution_mode is not None and (
+            not isinstance(self.execution_mode, str)
+            or not self.execution_mode.strip()
+        ):
+            msg = 'execution_mode must be a non-empty string or None'
+            raise ValueError(msg)
+
+        if self.order_type is not None and (
+            not isinstance(self.order_type, str)
+            or not self.order_type.strip()
+        ):
+            msg = 'order_type must be a non-empty string or None'
+            raise ValueError(msg)
+
+        if self.execution_params is not None and not isinstance(
+            self.execution_params, dict
+        ):
+            msg = 'execution_params must be a dict or None'
+            raise ValueError(msg)
+
+        if self.deadline is not None and (
+            isinstance(self.deadline, bool)
+            or not isinstance(self.deadline, int)
+            or self.deadline <= 0
+        ):
+            msg = 'deadline must be a positive int or None'
+            raise ValueError(msg)
+
+        if self.trade_id is not None and (
+            not isinstance(self.trade_id, str)
+            or not self.trade_id.strip()
+        ):
+            msg = 'trade_id must be a non-empty string or None'
+            raise ValueError(msg)
+
+        if self.maker_preference is not None and (
+            not isinstance(self.maker_preference, str)
+            or not self.maker_preference.strip()
+        ):
+            msg = 'maker_preference must be a non-empty string or None'
+            raise ValueError(msg)
+
+        if self.reference_price is not None and (
+            not isinstance(self.reference_price, Decimal)
+            or not self.reference_price.is_finite()
+            or self.reference_price <= _ZERO
+        ):
+            msg = 'reference_price must be a finite positive Decimal or None'
+            raise ValueError(msg)
+
+        self._validate_action_type_requirements()
+
+    def _validate_action_type_requirements(self) -> None:
+        '''Validate field requirements per action_type.'''
+
+        if self.action_type == ActionType.ENTER:
+            missing = []
+            if self.direction is None:
+                missing.append('direction')
+            if self.size is None:
+                missing.append('size')
+            if self.execution_mode is None:
+                missing.append('execution_mode')
+            if self.order_type is None:
+                missing.append('order_type')
+            if self.deadline is None:
+                missing.append('deadline')
+            if missing:
+                msg = f"ENTER requires: {', '.join(missing)}"
+                raise ValueError(msg)
+
+        elif self.action_type == ActionType.EXIT:
+            missing = []
+            if self.trade_id is None:
+                missing.append('trade_id')
+            if self.size is None:
+                missing.append('size')
+            if missing:
+                msg = f"EXIT requires: {', '.join(missing)}"
+                raise ValueError(msg)
+
+        elif self.action_type == ActionType.MODIFY:
+            if self.trade_id is None:
+                msg = 'MODIFY requires: trade_id'
+                raise ValueError(msg)
+
+        elif self.action_type == ActionType.ABORT:
+            if self.trade_id is None:
+                msg = 'ABORT requires: trade_id'
+                raise ValueError(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.26.0"
+version = "0.27.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_health_loop.py
+++ b/tests/test_health_loop.py
@@ -1,0 +1,178 @@
+'''Tests for HealthLoop periodic re-evaluation.'''
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.health_evaluator import HealthEvaluator, HealthSnapshot, HealthThresholds
+from nexus.core.health_loop import HealthLoop
+
+
+def _make_state() -> InstanceState:
+    return InstanceState(capital=CapitalState(capital_pool=Decimal('10000')))
+
+
+def _make_evaluator() -> HealthEvaluator:
+    return HealthEvaluator(
+        thresholds=HealthThresholds(
+            latency_warn_ms=10.0,
+            latency_breach_ms=100.0,
+            latency_halt_ms=1000.0,
+        ),
+    )
+
+
+def test_invalid_interval_rejected() -> None:
+    state = _make_state()
+    evaluator = _make_evaluator()
+
+    with pytest.raises(ValueError, match='interval_seconds must be a positive number'):
+        HealthLoop(snapshot_provider=lambda: HealthSnapshot(), evaluator=evaluator, state=state, interval_seconds=0)
+
+
+def test_bool_interval_rejected() -> None:
+    state = _make_state()
+    evaluator = _make_evaluator()
+
+    with pytest.raises(ValueError, match='interval_seconds must be a positive number'):
+        HealthLoop(
+            snapshot_provider=lambda: HealthSnapshot(),
+            evaluator=evaluator,
+            state=state,
+            interval_seconds=True,  # type: ignore[arg-type]
+        )
+
+
+def test_tick_once_no_transition_when_active() -> None:
+    state = _make_state()
+    snapshot = HealthSnapshot()
+    loop = HealthLoop(
+        snapshot_provider=lambda: snapshot,
+        evaluator=_make_evaluator(),
+        state=state,
+    )
+
+    loop.tick_once()
+
+    assert state.mode.mode == OperationalMode.ACTIVE
+    assert state.mode.trigger == 'init'
+
+
+def test_tick_once_transitions_to_reduce_only() -> None:
+    state = _make_state()
+    snapshot = HealthSnapshot(latency_p99_ms=200.0)
+    loop = HealthLoop(
+        snapshot_provider=lambda: snapshot,
+        evaluator=_make_evaluator(),
+        state=state,
+    )
+
+    loop.tick_once()
+
+    assert state.mode.mode == OperationalMode.REDUCE_ONLY
+    assert state.mode.trigger == 'health'
+    assert state.mode.transitioned_at != datetime.min
+
+
+def test_tick_once_transitions_through_active_reduce_halted() -> None:
+    state = _make_state()
+    snapshots = iter([
+        HealthSnapshot(),
+        HealthSnapshot(latency_p99_ms=200.0),
+        HealthSnapshot(latency_p99_ms=2000.0),
+    ])
+    loop = HealthLoop(
+        snapshot_provider=lambda: next(snapshots),
+        evaluator=_make_evaluator(),
+        state=state,
+    )
+
+    loop.tick_once()
+    assert state.mode.mode == OperationalMode.ACTIVE
+
+    loop.tick_once()
+    assert state.mode.mode == OperationalMode.REDUCE_ONLY
+
+    loop.tick_once()
+    assert state.mode.mode == OperationalMode.HALTED
+
+
+def test_tick_once_provider_exception_swallowed() -> None:
+    state = _make_state()
+
+    def bad_provider() -> HealthSnapshot:
+        raise RuntimeError('praxis down')
+
+    loop = HealthLoop(
+        snapshot_provider=bad_provider,
+        evaluator=_make_evaluator(),
+        state=state,
+    )
+
+    loop.tick_once()
+
+    assert state.mode.mode == OperationalMode.ACTIVE
+
+
+def test_start_then_stop_is_clean() -> None:
+    state = _make_state()
+    loop = HealthLoop(
+        snapshot_provider=lambda: HealthSnapshot(),
+        evaluator=_make_evaluator(),
+        state=state,
+        interval_seconds=0.05,
+    )
+
+    assert loop.running is False
+    loop.start()
+    assert loop.running is True
+    loop.stop()
+    assert loop.running is False
+
+
+def test_periodic_tick_invokes_provider() -> None:
+    state = _make_state()
+    invocations = 0
+    invoked = threading.Event()
+
+    def provider() -> HealthSnapshot:
+        nonlocal invocations
+        invocations += 1
+        invoked.set()
+        return HealthSnapshot()
+
+    loop = HealthLoop(
+        snapshot_provider=provider,
+        evaluator=_make_evaluator(),
+        state=state,
+        interval_seconds=0.05,
+    )
+
+    loop.start()
+    triggered = invoked.wait(timeout=1.0)
+    loop.stop()
+
+    assert triggered
+    assert invocations >= 1
+
+
+def test_start_is_idempotent() -> None:
+    state = _make_state()
+    loop = HealthLoop(
+        snapshot_provider=lambda: HealthSnapshot(),
+        evaluator=_make_evaluator(),
+        state=state,
+        interval_seconds=0.05,
+    )
+
+    loop.start()
+    loop.start()
+    assert loop.running is True
+    loop.stop()

--- a/tests/test_instance_state.py
+++ b/tests/test_instance_state.py
@@ -7,8 +7,10 @@ from decimal import Decimal
 import pytest
 
 from nexus.core.domain.capital_state import CapitalState
-from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.enums import OperationalMode, OrderSide
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.operational_mode import StrategyModeState
+from nexus.core.domain.position import Position
 from nexus.instance_config import InstanceConfig
 
 
@@ -44,9 +46,6 @@ def test_from_config() -> None:
 def test_positions_key_mismatch_rejected() -> None:
     '''Verify positions dict key not matching trade_id raises ValueError.'''
 
-    from nexus.core.domain.enums import OrderSide
-    from nexus.core.domain.position import Position
-
     with pytest.raises(ValueError, match='does not match trade_id'):
         InstanceState(
             capital=CapitalState(capital_pool=Decimal('10000')),
@@ -65,8 +64,6 @@ def test_positions_key_mismatch_rejected() -> None:
 
 def test_strategy_modes_key_mismatch_rejected() -> None:
     '''Verify strategy_modes dict key not matching strategy_id raises ValueError.'''
-
-    from nexus.core.domain.operational_mode import StrategyModeState
 
     with pytest.raises(ValueError, match='does not match strategy_id'):
         InstanceState(

--- a/tests/test_praxis_outbound.py
+++ b/tests/test_praxis_outbound.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -108,6 +108,7 @@ class TestPraxisOutbound:
         assert received_kwargs['execution_params'] == {'slippage_bps': 10}
         assert received_kwargs['maker_preference'] == MakerPreference.NO_PREFERENCE
         assert received_kwargs['reference_price'] == Decimal('100000')
+        assert received_kwargs['timeout'] == 300
 
     def test_timeout_raises(
         self,
@@ -239,6 +240,63 @@ class TestPraxisOutboundSendAbort:
                 account_id='acc_001',
                 reason='shutdown',
                 created_at=datetime.now(tz=timezone.utc),
+            )
+
+    def test_naive_created_at_rejected(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''send_abort rejects naive datetime.'''
+
+        loop, _ = event_loop_thread
+
+        async def mock_submit_abort(**_kwargs: object) -> None:
+            return
+
+        async def mock_submit(**_kwargs: object) -> str:
+            return 'unused'
+
+        outbound = PraxisOutbound(
+            submit_fn=mock_submit,
+            loop=loop,
+            submit_abort_fn=mock_submit_abort,
+        )
+
+        with pytest.raises(ValueError, match='must be timezone-aware UTC'):
+            outbound.send_abort(
+                command_id='cmd_42',
+                account_id='acc_001',
+                reason='shutdown',
+                created_at=datetime(2026, 4, 18, 12, 0, 0),
+            )
+
+    def test_non_utc_created_at_rejected(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''send_abort rejects non-UTC timezone.'''
+
+        loop, _ = event_loop_thread
+
+        async def mock_submit_abort(**_kwargs: object) -> None:
+            return
+
+        async def mock_submit(**_kwargs: object) -> str:
+            return 'unused'
+
+        outbound = PraxisOutbound(
+            submit_fn=mock_submit,
+            loop=loop,
+            submit_abort_fn=mock_submit_abort,
+        )
+
+        non_utc = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+        with pytest.raises(ValueError, match='must be timezone-aware UTC'):
+            outbound.send_abort(
+                command_id='cmd_42',
+                account_id='acc_001',
+                reason='shutdown',
+                created_at=non_utc,
             )
 
 

--- a/tests/test_praxis_outbound.py
+++ b/tests/test_praxis_outbound.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 import pytest
 
 from nexus.core.domain.enums import OrderSide
+from nexus.core.domain.order_types import ExecutionMode, MakerPreference, OrderType
 from nexus.core.stp_mode import STPMode
 from nexus.infrastructure.praxis_connector.praxis_outbound import PraxisOutbound
 from nexus.infrastructure.praxis_connector.trade_command import TradeCommand
@@ -43,6 +44,12 @@ def _make_command(command_id: str = 'cmd_001') -> TradeCommand:
         size=Decimal('0.01'),
         stp_mode=STPMode.CANCEL_TAKER,
         trade_id='trade_001',
+        execution_mode=ExecutionMode.SINGLE_SHOT,
+        order_type=OrderType.MARKET,
+        execution_params={'slippage_bps': 10},
+        deadline=300,
+        maker_preference=MakerPreference.NO_PREFERENCE,
+        reference_price=Decimal('100000'),
     )
 
 
@@ -95,6 +102,11 @@ class TestPraxisOutbound:
         assert received_kwargs['side'] == OrderSide.BUY
         assert received_kwargs['trade_id'] == 'trade_001'
         assert received_kwargs['stp_mode'] == STPMode.CANCEL_TAKER
+        assert received_kwargs['order_type'] == OrderType.MARKET
+        assert received_kwargs['execution_mode'] == ExecutionMode.SINGLE_SHOT
+        assert received_kwargs['execution_params'] == {'slippage_bps': 10}
+        assert received_kwargs['maker_preference'] == MakerPreference.NO_PREFERENCE
+        assert received_kwargs['reference_price'] == Decimal('100000')
 
     def test_timeout_raises(
         self,

--- a/tests/test_praxis_outbound.py
+++ b/tests/test_praxis_outbound.py
@@ -152,3 +152,90 @@ class TestPraxisOutbound:
 
         with pytest.raises(ValueError, match='account not registered'):
             outbound.send_command(command)
+
+
+class TestPraxisOutboundSendAbort:
+
+    def test_sends_abort_with_fields(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''send_abort bridges to async submit_abort_fn with named fields.'''
+
+        loop, _ = event_loop_thread
+        received: dict[str, object] = {}
+
+        async def mock_submit_abort(**kwargs: object) -> None:
+            received.update(kwargs)
+
+        async def mock_submit(**_kwargs: object) -> str:
+            return 'unused'
+
+        outbound = PraxisOutbound(
+            submit_fn=mock_submit,
+            loop=loop,
+            submit_abort_fn=mock_submit_abort,
+        )
+
+        created_at = datetime.now(tz=timezone.utc)
+        outbound.send_abort(
+            command_id='cmd_42',
+            account_id='acc_001',
+            reason='shutdown',
+            created_at=created_at,
+        )
+
+        assert received['command_id'] == 'cmd_42'
+        assert received['account_id'] == 'acc_001'
+        assert received['reason'] == 'shutdown'
+        assert received['created_at'] == created_at
+
+    def test_raises_when_fn_not_configured(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''send_abort raises RuntimeError if submit_abort_fn is None.'''
+
+        loop, _ = event_loop_thread
+
+        async def mock_submit(**_kwargs: object) -> str:
+            return 'unused'
+
+        outbound = PraxisOutbound(submit_fn=mock_submit, loop=loop)
+
+        with pytest.raises(RuntimeError, match='submit_abort_fn not configured'):
+            outbound.send_abort(
+                command_id='cmd_42',
+                account_id='acc_001',
+                reason='shutdown',
+                created_at=datetime.now(tz=timezone.utc),
+            )
+
+    def test_async_error_propagates(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''Async submit_abort_fn exception propagates to sync caller.'''
+
+        loop, _ = event_loop_thread
+
+        async def failing_abort(**_kwargs: object) -> None:
+            msg = 'unknown command'
+            raise ValueError(msg)
+
+        async def mock_submit(**_kwargs: object) -> str:
+            return 'unused'
+
+        outbound = PraxisOutbound(
+            submit_fn=mock_submit,
+            loop=loop,
+            submit_abort_fn=failing_abort,
+        )
+
+        with pytest.raises(ValueError, match='unknown command'):
+            outbound.send_abort(
+                command_id='cmd_42',
+                account_id='acc_001',
+                reason='shutdown',
+                created_at=datetime.now(tz=timezone.utc),
+            )

--- a/tests/test_praxis_outbound.py
+++ b/tests/test_praxis_outbound.py
@@ -12,6 +12,7 @@ import pytest
 
 from nexus.core.domain.enums import OrderSide
 from nexus.core.domain.order_types import ExecutionMode, MakerPreference, OrderType
+from nexus.core.health_evaluator import HealthSnapshot
 from nexus.core.stp_mode import STPMode
 from nexus.infrastructure.praxis_connector.praxis_outbound import PraxisOutbound
 from nexus.infrastructure.praxis_connector.trade_command import TradeCommand
@@ -239,3 +240,74 @@ class TestPraxisOutboundSendAbort:
                 reason='shutdown',
                 created_at=datetime.now(tz=timezone.utc),
             )
+
+
+class TestPraxisOutboundGetHealthSnapshot:
+
+    def test_pulls_snapshot(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''get_health_snapshot bridges to async fn and returns the snapshot.'''
+
+        loop, _ = event_loop_thread
+        target = HealthSnapshot(latency_p99_ms=42.0, consecutive_failures=1)
+        received: dict[str, object] = {}
+
+        async def fake_get_snapshot(account_id: str) -> HealthSnapshot:
+            received['account_id'] = account_id
+            return target
+
+        async def mock_submit(**_kwargs: object) -> str:
+            return 'unused'
+
+        outbound = PraxisOutbound(
+            submit_fn=mock_submit,
+            loop=loop,
+            get_health_snapshot_fn=fake_get_snapshot,
+        )
+
+        result = outbound.get_health_snapshot('acc-1')
+
+        assert result is target
+        assert received['account_id'] == 'acc-1'
+
+    def test_raises_when_fn_not_configured(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''get_health_snapshot raises RuntimeError when fn is None.'''
+
+        loop, _ = event_loop_thread
+
+        async def mock_submit(**_kwargs: object) -> str:
+            return 'unused'
+
+        outbound = PraxisOutbound(submit_fn=mock_submit, loop=loop)
+
+        with pytest.raises(RuntimeError, match='get_health_snapshot_fn not configured'):
+            outbound.get_health_snapshot('acc-1')
+
+    def test_async_error_propagates(
+        self,
+        event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        '''Exception from get_health_snapshot_fn propagates.'''
+
+        loop, _ = event_loop_thread
+
+        async def failing_get_snapshot(_account_id: str) -> object:
+            msg = 'praxis not started'
+            raise RuntimeError(msg)
+
+        async def mock_submit(**_kwargs: object) -> str:
+            return 'unused'
+
+        outbound = PraxisOutbound(
+            submit_fn=mock_submit,
+            loop=loop,
+            get_health_snapshot_fn=failing_get_snapshot,
+        )
+
+        with pytest.raises(RuntimeError, match='praxis not started'):
+            outbound.get_health_snapshot('acc-1')

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -19,6 +19,7 @@ from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
 from nexus.infrastructure.state_store import StateStore
 from nexus.startup.shutdown_sequencer import ShutdownSequencer
+from nexus.core.domain.enums import OrderSide
 from nexus.strategy.action import Action, ActionType
 from nexus.strategy.runner import StrategyRunner
 
@@ -146,7 +147,7 @@ class TestDispatchShutdown:
 
     def test_dispatch_shutdown_collects_actions(self) -> None:
         runner = _make_mock_runner()
-        action = Action(action_type=ActionType.EXIT)
+        action = Action(action_type=ActionType.EXIT, trade_id='t-1', size=Decimal('1'))
         runner.dispatch_shutdown.return_value = [action]
         sequencer = _make_sequencer(runner=runner)
 
@@ -171,10 +172,10 @@ class TestSubmitActions:
         sequencer = _make_sequencer()
         sequencer._shutdown_actions = {
             'test': [
-                Action(action_type=ActionType.EXIT),
-                Action(action_type=ActionType.ABORT),
-                Action(action_type=ActionType.ENTER),
-                Action(action_type=ActionType.MODIFY),
+                Action(action_type=ActionType.EXIT, trade_id='t-1', size=Decimal('1')),
+                Action(action_type=ActionType.ABORT, trade_id='t-2'),
+                Action(action_type=ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300),
+                Action(action_type=ActionType.MODIFY, trade_id='t-3'),
             ],
         }
 

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -289,6 +289,67 @@ class TestSubmitActions:
         outbound.send_command.assert_not_called()
         assert sequencer._submitted_command_ids == []
 
+    def test_submit_exit_swallows_send_command_errors(self) -> None:
+        '''send_command exceptions do not abort shutdown or record a command_id.'''
+
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+        state = InstanceState(
+            capital=CapitalState(capital_pool=Decimal('10000')),
+            positions={
+                't-1': Position(
+                    trade_id='t-1',
+                    strategy_id='test',
+                    symbol='BTCUSDT',
+                    side=OrderSide.BUY,
+                    size=Decimal('0.5'),
+                    entry_price=Decimal('50000'),
+                ),
+            },
+        )
+        outbound = MagicMock(spec=['send_command', 'send_abort'])
+        outbound.send_command.side_effect = RuntimeError('praxis down')
+        sequencer = _make_sequencer(state=state)
+        sequencer._praxis_outbound = outbound
+        sequencer._config = config
+        sequencer._shutdown_actions = {
+            'test': [
+                Action(action_type=ActionType.EXIT, trade_id='t-1', size=Decimal('0.5')),
+            ],
+        }
+
+        sequencer._submit_actions()
+
+        assert outbound.send_command.call_count == 1
+        assert sequencer._submitted_command_ids == []
+
+    def test_submit_abort_swallows_send_abort_errors(self) -> None:
+        '''send_abort exceptions do not abort shutdown or record a command_id.'''
+
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+        outbound = MagicMock(spec=['send_command', 'send_abort'])
+        outbound.send_abort.side_effect = RuntimeError('abort not supported')
+        sequencer = _make_sequencer()
+        sequencer._praxis_outbound = outbound
+        sequencer._config = config
+        sequencer._shutdown_actions = {
+            'test': [Action(action_type=ActionType.ABORT, command_id='cmd-1')],
+        }
+
+        sequencer._submit_actions()
+
+        assert outbound.send_abort.call_count == 1
+        assert sequencer._submitted_command_ids == []
+
 
 class TestDispatchSave:
 

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -173,9 +173,9 @@ class TestSubmitActions:
         sequencer._shutdown_actions = {
             'test': [
                 Action(action_type=ActionType.EXIT, trade_id='t-1', size=Decimal('1')),
-                Action(action_type=ActionType.ABORT, trade_id='t-2'),
+                Action(action_type=ActionType.ABORT, command_id='cmd-2'),
                 Action(action_type=ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300),
-                Action(action_type=ActionType.MODIFY, trade_id='t-3'),
+                Action(action_type=ActionType.MODIFY, command_id='cmd-3'),
             ],
         }
 

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -238,6 +238,51 @@ class TestSubmitActions:
         assert abort_kwargs['account_id'] == 'acc_001'
         assert abort_kwargs['reason'] == 'shutdown'
 
+    def test_exit_side_derived_from_position_side(self) -> None:
+        '''_build_exit_context picks the opposite side of the open position.'''
+
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+        state = InstanceState(
+            capital=CapitalState(capital_pool=Decimal('10000')),
+            positions={
+                't-buy': Position(
+                    trade_id='t-buy',
+                    strategy_id='s',
+                    symbol='BTCUSDT',
+                    side=OrderSide.BUY,
+                    size=Decimal('0.1'),
+                    entry_price=Decimal('50000'),
+                ),
+                't-sell': Position(
+                    trade_id='t-sell',
+                    strategy_id='s',
+                    symbol='BTCUSDT',
+                    side=OrderSide.SELL,
+                    size=Decimal('0.1'),
+                    entry_price=Decimal('50000'),
+                ),
+            },
+        )
+        sequencer = _make_sequencer(state=state)
+        sequencer._config = config
+
+        ctx_buy = sequencer._build_exit_context(
+            's',
+            Action(action_type=ActionType.EXIT, trade_id='t-buy', size=Decimal('0.1')),
+        )
+        ctx_sell = sequencer._build_exit_context(
+            's',
+            Action(action_type=ActionType.EXIT, trade_id='t-sell', size=Decimal('0.1')),
+        )
+
+        assert ctx_buy is not None and ctx_buy.order_side == OrderSide.SELL
+        assert ctx_sell is not None and ctx_sell.order_side == OrderSide.BUY
+
     def test_submit_actions_skips_when_outbound_missing(self) -> None:
         config = InstanceConfig(
             account_id='acc_001',

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -546,6 +546,95 @@ class TestWaitTerminal:
 
         assert q.empty()
 
+    def test_wait_terminal_escalates_abort_on_timeout(self) -> None:
+        '''On first-round timeout, _wait_terminal sends ABORT for each pending command.'''
+
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+        q: queue.Queue[TradeOutcome] = queue.Queue()
+        inbound = PraxisInbound(outcome_queue=q, poll_timeout=0.01)
+        outbound = MagicMock(spec=['send_command', 'send_abort'])
+
+        sequencer = ShutdownSequencer(
+            runner=_make_mock_runner(),
+            manifest=_make_manifest(),
+            state_store=_make_mock_state_store(),
+            state=_make_instance_state(),
+            strategy_state_path=_PLACEHOLDER_PATH,
+            praxis_inbound=inbound,
+            praxis_outbound=outbound,
+            config=config,
+            shutdown_timeout=0.05,
+        )
+        sequencer._submitted_command_ids.extend(['cmd_a', 'cmd_b'])
+
+        sequencer._wait_terminal()
+
+        assert outbound.send_abort.call_count == 2
+        reasons = {call.kwargs['reason'] for call in outbound.send_abort.call_args_list}
+        command_ids = {call.kwargs['command_id'] for call in outbound.send_abort.call_args_list}
+        assert reasons == {'shutdown_escalation'}
+        assert command_ids == {'cmd_a', 'cmd_b'}
+
+    def test_wait_terminal_escalation_noop_when_outbound_missing(self) -> None:
+        '''Escalation is a no-op (logged) when outbound or config is missing.'''
+
+        q: queue.Queue[TradeOutcome] = queue.Queue()
+        inbound = PraxisInbound(outcome_queue=q, poll_timeout=0.01)
+
+        sequencer = ShutdownSequencer(
+            runner=_make_mock_runner(),
+            manifest=_make_manifest(),
+            state_store=_make_mock_state_store(),
+            state=_make_instance_state(),
+            strategy_state_path=_PLACEHOLDER_PATH,
+            praxis_inbound=inbound,
+            shutdown_timeout=0.05,
+        )
+        sequencer._submitted_command_ids.append('cmd_a')
+
+        sequencer._wait_terminal()
+
+    def test_wait_terminal_no_escalation_when_all_terminal(self) -> None:
+        '''Escalation does not fire when all commands terminate before timeout.'''
+
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+        q: queue.Queue[TradeOutcome] = queue.Queue()
+        q.put(TradeOutcome(
+            outcome_id='out_a',
+            command_id='cmd_a',
+            outcome_type=TradeOutcomeType.CANCELED,
+            timestamp=datetime.now(tz=timezone.utc),
+        ))
+        inbound = PraxisInbound(outcome_queue=q, poll_timeout=0.01)
+        outbound = MagicMock(spec=['send_command', 'send_abort'])
+
+        sequencer = ShutdownSequencer(
+            runner=_make_mock_runner(),
+            manifest=_make_manifest(),
+            state_store=_make_mock_state_store(),
+            state=_make_instance_state(),
+            strategy_state_path=_PLACEHOLDER_PATH,
+            praxis_inbound=inbound,
+            praxis_outbound=outbound,
+            config=config,
+            shutdown_timeout=5.0,
+        )
+        sequencer._submitted_command_ids.append('cmd_a')
+
+        sequencer._wait_terminal()
+
+        outbound.send_abort.assert_not_called()
+
 
 class TestStopTimers:
 

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -20,6 +20,7 @@ from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcom
 from nexus.infrastructure.state_store import StateStore
 from nexus.startup.shutdown_sequencer import ShutdownSequencer
 from nexus.core.domain.enums import OrderSide
+from nexus.core.domain.order_types import ExecutionMode, OrderType
 from nexus.strategy.action import Action, ActionType
 from nexus.strategy.runner import StrategyRunner
 
@@ -174,7 +175,7 @@ class TestSubmitActions:
             'test': [
                 Action(action_type=ActionType.EXIT, trade_id='t-1', size=Decimal('1')),
                 Action(action_type=ActionType.ABORT, command_id='cmd-2'),
-                Action(action_type=ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300),
+                Action(action_type=ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode=ExecutionMode.SINGLE_SHOT, order_type=OrderType.MARKET, deadline=300),
                 Action(action_type=ActionType.MODIFY, command_id='cmd-3'),
             ],
         }

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -12,15 +12,18 @@ from unittest.mock import MagicMock
 import pytest
 
 from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OrderSide
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.order_types import ExecutionMode, OrderType
+from nexus.core.domain.position import Position
+from nexus.core.stp_mode import STPMode
 from nexus.infrastructure.manifest import Manifest, SensorSpec, StrategySpec
 from nexus.infrastructure.praxis_connector.praxis_inbound import PraxisInbound
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
 from nexus.infrastructure.state_store import StateStore
+from nexus.instance_config import InstanceConfig
 from nexus.startup.shutdown_sequencer import ShutdownSequencer
-from nexus.core.domain.enums import OrderSide
-from nexus.core.domain.order_types import ExecutionMode, OrderType
 from nexus.strategy.action import Action, ActionType
 from nexus.strategy.runner import StrategyRunner
 
@@ -190,6 +193,100 @@ class TestSubmitActions:
 
         sequencer._submit_actions()
 
+        assert sequencer._submitted_command_ids == []
+
+    def test_submit_actions_routes_exit_and_abort(self) -> None:
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+        state = InstanceState(
+            capital=CapitalState(capital_pool=Decimal('10000')),
+            positions={
+                't-1': Position(
+                    trade_id='t-1',
+                    strategy_id='test',
+                    symbol='BTCUSDT',
+                    side=OrderSide.BUY,
+                    size=Decimal('0.5'),
+                    entry_price=Decimal('50000'),
+                ),
+            },
+        )
+        outbound = MagicMock(spec=['send_command', 'send_abort'])
+        outbound.send_command.return_value = 'praxis_cmd_42'
+        sequencer = _make_sequencer(state=state)
+        sequencer._praxis_outbound = outbound
+        sequencer._config = config
+        sequencer._shutdown_actions = {
+            'test': [
+                Action(action_type=ActionType.EXIT, trade_id='t-1', size=Decimal('0.5')),
+                Action(action_type=ActionType.ABORT, command_id='cmd-99'),
+            ],
+        }
+
+        sequencer._submit_actions()
+
+        assert outbound.send_command.call_count == 1
+        assert outbound.send_abort.call_count == 1
+        assert sequencer._submitted_command_ids == ['praxis_cmd_42', 'cmd-99']
+
+        abort_kwargs = outbound.send_abort.call_args.kwargs
+        assert abort_kwargs['command_id'] == 'cmd-99'
+        assert abort_kwargs['account_id'] == 'acc_001'
+        assert abort_kwargs['reason'] == 'shutdown'
+
+    def test_submit_actions_skips_when_outbound_missing(self) -> None:
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+        sequencer = _make_sequencer()
+        sequencer._config = config
+        sequencer._shutdown_actions = {
+            'test': [Action(action_type=ActionType.ABORT, command_id='cmd-1')],
+        }
+
+        sequencer._submit_actions()
+
+        assert sequencer._submitted_command_ids == []
+
+    def test_submit_actions_skips_when_config_missing(self) -> None:
+        outbound = MagicMock(spec=['send_command', 'send_abort'])
+        sequencer = _make_sequencer()
+        sequencer._praxis_outbound = outbound
+        sequencer._shutdown_actions = {
+            'test': [Action(action_type=ActionType.ABORT, command_id='cmd-1')],
+        }
+
+        sequencer._submit_actions()
+
+        outbound.send_command.assert_not_called()
+        outbound.send_abort.assert_not_called()
+        assert sequencer._submitted_command_ids == []
+
+    def test_submit_exit_skips_unknown_trade_id(self) -> None:
+        config = InstanceConfig(
+            account_id='acc_001',
+            venue='binance_spot',
+            allocated_capital=Decimal('10000'),
+            stp_mode=STPMode.CANCEL_TAKER,
+        )
+        outbound = MagicMock(spec=['send_command', 'send_abort'])
+        sequencer = _make_sequencer()
+        sequencer._praxis_outbound = outbound
+        sequencer._config = config
+        sequencer._shutdown_actions = {
+            'test': [Action(action_type=ActionType.EXIT, trade_id='missing', size=Decimal('1'))],
+        }
+
+        sequencer._submit_actions()
+
+        outbound.send_command.assert_not_called()
         assert sequencer._submitted_command_ids == []
 
 

--- a/tests/test_signal_producer.py
+++ b/tests/test_signal_producer.py
@@ -8,14 +8,16 @@ from datetime import timezone
 from pathlib import Path
 from typing import Any
 
-import limen
 import numpy as np
 import polars as pl
 import pytest
-from limen.experiment.trainer.trainer import Trainer
 
 from nexus.startup.sequencer import WiredSensor
 from nexus.strategy.signal_producer import _extract_values, produce_signal
+
+limen = pytest.importorskip('limen')
+_trainer_module = pytest.importorskip('limen.experiment.trainer.trainer')
+Trainer = _trainer_module.Trainer
 
 
 def _find_limen_root() -> Path | None:

--- a/tests/test_signal_producer.py
+++ b/tests/test_signal_producer.py
@@ -8,8 +8,6 @@ from datetime import timezone
 from pathlib import Path
 from typing import Any
 
-import numpy as np
-import polars as pl
 import pytest
 
 from nexus.startup.sequencer import WiredSensor
@@ -18,6 +16,8 @@ from nexus.strategy.signal_producer import _extract_values, produce_signal
 limen = pytest.importorskip('limen')
 _trainer_module = pytest.importorskip('limen.experiment.trainer.trainer')
 Trainer = _trainer_module.Trainer
+np = pytest.importorskip('numpy')
+pl = pytest.importorskip('polars')
 
 
 def _find_limen_root() -> Path | None:

--- a/tests/test_signal_producer.py
+++ b/tests/test_signal_producer.py
@@ -8,10 +8,10 @@ from datetime import timezone
 from pathlib import Path
 from typing import Any
 
+import limen
 import numpy as np
 import polars as pl
 import pytest
-
 from limen.experiment.trainer.trainer import Trainer
 
 from nexus.startup.sequencer import WiredSensor
@@ -19,13 +19,9 @@ from nexus.strategy.signal_producer import _extract_values, produce_signal
 
 
 def _find_limen_root() -> Path | None:
-    try:
-        import limen
-        root = Path(limen.__file__).parent.parent
-        if (root / 'datasets').is_dir():
-            return root
-    except ImportError:
-        pass
+    root = Path(limen.__file__).parent.parent
+    if (root / 'datasets').is_dir():
+        return root
     return None
 
 

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.state_store import StateStore
+from nexus.infrastructure.strategy_event import StrategyEvent
 from nexus.startup import StartupError, StartupSequencer
+from nexus.strategy.runner import StrategyRunner
 
 
 @pytest.fixture(autouse=True)
@@ -195,8 +200,6 @@ class TestStartupSequencerStart:
         assert sequencer._runner is not None
 
     def test_start_runner_ready_for_dispatch(self, tmp_path: Path) -> None:
-        from nexus.strategy.runner import StrategyRunner
-
         manifest_path = tmp_path / 'manifest.yaml'
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
@@ -243,8 +246,6 @@ class TestStateRecovery:
         assert sequencer._state is mock_state
 
     def test_recover_state_creates_initial_state_on_fresh_start(self) -> None:
-        from nexus.core.domain.instance_state import InstanceState
-
         mock_store = _make_mock_state_store()
         mock_store.recover.return_value = None
         sequencer = _make_sequencer(
@@ -324,8 +325,6 @@ class TestExternalIntegrationStubs:
             sequencer._register_timers()
 
     def test_determine_mode_sets_active(self) -> None:
-        from nexus.core.domain.enums import OperationalMode
-
         sequencer = _make_sequencer()
 
         sequencer._determine_mode()
@@ -468,9 +467,6 @@ class TestEventReplay:
         sequencer._replay_strategy_events()
 
     def test_replay_dispatches_events_to_runner(self, tmp_path: Path) -> None:
-        from datetime import datetime, timezone
-        from nexus.infrastructure.strategy_event import StrategyEvent
-
         manifest_path = tmp_path / 'manifest.yaml'
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
@@ -506,9 +502,6 @@ class TestEventReplay:
         sequencer._runner.dispatch_event_replay.assert_called_once_with('test_strat', event)
 
     def test_replay_skips_unknown_strategy(self, tmp_path: Path) -> None:
-        from datetime import datetime, timezone
-        from nexus.infrastructure.strategy_event import StrategyEvent
-
         manifest_path = tmp_path / 'manifest.yaml'
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
@@ -871,9 +864,6 @@ class TestCrashOnlyDesign:
         sequencer._runner.dispatch_load.assert_called_once_with('test_strat', b'')
 
     def test_event_replay_calls_dispatch_event_replay(self, tmp_path: Path) -> None:
-        from datetime import datetime, timezone
-        from nexus.infrastructure.strategy_event import StrategyEvent
-
         manifest_path = tmp_path / 'manifest.yaml'
         strategy_file = tmp_path / 'strat.py'
 

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -9,7 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OperationalMode, OrderSide
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.state_store import StateStore
 from nexus.infrastructure.strategy_event import StrategyEvent
@@ -281,6 +282,69 @@ class TestExternalIntegrationStubs:
         sequencer = _make_sequencer()
 
         sequencer._reconcile_capital()
+
+    def test_reconcile_capital_imports_praxis_only_position(self) -> None:
+        '''A Praxis position Nexus does not know about is imported into InstanceState.'''
+
+        praxis_pos = MagicMock()
+        praxis_pos.account_id = 'acc_001'
+        praxis_pos.trade_id = 'trade_xyz'
+        praxis_pos.symbol = 'BTCUSDT'
+        praxis_pos.side = OrderSide.BUY
+        praxis_pos.qty = Decimal('0.5')
+        praxis_pos.avg_entry_price = Decimal('50000')
+        praxis_pos.strategy_id = 'momentum'
+
+        outbound = MagicMock()
+        outbound.pull_positions.return_value = {
+            ('acc_001', 'trade_xyz'): praxis_pos,
+        }
+
+        sequencer = _make_sequencer()
+        sequencer._praxis_outbound = outbound
+        sequencer._account_id = 'acc_001'
+        sequencer._state = InstanceState(
+            capital=CapitalState(capital_pool=Decimal('10000')),
+        )
+
+        sequencer._reconcile_capital()
+
+        imported = sequencer._state.positions.get('trade_xyz')
+        assert imported is not None
+        assert imported.strategy_id == 'momentum'
+        assert imported.symbol == 'BTCUSDT'
+        assert imported.side == OrderSide.BUY
+        assert imported.size == Decimal('0.5')
+        assert imported.entry_price == Decimal('50000')
+        assert sequencer._state.capital.position_notional == Decimal('25000')
+
+    def test_reconcile_capital_skips_praxis_position_without_strategy_id(self) -> None:
+        '''Praxis positions lacking strategy_id are not imported.'''
+
+        praxis_pos = MagicMock()
+        praxis_pos.account_id = 'acc_001'
+        praxis_pos.trade_id = 'trade_xyz'
+        praxis_pos.symbol = 'BTCUSDT'
+        praxis_pos.side = OrderSide.BUY
+        praxis_pos.qty = Decimal('0.5')
+        praxis_pos.avg_entry_price = Decimal('50000')
+        praxis_pos.strategy_id = None
+
+        outbound = MagicMock()
+        outbound.pull_positions.return_value = {
+            ('acc_001', 'trade_xyz'): praxis_pos,
+        }
+
+        sequencer = _make_sequencer()
+        sequencer._praxis_outbound = outbound
+        sequencer._account_id = 'acc_001'
+        sequencer._state = InstanceState(
+            capital=CapitalState(capital_pool=Decimal('10000')),
+        )
+
+        sequencer._reconcile_capital()
+
+        assert 'trade_xyz' not in sequencer._state.positions
 
     def test_restore_strategy_state_without_path_logs_warning(self) -> None:
         sequencer = _make_sequencer()

--- a/tests/test_strategy_base.py
+++ b/tests/test_strategy_base.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from decimal import Decimal
+
 import pytest
 
-from nexus.strategy import Action, Strategy, StrategyContext, StrategyParams
-from nexus.strategy.signal import Signal
+from nexus.core.domain.enums import OperationalMode, OrderSide
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
+from nexus.strategy import Action, ActionType, Strategy, StrategyContext, StrategyParams
+from nexus.strategy.signal import Signal
 
 
 class ConcreteStrategy(Strategy):
@@ -244,15 +249,6 @@ class TestEventCallbacks:
     def test_callbacks_return_empty_list(self) -> None:
         '''Callbacks can return empty list.'''
 
-        from datetime import datetime, timezone
-        from decimal import Decimal
-
-        from nexus.core.domain.enums import OperationalMode
-        from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
-        from nexus.infrastructure.praxis_connector.trade_outcome_type import (
-            TradeOutcomeType,
-        )
-
         strategy = ConcreteStrategy('test')
         params = StrategyParams(raw={})
         ctx = StrategyContext(
@@ -281,11 +277,6 @@ class TestEventCallbacks:
     def test_callbacks_return_action_list(self) -> None:
         '''Callbacks can return list of Actions.'''
 
-        from decimal import Decimal
-
-        from nexus.core.domain.enums import OperationalMode
-        from nexus.strategy import ActionType
-
         class ActionReturningStrategy(Strategy):
             '''Strategy that returns actions from callbacks.'''
 
@@ -300,7 +291,7 @@ class TestEventCallbacks:
                 _params: StrategyParams,
                 _context: StrategyContext,
             ) -> list[Action]:
-                return [Action(action_type=ActionType.ENTER)]
+                return [Action(action_type=ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
 
             def on_signal(
                 self,
@@ -308,7 +299,7 @@ class TestEventCallbacks:
                 _params: StrategyParams,
                 _context: StrategyContext,
             ) -> list[Action]:
-                return [Action(action_type=ActionType.ENTER)]
+                return [Action(action_type=ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
 
             def on_outcome(
                 self,
@@ -316,7 +307,7 @@ class TestEventCallbacks:
                 _params: StrategyParams,
                 _context: StrategyContext,
             ) -> list[Action]:
-                return [Action(action_type=ActionType.EXIT)]
+                return [Action(action_type=ActionType.EXIT, trade_id='t-1', size=Decimal('1'))]
 
             def on_timer(
                 self,
@@ -324,14 +315,14 @@ class TestEventCallbacks:
                 _params: StrategyParams,
                 _context: StrategyContext,
             ) -> list[Action]:
-                return [Action(action_type=ActionType.MODIFY)]
+                return [Action(action_type=ActionType.MODIFY, trade_id='t-1')]
 
             def on_shutdown(
                 self,
                 _params: StrategyParams,
                 _context: StrategyContext,
             ) -> list[Action]:
-                return [Action(action_type=ActionType.ABORT)]
+                return [Action(action_type=ActionType.ABORT, trade_id='t-1')]
 
         strategy = ActionReturningStrategy('test')
         params = StrategyParams(raw={})

--- a/tests/test_strategy_base.py
+++ b/tests/test_strategy_base.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 import pytest
 
 from nexus.core.domain.enums import OperationalMode, OrderSide
+from nexus.core.domain.order_types import ExecutionMode, OrderType
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
 from nexus.strategy import Action, ActionType, Strategy, StrategyContext, StrategyParams
@@ -291,7 +292,7 @@ class TestEventCallbacks:
                 _params: StrategyParams,
                 _context: StrategyContext,
             ) -> list[Action]:
-                return [Action(action_type=ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
+                return [Action(action_type=ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode=ExecutionMode.SINGLE_SHOT, order_type=OrderType.MARKET, deadline=300)]
 
             def on_signal(
                 self,
@@ -299,7 +300,7 @@ class TestEventCallbacks:
                 _params: StrategyParams,
                 _context: StrategyContext,
             ) -> list[Action]:
-                return [Action(action_type=ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
+                return [Action(action_type=ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode=ExecutionMode.SINGLE_SHOT, order_type=OrderType.MARKET, deadline=300)]
 
             def on_outcome(
                 self,

--- a/tests/test_strategy_base.py
+++ b/tests/test_strategy_base.py
@@ -315,14 +315,14 @@ class TestEventCallbacks:
                 _params: StrategyParams,
                 _context: StrategyContext,
             ) -> list[Action]:
-                return [Action(action_type=ActionType.MODIFY, trade_id='t-1')]
+                return [Action(action_type=ActionType.MODIFY, command_id='cmd-1')]
 
             def on_shutdown(
                 self,
                 _params: StrategyParams,
                 _context: StrategyContext,
             ) -> list[Action]:
-                return [Action(action_type=ActionType.ABORT, trade_id='t-1')]
+                return [Action(action_type=ActionType.ABORT, command_id='cmd-1')]
 
         strategy = ActionReturningStrategy('test')
         params = StrategyParams(raw={})

--- a/tests/test_strategy_event_types.py
+++ b/tests/test_strategy_event_types.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 import pytest
 
 from nexus.core.domain.enums import OperationalMode, OrderSide
+from nexus.core.domain.order_types import ExecutionMode, OrderType
 from nexus.core.domain.position import Position
 from nexus.strategy import Action, ActionType, StrategyContext, StrategyParams
 from nexus.strategy.signal import Signal
@@ -253,8 +254,8 @@ class TestAction:
                 action_type=ActionType.ENTER,
                 direction=OrderSide.BUY,
                 size=Decimal('1'),
-                execution_mode='SingleShot',
-                order_type='Market',
+                execution_mode=ExecutionMode.SINGLE_SHOT,
+                order_type=OrderType.MARKET,
                 deadline=300,
             ),
             ActionType.EXIT: Action(

--- a/tests/test_strategy_event_types.py
+++ b/tests/test_strategy_event_types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -211,21 +211,17 @@ class TestSignal:
     def test_naive_timestamp_raises(self) -> None:
         '''Naive datetime raises ValueError.'''
 
-        from datetime import datetime as dt
-
         with pytest.raises(ValueError, match='must be UTC'):
             Signal(
                 predictor_fn_id='test',
                 values={'CAN_ENTER': 1},
-                timestamp=dt.now(),
+                timestamp=datetime.now(),
             )
 
     def test_non_utc_timestamp_rejected(self) -> None:
         '''Non-UTC timezone raises ValueError.'''
 
-        from datetime import datetime as dt, timedelta, timezone as tz
-
-        non_utc = dt(2024, 1, 1, 12, 0, 0, tzinfo=tz(timedelta(hours=5)))
+        non_utc = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
         with pytest.raises(ValueError, match='must be UTC'):
             Signal(
                 predictor_fn_id='test',
@@ -250,11 +246,33 @@ class TestAction:
     '''Tests for Action dataclass.'''
 
     def test_action_with_each_type(self) -> None:
-        '''Action constructs with each ActionType.'''
+        '''Action constructs with each ActionType and required fields.'''
 
-        for action_type in ActionType:
-            action = Action(action_type=action_type)
+        valid_actions = {
+            ActionType.ENTER: Action(
+                action_type=ActionType.ENTER,
+                direction=OrderSide.BUY,
+                size=Decimal('1'),
+                execution_mode='SingleShot',
+                order_type='Market',
+                deadline=300,
+            ),
+            ActionType.EXIT: Action(
+                action_type=ActionType.EXIT,
+                trade_id='t-1',
+                size=Decimal('1'),
+            ),
+            ActionType.MODIFY: Action(
+                action_type=ActionType.MODIFY,
+                trade_id='t-1',
+            ),
+            ActionType.ABORT: Action(
+                action_type=ActionType.ABORT,
+                trade_id='t-1',
+            ),
+        }
 
+        for action_type, action in valid_actions.items():
             assert action.action_type == action_type
 
     def test_action_type_must_be_actiontype(self) -> None:

--- a/tests/test_strategy_event_types.py
+++ b/tests/test_strategy_event_types.py
@@ -469,15 +469,43 @@ class TestAction:
                 reference_price=Decimal('0'),
             )
 
-    def test_execution_params_must_be_dict(self) -> None:
-        '''execution_params must be a dict when provided.'''
+    def test_execution_params_must_be_mapping(self) -> None:
+        '''execution_params must be a Mapping when provided.'''
 
-        with pytest.raises(ValueError, match='execution_params must be a dict'):
+        with pytest.raises(ValueError, match='execution_params must be a Mapping'):
             Action(
                 action_type=ActionType.ABORT,
                 command_id='cmd-1',
                 execution_params='not a dict',  # type: ignore[arg-type]
             )
+
+    def test_execution_params_defensive_copy(self) -> None:
+        '''Mutating the source dict after construction must not change the Action.'''
+
+        source: dict[str, object] = {'slippage_bps': 10}
+        action = Action(
+            action_type=ActionType.ABORT,
+            command_id='cmd-1',
+            execution_params=source,
+        )
+
+        source['slippage_bps'] = 999
+
+        assert action.execution_params is not None
+        assert action.execution_params['slippage_bps'] == 10
+
+    def test_execution_params_read_only(self) -> None:
+        '''The stored execution_params is read-only (MappingProxyType).'''
+
+        action = Action(
+            action_type=ActionType.ABORT,
+            command_id='cmd-1',
+            execution_params={'slippage_bps': 10},
+        )
+
+        assert action.execution_params is not None
+        with pytest.raises(TypeError):
+            action.execution_params['slippage_bps'] = 999  # type: ignore[index]
 
 
 class TestStrategyContext:

--- a/tests/test_strategy_event_types.py
+++ b/tests/test_strategy_event_types.py
@@ -312,6 +312,173 @@ class TestAction:
         with pytest.raises(ValueError, match='command_id must be a non-empty string or None'):
             Action(action_type=ActionType.ABORT, command_id='   ')
 
+    def test_enter_requires_direction(self) -> None:
+        '''ENTER raises when direction is missing.'''
+
+        with pytest.raises(ValueError, match=r'ENTER requires:.*direction'):
+            Action(
+                action_type=ActionType.ENTER,
+                size=Decimal('1'),
+                execution_mode=ExecutionMode.SINGLE_SHOT,
+                order_type=OrderType.MARKET,
+                deadline=300,
+            )
+
+    def test_enter_requires_size(self) -> None:
+        '''ENTER raises when size is missing.'''
+
+        with pytest.raises(ValueError, match=r'ENTER requires:.*size'):
+            Action(
+                action_type=ActionType.ENTER,
+                direction=OrderSide.BUY,
+                execution_mode=ExecutionMode.SINGLE_SHOT,
+                order_type=OrderType.MARKET,
+                deadline=300,
+            )
+
+    def test_enter_requires_execution_mode(self) -> None:
+        '''ENTER raises when execution_mode is missing.'''
+
+        with pytest.raises(ValueError, match=r'ENTER requires:.*execution_mode'):
+            Action(
+                action_type=ActionType.ENTER,
+                direction=OrderSide.BUY,
+                size=Decimal('1'),
+                order_type=OrderType.MARKET,
+                deadline=300,
+            )
+
+    def test_enter_requires_order_type(self) -> None:
+        '''ENTER raises when order_type is missing.'''
+
+        with pytest.raises(ValueError, match=r'ENTER requires:.*order_type'):
+            Action(
+                action_type=ActionType.ENTER,
+                direction=OrderSide.BUY,
+                size=Decimal('1'),
+                execution_mode=ExecutionMode.SINGLE_SHOT,
+                deadline=300,
+            )
+
+    def test_enter_requires_deadline(self) -> None:
+        '''ENTER raises when deadline is missing.'''
+
+        with pytest.raises(ValueError, match=r'ENTER requires:.*deadline'):
+            Action(
+                action_type=ActionType.ENTER,
+                direction=OrderSide.BUY,
+                size=Decimal('1'),
+                execution_mode=ExecutionMode.SINGLE_SHOT,
+                order_type=OrderType.MARKET,
+            )
+
+    def test_exit_requires_trade_id(self) -> None:
+        '''EXIT raises when trade_id is missing.'''
+
+        with pytest.raises(ValueError, match=r'EXIT requires:.*trade_id'):
+            Action(action_type=ActionType.EXIT, size=Decimal('1'))
+
+    def test_exit_requires_size(self) -> None:
+        '''EXIT raises when size is missing.'''
+
+        with pytest.raises(ValueError, match=r'EXIT requires:.*size'):
+            Action(action_type=ActionType.EXIT, trade_id='t-1')
+
+    def test_execution_mode_must_be_enum(self) -> None:
+        '''execution_mode must be an ExecutionMode member when provided.'''
+
+        with pytest.raises(ValueError, match='execution_mode must be an ExecutionMode'):
+            Action(
+                action_type=ActionType.ENTER,
+                direction=OrderSide.BUY,
+                size=Decimal('1'),
+                execution_mode='SINGLE_SHOT',  # type: ignore[arg-type]
+                order_type=OrderType.MARKET,
+                deadline=300,
+            )
+
+    def test_order_type_must_be_enum(self) -> None:
+        '''order_type must be an OrderType member when provided.'''
+
+        with pytest.raises(ValueError, match='order_type must be an OrderType'):
+            Action(
+                action_type=ActionType.ENTER,
+                direction=OrderSide.BUY,
+                size=Decimal('1'),
+                execution_mode=ExecutionMode.SINGLE_SHOT,
+                order_type='MARKET',  # type: ignore[arg-type]
+                deadline=300,
+            )
+
+    def test_maker_preference_must_be_enum(self) -> None:
+        '''maker_preference must be a MakerPreference member when provided.'''
+
+        with pytest.raises(ValueError, match='maker_preference must be a MakerPreference'):
+            Action(
+                action_type=ActionType.ABORT,
+                command_id='cmd-1',
+                maker_preference='NO_PREFERENCE',  # type: ignore[arg-type]
+            )
+
+    def test_direction_must_be_order_side(self) -> None:
+        '''direction must be an OrderSide member when provided.'''
+
+        with pytest.raises(ValueError, match='direction must be an OrderSide'):
+            Action(
+                action_type=ActionType.ENTER,
+                direction='BUY',  # type: ignore[arg-type]
+                size=Decimal('1'),
+                execution_mode=ExecutionMode.SINGLE_SHOT,
+                order_type=OrderType.MARKET,
+                deadline=300,
+            )
+
+    def test_size_must_be_positive_decimal(self) -> None:
+        '''size must be a finite positive Decimal when provided.'''
+
+        with pytest.raises(ValueError, match='size must be a finite positive Decimal'):
+            Action(
+                action_type=ActionType.ENTER,
+                direction=OrderSide.BUY,
+                size=Decimal('0'),
+                execution_mode=ExecutionMode.SINGLE_SHOT,
+                order_type=OrderType.MARKET,
+                deadline=300,
+            )
+
+    def test_deadline_must_be_positive_int(self) -> None:
+        '''deadline must be a positive int when provided.'''
+
+        with pytest.raises(ValueError, match='deadline must be a positive int'):
+            Action(
+                action_type=ActionType.ENTER,
+                direction=OrderSide.BUY,
+                size=Decimal('1'),
+                execution_mode=ExecutionMode.SINGLE_SHOT,
+                order_type=OrderType.MARKET,
+                deadline=0,
+            )
+
+    def test_reference_price_must_be_positive(self) -> None:
+        '''reference_price must be a finite positive Decimal when provided.'''
+
+        with pytest.raises(ValueError, match='reference_price must be a finite positive Decimal'):
+            Action(
+                action_type=ActionType.ABORT,
+                command_id='cmd-1',
+                reference_price=Decimal('0'),
+            )
+
+    def test_execution_params_must_be_dict(self) -> None:
+        '''execution_params must be a dict when provided.'''
+
+        with pytest.raises(ValueError, match='execution_params must be a dict'):
+            Action(
+                action_type=ActionType.ABORT,
+                command_id='cmd-1',
+                execution_params='not a dict',  # type: ignore[arg-type]
+            )
+
 
 class TestStrategyContext:
     '''Tests for StrategyContext dataclass.'''

--- a/tests/test_strategy_event_types.py
+++ b/tests/test_strategy_event_types.py
@@ -264,11 +264,11 @@ class TestAction:
             ),
             ActionType.MODIFY: Action(
                 action_type=ActionType.MODIFY,
-                trade_id='t-1',
+                command_id='cmd-1',
             ),
             ActionType.ABORT: Action(
                 action_type=ActionType.ABORT,
-                trade_id='t-1',
+                command_id='cmd-1',
             ),
         }
 
@@ -280,6 +280,36 @@ class TestAction:
 
         with pytest.raises(ValueError, match='must be an ActionType'):
             Action(action_type='enter')  # type: ignore[arg-type]
+
+    def test_modify_requires_command_id(self) -> None:
+        '''MODIFY raises when command_id is missing.'''
+
+        with pytest.raises(ValueError, match='MODIFY requires: command_id'):
+            Action(action_type=ActionType.MODIFY)
+
+    def test_abort_requires_command_id(self) -> None:
+        '''ABORT raises when command_id is missing.'''
+
+        with pytest.raises(ValueError, match='ABORT requires: command_id'):
+            Action(action_type=ActionType.ABORT)
+
+    def test_modify_rejects_trade_id_only(self) -> None:
+        '''MODIFY without command_id raises even when trade_id is provided.'''
+
+        with pytest.raises(ValueError, match='MODIFY requires: command_id'):
+            Action(action_type=ActionType.MODIFY, trade_id='t-1')
+
+    def test_abort_rejects_trade_id_only(self) -> None:
+        '''ABORT without command_id raises even when trade_id is provided.'''
+
+        with pytest.raises(ValueError, match='ABORT requires: command_id'):
+            Action(action_type=ActionType.ABORT, trade_id='t-1')
+
+    def test_command_id_must_be_non_empty_string(self) -> None:
+        '''command_id must be a non-empty string when provided.'''
+
+        with pytest.raises(ValueError, match='command_id must be a non-empty string or None'):
+            Action(action_type=ActionType.ABORT, command_id='   ')
 
 
 class TestStrategyContext:

--- a/tests/test_strategy_executor.py
+++ b/tests/test_strategy_executor.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 import pytest
 
 from nexus.core.domain.enums import OperationalMode, OrderSide
+from nexus.core.domain.order_types import ExecutionMode, OrderType
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
 from nexus.infrastructure.strategy_event import StrategyEvent
@@ -41,7 +42,7 @@ class StubStrategy(Strategy):
         if self.delay:
             time.sleep(self.delay)
         self.calls.append('on_startup')
-        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
+        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode=ExecutionMode.SINGLE_SHOT, order_type=OrderType.MARKET, deadline=300)]
 
     def on_signal(
         self,
@@ -52,7 +53,7 @@ class StubStrategy(Strategy):
         if self.delay:
             time.sleep(self.delay)
         self.calls.append('on_signal')
-        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
+        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode=ExecutionMode.SINGLE_SHOT, order_type=OrderType.MARKET, deadline=300)]
 
     def on_outcome(
         self,

--- a/tests/test_strategy_executor.py
+++ b/tests/test_strategy_executor.py
@@ -84,7 +84,7 @@ class StubStrategy(Strategy):
         if self.delay:
             time.sleep(self.delay)
         self.calls.append('on_shutdown')
-        return [Action(ActionType.ABORT, trade_id='t-1')]
+        return [Action(ActionType.ABORT, command_id='cmd-1')]
 
     def on_event_replay(self, event: StrategyEvent) -> None:
         self.calls.append('on_event_replay')

--- a/tests/test_strategy_executor.py
+++ b/tests/test_strategy_executor.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 
 import pytest
 
-from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.enums import OperationalMode, OrderSide
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
 from nexus.infrastructure.strategy_event import StrategyEvent
@@ -41,7 +41,7 @@ class StubStrategy(Strategy):
         if self.delay:
             time.sleep(self.delay)
         self.calls.append('on_startup')
-        return [Action(ActionType.ENTER)]
+        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
 
     def on_signal(
         self,
@@ -52,7 +52,7 @@ class StubStrategy(Strategy):
         if self.delay:
             time.sleep(self.delay)
         self.calls.append('on_signal')
-        return [Action(ActionType.ENTER)]
+        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
 
     def on_outcome(
         self,
@@ -63,7 +63,7 @@ class StubStrategy(Strategy):
         if self.delay:
             time.sleep(self.delay)
         self.calls.append('on_outcome')
-        return [Action(ActionType.EXIT)]
+        return [Action(ActionType.EXIT, trade_id='t-1', size=Decimal('1'))]
 
     def on_timer(
         self,
@@ -84,7 +84,7 @@ class StubStrategy(Strategy):
         if self.delay:
             time.sleep(self.delay)
         self.calls.append('on_shutdown')
-        return [Action(ActionType.ABORT)]
+        return [Action(ActionType.ABORT, trade_id='t-1')]
 
     def on_event_replay(self, event: StrategyEvent) -> None:
         self.calls.append('on_event_replay')

--- a/tests/test_strategy_runner.py
+++ b/tests/test_strategy_runner.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 import pytest
 
-from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.enums import OperationalMode, OrderSide
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
 from nexus.infrastructure.strategy_event import StrategyEvent
@@ -37,7 +37,7 @@ class StubStrategy(Strategy):
         _context: StrategyContext,
     ) -> list[Action]:
         self.calls.append('on_startup')
-        return [Action(ActionType.ENTER)]
+        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
 
     def on_signal(
         self,
@@ -46,7 +46,7 @@ class StubStrategy(Strategy):
         _context: StrategyContext,
     ) -> list[Action]:
         self.calls.append('on_signal')
-        return [Action(ActionType.ENTER)]
+        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
 
     def on_outcome(
         self,
@@ -55,7 +55,7 @@ class StubStrategy(Strategy):
         _context: StrategyContext,
     ) -> list[Action]:
         self.calls.append('on_outcome')
-        return [Action(ActionType.EXIT)]
+        return [Action(ActionType.EXIT, trade_id='t-1', size=Decimal('1'))]
 
     def on_timer(
         self,
@@ -72,7 +72,7 @@ class StubStrategy(Strategy):
         _context: StrategyContext,
     ) -> list[Action]:
         self.calls.append('on_shutdown')
-        return [Action(ActionType.ABORT)]
+        return [Action(ActionType.ABORT, trade_id='t-1')]
 
     def on_event_replay(self, event: StrategyEvent) -> None:
         self.calls.append('on_event_replay')

--- a/tests/test_strategy_runner.py
+++ b/tests/test_strategy_runner.py
@@ -72,7 +72,7 @@ class StubStrategy(Strategy):
         _context: StrategyContext,
     ) -> list[Action]:
         self.calls.append('on_shutdown')
-        return [Action(ActionType.ABORT, trade_id='t-1')]
+        return [Action(ActionType.ABORT, command_id='cmd-1')]
 
     def on_event_replay(self, event: StrategyEvent) -> None:
         self.calls.append('on_event_replay')

--- a/tests/test_strategy_runner.py
+++ b/tests/test_strategy_runner.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 import pytest
 
 from nexus.core.domain.enums import OperationalMode, OrderSide
+from nexus.core.domain.order_types import ExecutionMode, OrderType
 from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
 from nexus.infrastructure.praxis_connector.trade_outcome_type import TradeOutcomeType
 from nexus.infrastructure.strategy_event import StrategyEvent
@@ -37,7 +38,7 @@ class StubStrategy(Strategy):
         _context: StrategyContext,
     ) -> list[Action]:
         self.calls.append('on_startup')
-        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
+        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode=ExecutionMode.SINGLE_SHOT, order_type=OrderType.MARKET, deadline=300)]
 
     def on_signal(
         self,
@@ -46,7 +47,7 @@ class StubStrategy(Strategy):
         _context: StrategyContext,
     ) -> list[Action]:
         self.calls.append('on_signal')
-        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode='SingleShot', order_type='Market', deadline=300)]
+        return [Action(ActionType.ENTER, direction=OrderSide.BUY, size=Decimal('1'), execution_mode=ExecutionMode.SINGLE_SHOT, order_type=OrderType.MARKET, deadline=300)]
 
     def on_outcome(
         self,

--- a/tests/test_timer_loop.py
+++ b/tests/test_timer_loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock
@@ -122,7 +123,6 @@ class TestTimerLoop:
 
         runner.dispatch_timer.reset_mock()
 
-        import time
         time.sleep(1.5)
 
         assert not runner.dispatch_timer.called

--- a/tests/test_trade_command.py
+++ b/tests/test_trade_command.py
@@ -452,3 +452,50 @@ def test_cancel_order_with_size_rejected() -> None:
             created_at=_now(),
             size=Decimal('0.01'),
         )
+
+
+def test_execution_params_defensive_copy() -> None:
+    '''TradeCommand stores a defensive copy of execution_params.'''
+
+    source: dict[str, object] = {'slippage_bps': 10}
+    cmd = TradeCommand(
+        command_id='cmd_001',
+        command_type=TradeCommandType.NEW_ORDER,
+        account_id='acc_001',
+        venue='binance_spot',
+        symbol='BTCUSDT',
+        notional=Decimal('1000'),
+        created_at=_now(),
+        side=OrderSide.BUY,
+        size=Decimal('0.01'),
+        stp_mode=STPMode.CANCEL_TAKER,
+        execution_params=source,
+    )
+
+    source['slippage_bps'] = 999
+
+    assert cmd.execution_params is not None
+    assert cmd.execution_params['slippage_bps'] == 10
+
+
+def test_execution_params_read_only() -> None:
+    '''Stored execution_params is a read-only mapping.'''
+
+    cmd = TradeCommand(
+        command_id='cmd_001',
+        command_type=TradeCommandType.NEW_ORDER,
+        account_id='acc_001',
+        venue='binance_spot',
+        symbol='BTCUSDT',
+        notional=Decimal('1000'),
+        created_at=_now(),
+        side=OrderSide.BUY,
+        size=Decimal('0.01'),
+        stp_mode=STPMode.CANCEL_TAKER,
+        execution_params={'slippage_bps': 10},
+    )
+
+    assert cmd.execution_params is not None
+    with pytest.raises(TypeError):
+        cmd.execution_params['slippage_bps'] = 999  # type: ignore[index]
+

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -324,6 +324,32 @@ def test_denied_decision_rejected() -> None:
         translate_to_trade_command(action, context, decision, config, now)
 
 
+def test_enter_translation_propagates_none_defaults() -> None:
+    '''An ENTER Action with only required fields yields a TradeCommand with None optionals.'''
+
+    minimal_action = Action(
+        action_type=ActionType.ENTER,
+        direction=OrderSide.BUY,
+        size=Decimal('0.01'),
+        execution_mode=ExecutionMode.SINGLE_SHOT,
+        order_type=OrderType.MARKET,
+        deadline=300,
+    )
+    context = _enter_context()
+    decision = ValidationDecision(allowed=True, reservation=_reservation())
+    config = _config()
+    now = _now()
+
+    cmd = translate_to_trade_command(minimal_action, context, decision, config, now)
+
+    assert cmd.maker_preference is None
+    assert cmd.reference_price is None
+    assert cmd.execution_params is None
+    assert cmd.execution_mode == ExecutionMode.SINGLE_SHOT
+    assert cmd.order_type == OrderType.MARKET
+    assert cmd.deadline == 300
+
+
 def test_missing_command_id_rejected() -> None:
     action = _exit_action()
     context = ValidationRequestContext(

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -7,8 +7,10 @@ from decimal import Decimal
 
 import pytest
 
+from nexus.core.capital_controller.reservation import Reservation
 from nexus.core.domain.enums import OrderSide
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.order_types import ExecutionMode, MakerPreference, OrderType
 from nexus.core.stp_mode import STPMode
 from nexus.core.validator.pipeline_models import (
     ValidationAction,
@@ -16,10 +18,10 @@ from nexus.core.validator.pipeline_models import (
     ValidationRequestContext,
     ValidationStage,
 )
-from nexus.core.capital_controller.reservation import Reservation
 from nexus.infrastructure.praxis_connector.trade_command_type import TradeCommandType
 from nexus.infrastructure.praxis_connector.translate import translate_to_trade_command
 from nexus.instance_config import InstanceConfig
+from nexus.strategy.action import Action, ActionType
 
 
 def _config(stp_mode: STPMode = STPMode.CANCEL_TAKER) -> InstanceConfig:
@@ -49,6 +51,40 @@ def _reservation() -> Reservation:
         created_at=now,
         expires_at=now + timedelta(minutes=1),
     )
+
+
+def _enter_action() -> Action:
+    return Action(
+        action_type=ActionType.ENTER,
+        direction=OrderSide.BUY,
+        size=Decimal('0.01'),
+        execution_mode=ExecutionMode.SINGLE_SHOT,
+        order_type=OrderType.MARKET,
+        deadline=300,
+        maker_preference=MakerPreference.NO_PREFERENCE,
+        reference_price=Decimal('100000'),
+        execution_params={'foo': 'bar'},
+    )
+
+
+def _exit_action() -> Action:
+    return Action(
+        action_type=ActionType.EXIT,
+        trade_id='trade_001',
+        size=Decimal('0.01'),
+    )
+
+
+def _modify_action() -> Action:
+    return Action(action_type=ActionType.MODIFY, command_id='cmd_003')
+
+
+def _abort_action() -> Action:
+    return Action(action_type=ActionType.ABORT, command_id='cmd_004')
+
+
+def _cancel_action() -> Action:
+    return Action(action_type=ActionType.ABORT, command_id='cmd_005')
 
 
 def _enter_context() -> ValidationRequestContext:
@@ -128,12 +164,13 @@ def _cancel_context() -> ValidationRequestContext:
 
 
 def test_enter_translation() -> None:
+    action = _enter_action()
     context = _enter_context()
     decision = ValidationDecision(allowed=True, reservation=_reservation())
     config = _config()
     now = _now()
 
-    cmd = translate_to_trade_command(context, decision, config, now)
+    cmd = translate_to_trade_command(action, context, decision, config, now)
 
     assert cmd.command_type == TradeCommandType.NEW_ORDER
     assert cmd.command_id == 'cmd_001'
@@ -146,15 +183,22 @@ def test_enter_translation() -> None:
     assert cmd.stp_mode == STPMode.CANCEL_TAKER
     assert cmd.reservation_id == 'res_001'
     assert cmd.created_at == now
+    assert cmd.execution_mode == ExecutionMode.SINGLE_SHOT
+    assert cmd.order_type == OrderType.MARKET
+    assert cmd.deadline == 300
+    assert cmd.maker_preference == MakerPreference.NO_PREFERENCE
+    assert cmd.reference_price == Decimal('100000')
+    assert cmd.execution_params == {'foo': 'bar'}
 
 
 def test_exit_translation() -> None:
+    action = _exit_action()
     context = _exit_context()
     decision = ValidationDecision(allowed=True)
     config = _config(stp_mode=STPMode.CANCEL_MAKER)
     now = _now()
 
-    cmd = translate_to_trade_command(context, decision, config, now)
+    cmd = translate_to_trade_command(action, context, decision, config, now)
 
     assert cmd.command_type == TradeCommandType.NEW_ORDER
     assert cmd.side == OrderSide.SELL
@@ -164,12 +208,13 @@ def test_exit_translation() -> None:
 
 
 def test_modify_translation() -> None:
+    action = _modify_action()
     context = _modify_context()
     decision = ValidationDecision(allowed=True)
     config = _config()
     now = _now()
 
-    cmd = translate_to_trade_command(context, decision, config, now)
+    cmd = translate_to_trade_command(action, context, decision, config, now)
 
     assert cmd.command_type == TradeCommandType.AMEND_ORDER
     assert cmd.command_id == 'cmd_003'
@@ -177,28 +222,39 @@ def test_modify_translation() -> None:
     assert cmd.side is None
     assert cmd.size is None
     assert cmd.stp_mode is None
+    assert cmd.execution_mode is None
+    assert cmd.order_type is None
+    assert cmd.execution_params is None
+    assert cmd.deadline is None
+    assert cmd.maker_preference is None
+    assert cmd.reference_price is None
 
 
 def test_abort_translation() -> None:
+    action = _abort_action()
     context = _abort_context()
     decision = ValidationDecision(allowed=True)
     config = _config()
     now = _now()
 
-    cmd = translate_to_trade_command(context, decision, config, now)
+    cmd = translate_to_trade_command(action, context, decision, config, now)
 
     assert cmd.command_type == TradeCommandType.CANCEL_ORDER
     assert cmd.command_id == 'cmd_004'
     assert cmd.stp_mode is None
+    assert cmd.execution_mode is None
+    assert cmd.order_type is None
+    assert cmd.maker_preference is None
 
 
 def test_cancel_translation() -> None:
+    action = _cancel_action()
     context = _cancel_context()
     decision = ValidationDecision(allowed=True)
     config = _config()
     now = _now()
 
-    cmd = translate_to_trade_command(context, decision, config, now)
+    cmd = translate_to_trade_command(action, context, decision, config, now)
 
     assert cmd.command_type == TradeCommandType.CANCEL_ORDER
     assert cmd.command_id == 'cmd_005'
@@ -206,49 +262,54 @@ def test_cancel_translation() -> None:
 
 
 def test_naive_datetime_rejected() -> None:
+    action = _enter_action()
     context = _enter_context()
     decision = ValidationDecision(allowed=True, reservation=_reservation())
     config = _config()
     now = datetime.now()
 
     with pytest.raises(ValueError, match='requires UTC'):
-        translate_to_trade_command(context, decision, config, now)
+        translate_to_trade_command(action, context, decision, config, now)
 
 
 def test_non_utc_datetime_rejected() -> None:
+    action = _enter_action()
     context = _enter_context()
     decision = ValidationDecision(allowed=True, reservation=_reservation())
     config = _config()
     non_utc = datetime(2026, 3, 25, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
 
     with pytest.raises(ValueError, match='requires UTC'):
-        translate_to_trade_command(context, decision, config, non_utc)
+        translate_to_trade_command(action, context, decision, config, non_utc)
 
 
 def test_deterministic_output() -> None:
+    action = _enter_action()
     context = _enter_context()
     decision = ValidationDecision(allowed=True, reservation=_reservation())
     config = _config()
     now = datetime(2026, 3, 25, 12, 0, 0, tzinfo=timezone.utc)
 
-    cmd1 = translate_to_trade_command(context, decision, config, now)
-    cmd2 = translate_to_trade_command(context, decision, config, now)
+    cmd1 = translate_to_trade_command(action, context, decision, config, now)
+    cmd2 = translate_to_trade_command(action, context, decision, config, now)
 
     assert cmd1 == cmd2
 
 
 def test_stp_mode_from_config() -> None:
+    action = _enter_action()
     context = _enter_context()
     decision = ValidationDecision(allowed=True, reservation=_reservation())
     now = _now()
 
     for mode in STPMode:
         config = _config(stp_mode=mode)
-        cmd = translate_to_trade_command(context, decision, config, now)
+        cmd = translate_to_trade_command(action, context, decision, config, now)
         assert cmd.stp_mode == mode
 
 
 def test_denied_decision_rejected() -> None:
+    action = _enter_action()
     context = _enter_context()
     decision = ValidationDecision(
         allowed=False,
@@ -260,10 +321,11 @@ def test_denied_decision_rejected() -> None:
     now = _now()
 
     with pytest.raises(ValueError, match='decision must be allowed'):
-        translate_to_trade_command(context, decision, config, now)
+        translate_to_trade_command(action, context, decision, config, now)
 
 
 def test_missing_command_id_rejected() -> None:
+    action = _exit_action()
     context = ValidationRequestContext(
         strategy_id='strat_001',
         action=ValidationAction.EXIT,
@@ -283,4 +345,4 @@ def test_missing_command_id_rejected() -> None:
     now = _now()
 
     with pytest.raises(ValueError, match='non-empty command_id'):
-        translate_to_trade_command(context, decision, config, now)
+        translate_to_trade_command(action, context, decision, config, now)

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -207,6 +207,26 @@ def test_exit_translation() -> None:
     assert cmd.reservation_id is None
 
 
+def test_exit_translation_fills_submission_defaults() -> None:
+    '''EXIT action without execution_mode/order_type/deadline gets safe defaults.'''
+
+    action = _exit_action()
+    context = _exit_context()
+    decision = ValidationDecision(allowed=True)
+    config = _config()
+    now = _now()
+
+    assert action.execution_mode is None
+    assert action.order_type is None
+    assert action.deadline is None
+
+    cmd = translate_to_trade_command(action, context, decision, config, now)
+
+    assert cmd.execution_mode == ExecutionMode.SINGLE_SHOT
+    assert cmd.order_type == OrderType.MARKET
+    assert cmd.deadline == 60
+
+
 def test_modify_translation() -> None:
     action = _modify_action()
     context = _modify_context()

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import cast
 
+import msgpack
 import pytest
 
 from nexus.core.domain.capital_state import CapitalState
@@ -267,19 +268,12 @@ class TestCodecVersioning:
     def test_unsupported_version_rejected(self) -> None:
         '''Verify deserialize rejects unknown codec version.'''
 
-        import msgpack
-
         bad_data = cast(bytes, msgpack.packb({'_v': 999}))
         with pytest.raises(ValueError, match='Unsupported WAL codec version'):
             deserialize_state(bad_data)
 
     def test_missing_version_defaults_to_v1(self) -> None:
         '''Verify deserialize treats missing _v as v1 for backward compatibility.'''
-
-        import msgpack
-
-        from nexus.core.domain.capital_state import CapitalState
-        from nexus.core.domain.instance_state import InstanceState
 
         state = InstanceState(capital=CapitalState(capital_pool=Decimal('10000')))
         v1_data = cast(bytes, serialize_state(state))
@@ -297,8 +291,6 @@ class TestRiskDecodeDefaults:
 
     def test_missing_risk_fields_seed_from_high_water_mark(self) -> None:
         '''Verify missing risk fields default from high_water_mark.'''
-
-        import msgpack
 
         payload = {
             '_v': 1,
@@ -342,8 +334,6 @@ class TestMalformedPayload:
     def test_non_dict_payload_raises(self) -> None:
         '''Verify non-dict msgpack payload raises ValueError.'''
 
-        import msgpack
-
         bad_data = cast(bytes, msgpack.packb([1, 2, 3]))
 
         with pytest.raises(ValueError, match='Expected dict from WAL payload'):
@@ -351,8 +341,6 @@ class TestMalformedPayload:
 
     def test_invalid_decimal_in_risk_payload_raises(self) -> None:
         '''Verify malformed Decimal risk field raises normalized ValueError.'''
-
-        import msgpack
 
         payload = {
             '_v': 1,
@@ -402,8 +390,6 @@ class TestSerializationOutput:
 
     def test_output_is_valid_msgpack(self) -> None:
         '''Verify serialized bytes are valid msgpack.'''
-
-        import msgpack
 
         state = _make_minimal_state()
         result = serialize_state(state)
@@ -464,15 +450,11 @@ class TestEventRoundTrip:
 
 class TestEventCodecVersion:
     def test_version_embedded(self) -> None:
-        import msgpack
-
         data = serialize_event(_make_event())
         unpacked = msgpack.unpackb(data, raw=False)
         assert unpacked['_v'] == 1
 
     def test_wrong_version_rejected(self) -> None:
-        import msgpack
-
         d = {
             '_v': 99,
             'strategy_id': 'strat_a',
@@ -488,16 +470,12 @@ class TestEventCodecVersion:
 
 class TestEventMalformedPayload:
     def test_non_dict_rejected(self) -> None:
-        import msgpack
-
         data = cast(bytes, msgpack.packb([1, 2, 3]))
 
         with pytest.raises(ValueError, match='Expected dict from event payload'):
             deserialize_event(data)
 
     def test_missing_field_rejected(self) -> None:
-        import msgpack
-
         d = {'_v': 1, 'strategy_id': 'strat_a'}
         data = cast(bytes, msgpack.packb(d))
 
@@ -505,8 +483,6 @@ class TestEventMalformedPayload:
             deserialize_event(data)
 
     def test_invalid_decimal_rejected(self) -> None:
-        import msgpack
-
         d = {
             '_v': 1,
             'strategy_id': 'strat_a',
@@ -520,8 +496,6 @@ class TestEventMalformedPayload:
             deserialize_event(data)
 
     def test_invalid_timestamp_rejected(self) -> None:
-        import msgpack
-
         d = {
             '_v': 1,
             'strategy_id': 'strat_a',
@@ -545,8 +519,6 @@ class TestEventSerializationOutput:
         assert len(result) > 0
 
     def test_output_is_valid_msgpack(self) -> None:
-        import msgpack
-
         result = serialize_event(_make_event())
         unpacked = msgpack.unpackb(result, raw=False)
         assert isinstance(unpacked, dict)

--- a/tests/test_wire_sensors.py
+++ b/tests/test_wire_sensors.py
@@ -8,13 +8,13 @@ from decimal import Decimal
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import numpy as np
 import pytest
 
 from nexus.infrastructure.state_store import StateStore
 from nexus.startup import StartupError, StartupSequencer
 
 limen = pytest.importorskip('limen')
+np = pytest.importorskip('numpy')
 
 
 def _find_limen_root() -> Path | None:

--- a/tests/test_wire_sensors.py
+++ b/tests/test_wire_sensors.py
@@ -8,19 +8,19 @@ from decimal import Decimal
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 from nexus.infrastructure.state_store import StateStore
 from nexus.startup import StartupError, StartupSequencer
 
+limen = pytest.importorskip('limen')
+
+
 def _find_limen_root() -> Path | None:
-    try:
-        import limen
-        root = Path(limen.__file__).parent.parent
-        if (root / 'datasets').is_dir():
-            return root
-    except ImportError:
-        pass
+    root = Path(limen.__file__).parent.parent
+    if (root / 'datasets').is_dir():
+        return root
     return None
 
 
@@ -179,8 +179,6 @@ class TestWireSensors:
         sequencer._load_manifest()
         sequencer._instantiate_strategies()
         sequencer._wire_sensors()
-
-        import numpy as np
 
         wired = sequencer.wired_sensors[0]
         result = wired.sensor.predict({'x_test': np.array([[1, 2, 3]])})


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Implements the strategy → trade execution path end-to-end (TD-023), the Praxis-only position import (TD-024), and the live health-snapshot consumer (TD-026). Issue #36 covers all three.

**TD-023 — Action dataclass trade fields and submission wiring:**

- `Action` (`nexus/strategy/action.py`) gains `direction`, `size`, `execution_mode`, `order_type`, `execution_params`, `deadline`, `trade_id`, `command_id`, `maker_preference`, `reference_price` per RFC §Action Parameters; per-action_type required-field validation in `__post_init__` via `_validate_action_type_requirements()`. Per RFC-3001 Stage 1: EXIT requires `trade_id`; MODIFY/ABORT require `command_id`.
- New `nexus/core/domain/order_types.py` mirrors Praxis enums: `ExecutionMode`, `OrderType`, `MakerPreference`. `Action` is retyped from free strings to these enums.
- `TradeCommand` extended with `execution_mode`, `order_type`, `execution_params`, `deadline`, `maker_preference`, `reference_price`; AMEND/CANCEL invariants enforce these are absent. `translate_to_trade_command` now takes an `Action` and populates the fields on NEW_ORDER.
- `PraxisOutbound.send_command` wires the real `order_type` / `execution_mode` / `execution_params` / `maker_preference` / `reference_price` from the TradeCommand instead of placeholder `None` values.
- `PraxisOutbound.send_abort` wraps Praxis `Trading.submit_abort` via `asyncio.run_coroutine_threadsafe` (new `submit_abort_fn` parameter).
- `ShutdownSequencer._submit_actions` translates EXIT actions through `translate_to_trade_command` and submits via `send_command`; ABORT actions submit via `send_abort` with reason `'shutdown'`. Returned command_ids stored in `_submitted_command_ids`. New optional `config: InstanceConfig` parameter on `ShutdownSequencer`.
- `ShutdownSequencer._wait_terminal` now escalates aborts on first-round timeout: sends ABORT for each pending command (reason `'shutdown_escalation'`) and re-polls with half the original `shutdown_timeout` before giving up. Refactored into `_poll_until_terminal` and `_escalate_abort_pending`.
- Renamed `_validate_required_fields` → `_validate_action_type_requirements` to reflect that field-shape validation already happened earlier in `__post_init__`.

**TD-024 — Praxis-only position import:**

- `StartupSequencer._reconcile_capital` now reconstructs a Nexus `Position` for any trade that exists in Praxis but not in Nexus (typical after Nexus state loss while Praxis still holds positions). `_resolve_imported_position_fields` handles strategy_id / symbol / side extraction; missing or invalid required fields are logged and skipped.

**TD-026 — Health snapshot consumer:**

- `PraxisOutbound.get_health_snapshot(account_id)` wraps Praxis `Trading.get_health_snapshot` via `asyncio.run_coroutine_threadsafe` (new `get_health_snapshot_fn` parameter). Documented as intentionally lifecycle-loose: account need not be ready.
- New `nexus/core/health_loop.py::HealthLoop` periodically pulls a `HealthSnapshot` from a configurable provider, evaluates via `HealthEvaluator`, and replaces `instance_state.mode` atomically (single `ModeState(...)` assignment) on transition. Provider/evaluator exceptions are logged-and-swallowed so a flaky source does not kill the loop. `start` is idempotent; `tick_once()` is exposed for synchronous callers.

**Hygiene:**

- All inline imports across `nexus/` and `tests/` promoted to top-of-file.

**Stats:** +1034 tests pass, 62 added across new and updated modules.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (51 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable

Refs #36 (TD-023.1–.7, TD-024.1–.2, TD-026.1–.3)
