### PR TITLE
feat: move account_id and allocated_capital into Manifest 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,8 +305,8 @@
 ## v0.28.0 on 19th of April, 2026
 
 - BREAKING: Move instance identity and capital ceiling into the strategy manifest. `Manifest` gains required `account_id: str` and `allocated_capital: Decimal` fields, with internal validation that `capital_pool ≤ allocated_capital`. Manifest YAML files must now declare `account_id:` and `allocated_capital:` alongside the existing `capital_pool:` and `strategies:` blocks
-- BREAKING: `load_manifest(path)` — drop the `allocated_capital` parameter; the ceiling is sourced from the manifest itself
-- BREAKING: [`StartupSequencer`](nexus/startup/sequencer.py) drops `allocated_capital` and `account_id` constructor parameters. Both are derived from the loaded manifest at runtime
+- BREAKING: Drop the `allocated_capital` parameter from `load_manifest(path)`; the ceiling is sourced from the manifest itself
+- BREAKING: Drop `allocated_capital` and `account_id` constructor parameters from [`StartupSequencer`](nexus/startup/sequencer.py); both are derived from the loaded manifest at runtime
 - Reorder startup sequence to call `_load_manifest` first (was step 4); `_recover_state`, `_register_with_trading`, and `_reconcile_capital` all read identity and capital from `self._manifest`
 - BREAKING: Remove `allocated_capital` field from [`InstanceConfig`](nexus/instance_config.py) — the ceiling no longer belongs in runtime/validator config, it is per-account manifest state
 - Rename `InstanceState.from_config(config)` → [`InstanceState.fresh(allocated_capital)`](nexus/core/domain/instance_state.py) — the factory never needed `config`, only the ceiling; drops the unused `InstanceConfig` dependency from `nexus.core.domain`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,3 +301,14 @@
 - Add [`health_loop.py`](nexus/core/health_loop.py) with `HealthLoop` — periodic timer pulls a `HealthSnapshot` from a configurable provider, evaluates via `HealthEvaluator`, and updates `instance_state.mode` on transition. Provider/evaluator exceptions are logged-and-swallowed; `start` is idempotent; `tick_once()` exposed for synchronous callers (TD-026.2)
 - Rename `_validate_required_fields` to `_validate_action_type_requirements` in `Action` (existing per-action_type checks; the rename reflects that field-shape validation already happened earlier in `__post_init__`)
 - Add 62 tests across new and updated modules (1034 total)
+
+## v0.28.0 on 19th of April, 2026
+
+- BREAKING: Move instance identity and capital ceiling into the strategy manifest. `Manifest` gains required `account_id: str` and `allocated_capital: Decimal` fields, with internal validation that `capital_pool ≤ allocated_capital`. Manifest YAML files must now declare `account_id:` and `allocated_capital:` alongside the existing `capital_pool:` and `strategies:` blocks
+- BREAKING: `load_manifest(path)` — drop the `allocated_capital` parameter; the ceiling is sourced from the manifest itself
+- BREAKING: [`StartupSequencer`](nexus/startup/sequencer.py) drops `allocated_capital` and `account_id` constructor parameters. Both are derived from the loaded manifest at runtime
+- Reorder startup sequence to call `_load_manifest` first (was step 4); `_recover_state`, `_register_with_trading`, and `_reconcile_capital` all read identity and capital from `self._manifest`
+- BREAKING: Remove `allocated_capital` field from [`InstanceConfig`](nexus/instance_config.py) — the ceiling no longer belongs in runtime/validator config, it is per-account manifest state
+- Rename `InstanceState.from_config(config)` → [`InstanceState.fresh(allocated_capital)`](nexus/core/domain/instance_state.py) — the factory never needed `config`, only the ceiling; drops the unused `InstanceConfig` dependency from `nexus.core.domain`
+- Update manifest YAML fixtures, direct `Manifest(...)` constructions, `InstanceConfig(...)` callers, and `InstanceState.fresh(...)` callers across all tests
+- Add `load_manifest` validation tests for missing / invalid / non-positive `allocated_capital` and for blank `account_id`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,6 @@
 - BREAKING: Drop `allocated_capital` and `account_id` constructor parameters from [`StartupSequencer`](nexus/startup/sequencer.py); both are derived from the loaded manifest at runtime
 - Reorder startup sequence to call `_load_manifest` first (was step 4); `_recover_state`, `_register_with_trading`, and `_reconcile_capital` all read identity and capital from `self._manifest`
 - BREAKING: Remove `allocated_capital` field from [`InstanceConfig`](nexus/instance_config.py) — the ceiling no longer belongs in runtime/validator config, it is per-account manifest state
-- Rename `InstanceState.from_config(config)` → [`InstanceState.fresh(allocated_capital)`](nexus/core/domain/instance_state.py) — the factory never needed `config`, only the ceiling; drops the unused `InstanceConfig` dependency from `nexus.core.domain`
+- Rename `InstanceState.from_config(config)` → [`InstanceState.fresh(capital_pool)`](nexus/core/domain/instance_state.py) — the factory seeds `CapitalState.capital_pool` from `Manifest.capital_pool` (the operational allocation), not `Manifest.allocated_capital` (the infrastructure ceiling); drops the unused `InstanceConfig` dependency from `nexus.core.domain`
 - Update manifest YAML fixtures, direct `Manifest(...)` constructions, `InstanceConfig(...)` callers, and `InstanceState.fresh(...)` callers across all tests
 - Add `load_manifest` validation tests for missing / invalid / non-positive `allocated_capital` and for blank `account_id`

--- a/nexus/core/domain/instance_state.py
+++ b/nexus/core/domain/instance_state.py
@@ -71,7 +71,18 @@ class InstanceState:
 
         Returns:
             Fresh InstanceState with capital pool set and everything else zeroed.
+
+        Raises:
+            ValueError: If `capital_pool` is not a finite positive Decimal.
         '''
+
+        if not isinstance(capital_pool, Decimal) or not capital_pool.is_finite():
+            msg = 'InstanceState.fresh(capital_pool) must receive a finite Decimal'
+            raise ValueError(msg)
+
+        if capital_pool <= 0:
+            msg = 'InstanceState.fresh(capital_pool) must receive a positive value'
+            raise ValueError(msg)
 
         return cls(
             capital=CapitalState(capital_pool=capital_pool),

--- a/nexus/core/domain/instance_state.py
+++ b/nexus/core/domain/instance_state.py
@@ -1,18 +1,18 @@
 '''Composite runtime state for a Manager instance.
 
 Composes capital, risk, positions, and operational mode into a
-single top-level container. Created from InstanceConfig at startup.
+single top-level container. Created with allocated_capital at startup.
 '''
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from decimal import Decimal
 
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.operational_mode import ModeState, StrategyModeState
 from nexus.core.domain.position import Position
 from nexus.core.domain.risk_state import RiskState
-from nexus.instance_config import InstanceConfig
 
 __all__ = ['InstanceState']
 
@@ -57,16 +57,17 @@ class InstanceState:
                 raise ValueError(msg)
 
     @classmethod
-    def from_config(cls, config: InstanceConfig) -> InstanceState:
-        '''Create initial state from instance configuration.
+    def fresh(cls, allocated_capital: Decimal) -> InstanceState:
+        '''Create an initial empty state for a freshly-started instance.
 
         Args:
-            config: Identity and capital ceiling for this instance.
+            allocated_capital: Hard ceiling on capital this instance can
+                use, sourced from `Manifest.allocated_capital`.
 
         Returns:
             Fresh InstanceState with capital pool set and everything else zeroed.
         '''
 
         return cls(
-            capital=CapitalState(capital_pool=config.allocated_capital),
+            capital=CapitalState(capital_pool=allocated_capital),
         )

--- a/nexus/core/domain/instance_state.py
+++ b/nexus/core/domain/instance_state.py
@@ -57,17 +57,20 @@ class InstanceState:
                 raise ValueError(msg)
 
     @classmethod
-    def fresh(cls, allocated_capital: Decimal) -> InstanceState:
+    def fresh(cls, capital_pool: Decimal) -> InstanceState:
         '''Create an initial empty state for a freshly-started instance.
 
         Args:
-            allocated_capital: Hard ceiling on capital this instance can
-                use, sourced from `Manifest.allocated_capital`.
+            capital_pool: Operational capital allocation in quote asset,
+                sourced from `Manifest.capital_pool`. Becomes the initial
+                `CapitalState.capital_pool` — NOT `Manifest.allocated_capital`,
+                which is the infrastructure ceiling, not the operational
+                allocation.
 
         Returns:
             Fresh InstanceState with capital pool set and everything else zeroed.
         '''
 
         return cls(
-            capital=CapitalState(capital_pool=allocated_capital),
+            capital=CapitalState(capital_pool=capital_pool),
         )

--- a/nexus/core/domain/instance_state.py
+++ b/nexus/core/domain/instance_state.py
@@ -1,7 +1,9 @@
 '''Composite runtime state for a Manager instance.
 
 Composes capital, risk, positions, and operational mode into a
-single top-level container. Created with allocated_capital at startup.
+single top-level container. Created with `capital_pool` (the operational
+allocation sourced from `Manifest.capital_pool`) at fresh startup via
+`InstanceState.fresh()`.
 '''
 
 from __future__ import annotations

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -192,6 +192,8 @@ class Manifest:
             msg = 'Manifest.account_id must be a non-empty string'
             raise ValueError(msg)
 
+        object.__setattr__(self, 'account_id', self.account_id.strip())
+
         if (
             not isinstance(self.allocated_capital, Decimal)
             or not self.allocated_capital.is_finite()

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -172,15 +172,36 @@ class Manifest:
     '''Immutable manifest for a Manager instance.
 
     Args:
-        capital_pool: Total capital in quote asset for this instance.
+        account_id: Trading account this Manager instance is bound to.
+        allocated_capital: Hard infrastructure ceiling on capital this
+            instance can use, in quote asset. The manifest's capital_pool
+            must not exceed this value.
+        capital_pool: Operational allocation in quote asset for this instance.
         strategies: Strategy specifications for this instance.
     '''
 
+    account_id: str
+    allocated_capital: Decimal
     capital_pool: Decimal
     strategies: tuple[StrategySpec, ...]
 
     def __post_init__(self) -> None:
         '''Validate manifest invariants.'''
+
+        if not isinstance(self.account_id, str) or not self.account_id.strip():
+            msg = 'Manifest.account_id must be a non-empty string'
+            raise ValueError(msg)
+
+        if (
+            not isinstance(self.allocated_capital, Decimal)
+            or not self.allocated_capital.is_finite()
+        ):
+            msg = 'Manifest.allocated_capital must be a finite Decimal'
+            raise ValueError(msg)
+
+        if self.allocated_capital <= _ZERO:
+            msg = 'Manifest.allocated_capital must be positive'
+            raise ValueError(msg)
 
         if (
             not isinstance(self.capital_pool, Decimal)
@@ -191,6 +212,13 @@ class Manifest:
 
         if self.capital_pool <= _ZERO:
             msg = 'Manifest.capital_pool must be positive'
+            raise ValueError(msg)
+
+        if self.capital_pool > self.allocated_capital:
+            msg = (
+                f'Manifest.capital_pool {self.capital_pool} exceeds '
+                f'allocated_capital {self.allocated_capital}'
+            )
             raise ValueError(msg)
 
         if not isinstance(self.strategies, tuple) or not self.strategies:
@@ -217,18 +245,18 @@ class Manifest:
             raise ValueError(msg)
 
 
-def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
+def load_manifest(path: Path) -> Manifest:
     '''Load and validate a manifest from a YAML file.
 
     Args:
         path: Path to the YAML manifest file.
-        allocated_capital: Hard ceiling for capital_pool validation.
 
     Returns:
         Validated Manifest instance.
 
     Raises:
-        ValueError: If manifest is invalid or capital_pool exceeds allocated_capital.
+        ValueError: If manifest is invalid (missing fields, capital_pool >
+            allocated_capital, etc.).
         FileNotFoundError: If manifest file does not exist.
         yaml.YAMLError: If the file contains malformed YAML.
     '''
@@ -244,6 +272,34 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
         msg = 'Manifest must be a YAML mapping'
         raise ValueError(msg)
 
+    raw_account_id = data.get('account_id')
+    if not isinstance(raw_account_id, str) or not raw_account_id.strip():
+        msg = 'Manifest missing or invalid required field: account_id'
+        raise ValueError(msg)
+
+    account_id = raw_account_id.strip()
+
+    raw_allocated_capital = data.get('allocated_capital')
+    if raw_allocated_capital is None:
+        msg = 'Manifest missing required field: allocated_capital'
+        raise ValueError(msg)
+
+    try:
+        allocated_capital = Decimal(str(raw_allocated_capital))
+    except InvalidOperation as e:
+        msg = (
+            f'Manifest allocated_capital is not a valid number: '
+            f'{raw_allocated_capital!r}'
+        )
+        raise ValueError(msg) from e
+
+    if not allocated_capital.is_finite() or allocated_capital <= _ZERO:
+        msg = (
+            f'Manifest allocated_capital must be a finite positive number: '
+            f'{allocated_capital}'
+        )
+        raise ValueError(msg)
+
     raw_capital_pool = data.get('capital_pool')
     if raw_capital_pool is None:
         msg = 'Manifest missing required field: capital_pool'
@@ -257,13 +313,6 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
 
     if not capital_pool.is_finite() or capital_pool <= _ZERO:
         msg = f'Manifest capital_pool must be a finite positive number: {capital_pool}'
-        raise ValueError(msg)
-
-    if (
-        not isinstance(allocated_capital, Decimal)
-        or not allocated_capital.is_finite()
-    ):
-        msg = 'allocated_capital must be a finite Decimal'
         raise ValueError(msg)
 
     if capital_pool > allocated_capital:
@@ -399,7 +448,12 @@ def load_manifest(path: Path, allocated_capital: Decimal) -> Manifest:
             )
         )
 
-    manifest = Manifest(capital_pool=capital_pool, strategies=tuple(specs))
+    manifest = Manifest(
+        account_id=account_id,
+        allocated_capital=allocated_capital,
+        capital_pool=capital_pool,
+        strategies=tuple(specs),
+    )
 
     _validate_strategy_files(manifest, path.parent)
 

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -29,9 +29,6 @@ class InstanceConfig:
     Args:
         account_id: Unique identifier for this instance's trading account.
         venue: Which venue to trade on (e.g. ``binance_spot``).
-        allocated_capital: Hard ceiling on capital this instance can use,
-            denominated in quote asset. The manifest's ``capital_pool``
-            must not exceed this value.
         duplicate_window_ms: Duplicate-order detection window for intake
             checks, in milliseconds.
         max_order_rate: Optional per-process cap on ENTER actions per second
@@ -58,7 +55,6 @@ class InstanceConfig:
 
     account_id: str
     venue: str
-    allocated_capital: Decimal
     duplicate_window_ms: int = 1000
     max_order_rate: int | None = None
     book_staleness_max_seconds: int | None = None
@@ -79,10 +75,6 @@ class InstanceConfig:
 
         if not self.venue or not self.venue.strip():
             msg = 'InstanceConfig.venue must be a non-empty string'
-            raise ValueError(msg)
-
-        if not self.allocated_capital.is_finite() or self.allocated_capital <= 0:
-            msg = 'InstanceConfig.allocated_capital must be a finite positive value'
             raise ValueError(msg)
 
         if isinstance(self.duplicate_window_ms, bool) or not isinstance(

--- a/nexus/instance_config.py
+++ b/nexus/instance_config.py
@@ -1,8 +1,12 @@
 '''Runtime configuration for a Manager instance.
 
-Frozen dataclass holding identity and capital ceiling for a single
-Manager instance. Additional fields (risk limits, health policy, etc.)
-are added as their respective phases land.
+Frozen dataclass holding identity and validator-level tunables for a
+single Manager instance (intake thresholds, STP mode, capital-pct
+mapping, shutdown timeouts). Capital ceiling and operational allocation
+are NOT tracked here — both `allocated_capital` and `capital_pool`
+live on the strategy `Manifest` (see
+`nexus.infrastructure.manifest.Manifest`). Additional fields (risk
+limits, health policy, etc.) are added as their respective phases land.
 '''
 
 from __future__ import annotations
@@ -24,7 +28,12 @@ _ALLOWED_REFERENCE_PRICE_SOURCES = frozenset({'origo_mid'})
 
 @dataclass(frozen=True)
 class InstanceConfig:
-    '''Immutable configuration for one Manager instance.
+    '''Immutable runtime/validator config for one Manager instance.
+
+    Identity and validator-level tunables. The capital ceiling
+    (``allocated_capital``) and operational allocation (``capital_pool``)
+    are NOT fields here — both live on the strategy
+    `Manifest` and are sourced from YAML at startup.
 
     Args:
         account_id: Unique identifier for this instance's trading account.

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -68,10 +68,8 @@ class StartupSequencer:
         state_store: Persistence facade for state recovery.
         manifest_path: Path to the strategy manifest YAML file.
         strategies_base_path: Base path for resolving strategy file paths.
-        allocated_capital: Hard ceiling for manifest capital_pool validation.
         strategy_state_path: Directory for strategy state blob files.
         praxis_outbound: Outbound connector for Praxis Trading operations.
-        account_id: Account identifier for Praxis registration.
     '''
 
     def __init__(
@@ -79,10 +77,8 @@ class StartupSequencer:
         state_store: StateStore,
         manifest_path: Path,
         strategies_base_path: Path,
-        allocated_capital: Decimal,
         strategy_state_path: Path | None = None,
         praxis_outbound: PraxisOutbound | None = None,
-        account_id: str | None = None,
         health_evaluator: HealthEvaluator | None = None,
         health_snapshot: HealthSnapshot | None = None,
     ) -> None:
@@ -98,14 +94,6 @@ class StartupSequencer:
             msg = 'strategies_base_path must be a Path'
             raise ValueError(msg)
 
-        if (
-            not isinstance(allocated_capital, Decimal)
-            or not allocated_capital.is_finite()
-            or allocated_capital <= 0
-        ):
-            msg = 'allocated_capital must be a finite positive Decimal'
-            raise ValueError(msg)
-
         if strategy_state_path is not None and not isinstance(strategy_state_path, Path):
             msg = 'strategy_state_path must be a Path or None'
             raise ValueError(msg)
@@ -113,10 +101,8 @@ class StartupSequencer:
         self._state_store = state_store
         self._manifest_path = manifest_path
         self._strategies_base_path = strategies_base_path
-        self._allocated_capital = allocated_capital
         self._strategy_state_path = strategy_state_path
         self._praxis_outbound = praxis_outbound
-        self._account_id = account_id
         self._health_evaluator = health_evaluator
         self._health_snapshot = health_snapshot
 
@@ -149,10 +135,10 @@ class StartupSequencer:
             StartupError: If any step fails.
         '''
 
+        self._load_manifest()
         self._recover_state()
         self._register_with_trading()
         self._reconcile_capital()
-        self._load_manifest()
         self._instantiate_strategies()
         self._restore_strategy_state()
         self._replay_strategy_events()
@@ -172,27 +158,35 @@ class StartupSequencer:
         Delegates to StateStore.recover() which loads the latest snapshot
         and replays STATE_MUTATION entries from WAL atomically. If no
         persisted state exists (fresh start), creates initial state from
-        allocated capital. Same code path for fresh start and crash recovery.
+        manifest allocated_capital. Same code path for fresh start and
+        crash recovery.
         '''
 
         try:
             self._state = self._state_store.recover()
             if self._state is None:
+                if self._manifest is None:
+                    raise StartupError(
+                        'recover_state',
+                        'manifest not loaded; cannot bootstrap fresh InstanceState',
+                    )
                 self._state = InstanceState(
-                    capital=CapitalState(capital_pool=self._allocated_capital),
+                    capital=CapitalState(capital_pool=self._manifest.allocated_capital),
                 )
+        except StartupError:
+            raise
         except Exception as e:
             raise StartupError('recover_state', str(e)) from e
 
     def _register_with_trading(self) -> None:
         '''Register this account with Trading sub-system via PraxisOutbound.'''
 
-        if self._praxis_outbound is None or self._account_id is None:
-            _log.warning('praxis_outbound or account_id not configured, skipping registration')
+        if self._praxis_outbound is None or self._manifest is None:
+            _log.warning('praxis_outbound or manifest not configured, skipping registration')
             return
 
         try:
-            self._praxis_outbound.register_account(self._account_id)
+            self._praxis_outbound.register_account(self._manifest.account_id)
         except Exception as e:
             raise StartupError('register_with_trading', str(e)) from e
 
@@ -286,15 +280,15 @@ class StartupSequencer:
         updates position_notional to match actual venue state. Logs discrepancies.
         '''
 
-        if self._praxis_outbound is None or self._account_id is None:
-            _log.warning('praxis_outbound or account_id not configured, skipping reconciliation')
+        if self._praxis_outbound is None or self._manifest is None:
+            _log.warning('praxis_outbound or manifest not configured, skipping reconciliation')
             return
 
         if self._state is None:
             raise StartupError('reconcile_capital', 'state not recovered')
 
         try:
-            praxis_positions = self._praxis_outbound.pull_positions(self._account_id)
+            praxis_positions = self._praxis_outbound.pull_positions(self._manifest.account_id)
         except Exception as e:
             raise StartupError('reconcile_capital', str(e)) from e
 
@@ -377,7 +371,7 @@ class StartupSequencer:
         '''Load and validate strategy manifest.'''
 
         try:
-            self._manifest = load_manifest(self._manifest_path, self._allocated_capital)
+            self._manifest = load_manifest(self._manifest_path)
         except Exception as e:
             raise StartupError('load_manifest', str(e)) from e
 

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -12,7 +12,6 @@ import structlog
 
 from limen.experiment.trainer.trainer import Trainer
 
-from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode, OrderSide
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.domain.position import Position
@@ -172,9 +171,7 @@ class StartupSequencer:
                         'recover_state',
                         'manifest not loaded; cannot bootstrap fresh InstanceState',
                     )
-                self._state = InstanceState(
-                    capital=CapitalState(capital_pool=self._manifest.capital_pool),
-                )
+                self._state = InstanceState.fresh(self._manifest.capital_pool)
         except StartupError:
             raise
         except Exception as e:

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -59,10 +59,11 @@ class WiredSensor:
 class StartupSequencer:
     '''Orchestrates the startup sequence for a Manager instance.
 
-    Executes steps in order: recover state (snapshot + WAL) → register with Trading →
-    reconcile capital → load manifest → instantiate strategies → restore strategy state →
-    replay strategy events → wire sensors → register timers →
-    determine mode → dispatch on_startup.
+    Executes steps in order: load manifest (source of account_id and
+    allocated_capital) → recover state (snapshot + WAL) → register with
+    Trading → reconcile capital → instantiate strategies → restore
+    strategy state → replay strategy events → wire sensors → register
+    timers → determine mode → dispatch on_startup.
 
     Args:
         state_store: Persistence facade for state recovery.

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -159,8 +159,9 @@ class StartupSequencer:
         Delegates to StateStore.recover() which loads the latest snapshot
         and replays STATE_MUTATION entries from WAL atomically. If no
         persisted state exists (fresh start), creates initial state from
-        manifest allocated_capital. Same code path for fresh start and
-        crash recovery.
+        manifest capital_pool (the operational allocation — NOT
+        allocated_capital, which is the infrastructure ceiling). Same
+        code path for fresh start and crash recovery.
         '''
 
         try:
@@ -172,7 +173,7 @@ class StartupSequencer:
                         'manifest not loaded; cannot bootstrap fresh InstanceState',
                     )
                 self._state = InstanceState(
-                    capital=CapitalState(capital_pool=self._manifest.allocated_capital),
+                    capital=CapitalState(capital_pool=self._manifest.capital_pool),
                 )
         except StartupError:
             raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.27.0"
+version = "0.28.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -17,11 +17,9 @@ def test_valid_creation() -> None:
     cfg = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
     )
     assert cfg.account_id == 'acc_001'
     assert cfg.venue == 'binance_spot'
-    assert cfg.allocated_capital == Decimal('10000')
     assert cfg.duplicate_window_ms == 1000
     assert cfg.max_order_rate is None
     assert cfg.book_staleness_max_seconds is None
@@ -38,7 +36,6 @@ def test_valid_creation_with_duplicate_window_ms() -> None:
     cfg = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
         duplicate_window_ms=250,
     )
     assert cfg.duplicate_window_ms == 250
@@ -48,7 +45,6 @@ def test_valid_creation_with_max_order_rate() -> None:
     cfg = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
         max_order_rate=7,
     )
     assert cfg.max_order_rate == 7
@@ -58,7 +54,6 @@ def test_valid_creation_with_price_validation_fields() -> None:
     cfg = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
         book_staleness_max_seconds=3,
         max_spread_bps=Decimal('7.5'),
         price_deviation_max_bps=Decimal('12.0'),
@@ -75,7 +70,6 @@ def test_reference_price_source_is_normalized() -> None:
     cfg = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
         price_deviation_max_bps=Decimal('5'),
         reference_price_source='  ORIGO_MID ',
     )
@@ -89,7 +83,6 @@ def test_valid_creation_with_capital_pct() -> None:
     cfg = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
         capital_pct={'momentum': Decimal('60'), 'mean_rev': Decimal('40')},
     )
 
@@ -103,7 +96,6 @@ def test_capital_pct_mapping_is_immutable() -> None:
     cfg = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
         capital_pct={'momentum': Decimal('60')},
     )
 
@@ -118,7 +110,6 @@ def test_frozen() -> None:
     cfg = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
     )
     with pytest.raises(AttributeError):
         cfg.account_id = 'acc_002'  # type: ignore[misc]
@@ -131,7 +122,6 @@ def test_empty_account_id_rejected() -> None:
         InstanceConfig(
             account_id='',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
         )
 
 
@@ -142,7 +132,6 @@ def test_whitespace_account_id_rejected() -> None:
         InstanceConfig(
             account_id='   ',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
         )
 
 
@@ -153,40 +142,6 @@ def test_empty_venue_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='',
-            allocated_capital=Decimal('10000'),
-        )
-
-
-def test_zero_capital_rejected() -> None:
-    '''Verify zero allocated_capital raises ValueError.'''
-
-    with pytest.raises(ValueError, match='allocated_capital'):
-        InstanceConfig(
-            account_id='acc_001',
-            venue='binance_spot',
-            allocated_capital=Decimal('0'),
-        )
-
-
-def test_negative_capital_rejected() -> None:
-    '''Verify negative allocated_capital raises ValueError.'''
-
-    with pytest.raises(ValueError, match='allocated_capital'):
-        InstanceConfig(
-            account_id='acc_001',
-            venue='binance_spot',
-            allocated_capital=Decimal('-100'),
-        )
-
-
-def test_nan_capital_rejected() -> None:
-    '''Verify NaN allocated_capital raises ValueError.'''
-
-    with pytest.raises(ValueError, match='allocated_capital'):
-        InstanceConfig(
-            account_id='acc_001',
-            venue='binance_spot',
-            allocated_capital=Decimal('NaN'),
         )
 
 
@@ -197,7 +152,6 @@ def test_non_int_duplicate_window_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             duplicate_window_ms=cast(int, cast(object, '1000')),
         )
 
@@ -207,7 +161,6 @@ def test_bool_duplicate_window_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             duplicate_window_ms=cast(int, cast(object, True)),
         )
 
@@ -219,7 +172,6 @@ def test_non_positive_duplicate_window_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             duplicate_window_ms=0,
         )
 
@@ -229,7 +181,6 @@ def test_non_int_max_order_rate_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             max_order_rate=cast(int, cast(object, '5')),
         )
 
@@ -239,7 +190,6 @@ def test_bool_max_order_rate_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             max_order_rate=cast(int, cast(object, True)),
         )
 
@@ -249,7 +199,6 @@ def test_non_positive_max_order_rate_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             max_order_rate=0,
         )
 
@@ -259,7 +208,6 @@ def test_non_int_book_staleness_max_seconds_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             book_staleness_max_seconds=cast(int, cast(object, '3')),
         )
 
@@ -269,7 +217,6 @@ def test_bool_book_staleness_max_seconds_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             book_staleness_max_seconds=cast(int, cast(object, True)),
         )
 
@@ -279,7 +226,6 @@ def test_non_positive_book_staleness_max_seconds_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             book_staleness_max_seconds=0,
         )
 
@@ -289,7 +235,6 @@ def test_non_decimal_max_spread_bps_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             max_spread_bps=cast(Decimal, cast(object, 5)),
         )
 
@@ -299,7 +244,6 @@ def test_negative_max_spread_bps_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             max_spread_bps=Decimal('-0.1'),
         )
 
@@ -309,7 +253,6 @@ def test_nan_max_spread_bps_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             max_spread_bps=Decimal('NaN'),
         )
 
@@ -319,7 +262,6 @@ def test_non_decimal_price_deviation_max_bps_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             price_deviation_max_bps=cast(Decimal, cast(object, 5)),
             reference_price_source='origo_mid',
         )
@@ -330,7 +272,6 @@ def test_negative_price_deviation_max_bps_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             price_deviation_max_bps=Decimal('-0.1'),
             reference_price_source='origo_mid',
         )
@@ -341,7 +282,6 @@ def test_nan_price_deviation_max_bps_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             price_deviation_max_bps=Decimal('NaN'),
             reference_price_source='origo_mid',
         )
@@ -352,7 +292,6 @@ def test_price_deviation_without_reference_source_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             price_deviation_max_bps=Decimal('5'),
         )
 
@@ -362,7 +301,6 @@ def test_empty_reference_price_source_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             price_deviation_max_bps=Decimal('5'),
             reference_price_source='   ',
         )
@@ -373,7 +311,6 @@ def test_invalid_reference_price_source_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             price_deviation_max_bps=Decimal('5'),
             reference_price_source='origo_last',
         )
@@ -383,7 +320,6 @@ def test_valid_creation_with_stp_mode_cancel_maker() -> None:
     cfg = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
         stp_mode=STPMode.CANCEL_MAKER,
     )
     assert cfg.stp_mode == STPMode.CANCEL_MAKER
@@ -393,7 +329,6 @@ def test_valid_creation_with_stp_mode_cancel_both() -> None:
     cfg = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
         stp_mode=STPMode.CANCEL_BOTH,
     )
     assert cfg.stp_mode == STPMode.CANCEL_BOTH
@@ -404,19 +339,7 @@ def test_invalid_stp_mode_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             stp_mode=cast(STPMode, cast(object, 'CANCEL_TAKER')),
-        )
-
-
-def test_infinity_capital_rejected() -> None:
-    '''Verify Infinity allocated_capital raises ValueError.'''
-
-    with pytest.raises(ValueError, match='allocated_capital'):
-        InstanceConfig(
-            account_id='acc_001',
-            venue='binance_spot',
-            allocated_capital=Decimal('Infinity'),
         )
 
 
@@ -427,7 +350,6 @@ def test_empty_capital_pct_key_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             capital_pct={'': Decimal('10')},
         )
 
@@ -439,7 +361,6 @@ def test_non_string_capital_pct_key_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             capital_pct=cast(dict[str, Decimal], {1: Decimal('10')}),
         )
 
@@ -451,7 +372,6 @@ def test_duplicate_capital_pct_key_after_normalization_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             capital_pct={'momentum': Decimal('10'), ' momentum ': Decimal('20')},
         )
 
@@ -463,7 +383,6 @@ def test_non_mapping_capital_pct_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             capital_pct=cast(dict[str, Decimal], cast(object, None)),
         )
 
@@ -475,7 +394,6 @@ def test_nan_capital_pct_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             capital_pct={'momentum': Decimal('NaN')},
         )
 
@@ -487,7 +405,6 @@ def test_non_positive_capital_pct_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             capital_pct={'momentum': Decimal('0')},
         )
 
@@ -499,7 +416,6 @@ def test_capital_pct_above_100_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             capital_pct={'momentum': Decimal('120')},
         )
 
@@ -511,7 +427,6 @@ def test_capital_pct_total_above_100_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             capital_pct={'momentum': Decimal('70'), 'mean_rev': Decimal('40')},
         )
 
@@ -523,7 +438,6 @@ def test_shutdown_wait_timeout_bool_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             shutdown_wait_timeout_seconds=True,
         )
 
@@ -535,7 +449,6 @@ def test_shutdown_abort_timeout_bool_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             shutdown_abort_timeout_seconds=False,
         )
 
@@ -547,7 +460,6 @@ def test_shutdown_wait_timeout_zero_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             shutdown_wait_timeout_seconds=0,
         )
 
@@ -559,6 +471,5 @@ def test_shutdown_abort_timeout_negative_rejected() -> None:
         InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             shutdown_abort_timeout_seconds=-5.0,
         )

--- a/tests/test_instance_state.py
+++ b/tests/test_instance_state.py
@@ -27,7 +27,7 @@ def test_direct_creation() -> None:
 
 
 def test_fresh() -> None:
-    '''Verify factory creates initial empty state with given capital ceiling.'''
+    '''Verify factory creates initial empty state seeded with the given capital_pool (operational allocation, not ceiling).'''
 
     state = InstanceState.fresh(Decimal('50000'))
     assert state.capital.capital_pool == Decimal('50000')
@@ -35,6 +35,39 @@ def test_fresh() -> None:
     assert state.risk.realized_pnl == Decimal(0)
     assert state.positions == {}
     assert state.mode.mode == OperationalMode.ACTIVE
+
+
+def test_fresh_rejects_non_decimal() -> None:
+    '''int/float/str capital_pool raises ValueError, not AttributeError.'''
+
+    with pytest.raises(ValueError, match='must receive a finite Decimal'):
+        InstanceState.fresh(10000)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match='must receive a finite Decimal'):
+        InstanceState.fresh(10000.0)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match='must receive a finite Decimal'):
+        InstanceState.fresh('10000')  # type: ignore[arg-type]
+
+
+def test_fresh_rejects_non_finite() -> None:
+    '''NaN/Infinity capital_pool raises ValueError.'''
+
+    with pytest.raises(ValueError, match='must receive a finite Decimal'):
+        InstanceState.fresh(Decimal('NaN'))
+
+    with pytest.raises(ValueError, match='must receive a finite Decimal'):
+        InstanceState.fresh(Decimal('Infinity'))
+
+
+def test_fresh_rejects_non_positive() -> None:
+    '''Zero or negative capital_pool raises ValueError.'''
+
+    with pytest.raises(ValueError, match='must receive a positive'):
+        InstanceState.fresh(Decimal('0'))
+
+    with pytest.raises(ValueError, match='must receive a positive'):
+        InstanceState.fresh(Decimal('-1000'))
 
 
 def test_positions_key_mismatch_rejected() -> None:

--- a/tests/test_instance_state.py
+++ b/tests/test_instance_state.py
@@ -11,7 +11,6 @@ from nexus.core.domain.enums import OperationalMode, OrderSide
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.domain.operational_mode import StrategyModeState
 from nexus.core.domain.position import Position
-from nexus.instance_config import InstanceConfig
 
 
 def test_direct_creation() -> None:
@@ -27,15 +26,10 @@ def test_direct_creation() -> None:
     assert state.strategy_modes == {}
 
 
-def test_from_config() -> None:
-    '''Verify factory creates state from InstanceConfig.'''
+def test_fresh() -> None:
+    '''Verify factory creates initial empty state with given capital ceiling.'''
 
-    config = InstanceConfig(
-        account_id='acc_001',
-        venue='binance_spot',
-        allocated_capital=Decimal('50000'),
-    )
-    state = InstanceState.from_config(config)
+    state = InstanceState.fresh(Decimal('50000'))
     assert state.capital.capital_pool == Decimal('50000')
     assert state.capital.available == Decimal('50000')
     assert state.risk.realized_pnl == Decimal(0)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -224,6 +224,18 @@ class TestManifest:
 
         assert manifest.capital_pool == Decimal('10000')
 
+    def test_account_id_is_normalized(self, tmp_path: Path) -> None:
+        '''account_id is stripped of surrounding whitespace at construction.'''
+
+        manifest = Manifest(
+            account_id='  test_acct  ',
+            allocated_capital=Decimal('100000'),
+            capital_pool=Decimal('10000'),
+            strategies=(_make_spec(tmp_path),),
+        )
+
+        assert manifest.account_id == 'test_acct'
+
     def test_capital_pct_sum_under_100_allowed(self, tmp_path: Path) -> None:
         '''capital_pct sum under 100 is allowed.'''
 
@@ -383,7 +395,7 @@ class TestLoadManifest:
         '''Blank account_id raises ValueError.'''
 
         path = tmp_path / 'manifest.yaml'
-        _write_yaml(path, "account_id: '   '\ncapital_pool: 10000\nstrategies: []\n")
+        _write_yaml(path, 'account_id: \'   \'\ncapital_pool: 10000\nstrategies: []\n')
 
         with pytest.raises(ValueError, match='missing or invalid required field: account_id'):
             load_manifest(path)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -71,6 +71,8 @@ class TestManifest:
         spec2 = _make_spec(tmp_path, 'strategy_b', Decimal('40'))
 
         manifest = Manifest(
+            account_id='test_acct',
+            allocated_capital=Decimal('100000'),
             capital_pool=Decimal('10000'),
             strategies=(spec1, spec2),
         )
@@ -82,6 +84,8 @@ class TestManifest:
         '''Manifest is immutable.'''
 
         manifest = Manifest(
+            account_id='test_acct',
+            allocated_capital=Decimal('100000'),
             capital_pool=Decimal('10000'),
             strategies=(_make_spec(tmp_path),),
         )
@@ -94,6 +98,8 @@ class TestManifest:
 
         with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
             Manifest(
+                account_id='test_acct',
+                allocated_capital=Decimal('100000'),
                 capital_pool=10000,  # type: ignore[arg-type]
                 strategies=(_make_spec(tmp_path),),
             )
@@ -103,6 +109,8 @@ class TestManifest:
 
         with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
             Manifest(
+                account_id='test_acct',
+                allocated_capital=Decimal('100000'),
                 capital_pool=Decimal('inf'),
                 strategies=(_make_spec(tmp_path),),
             )
@@ -112,6 +120,8 @@ class TestManifest:
 
         with pytest.raises(ValueError, match='capital_pool must be a finite Decimal'):
             Manifest(
+                account_id='test_acct',
+                allocated_capital=Decimal('100000'),
                 capital_pool=Decimal('nan'),
                 strategies=(_make_spec(tmp_path),),
             )
@@ -121,6 +131,8 @@ class TestManifest:
 
         with pytest.raises(ValueError, match='capital_pool must be positive'):
             Manifest(
+                account_id='test_acct',
+                allocated_capital=Decimal('100000'),
                 capital_pool=Decimal('0'),
                 strategies=(_make_spec(tmp_path),),
             )
@@ -130,6 +142,8 @@ class TestManifest:
 
         with pytest.raises(ValueError, match='capital_pool must be positive'):
             Manifest(
+                account_id='test_acct',
+                allocated_capital=Decimal('100000'),
                 capital_pool=Decimal('-1000'),
                 strategies=(_make_spec(tmp_path),),
             )
@@ -139,6 +153,8 @@ class TestManifest:
 
         with pytest.raises(ValueError, match='strategies must be a non-empty tuple'):
             Manifest(
+                account_id='test_acct',
+                allocated_capital=Decimal('100000'),
                 capital_pool=Decimal('10000'),
                 strategies=(),
             )
@@ -148,6 +164,8 @@ class TestManifest:
 
         with pytest.raises(ValueError, match='strategies must be a non-empty tuple'):
             Manifest(
+                account_id='test_acct',
+                allocated_capital=Decimal('100000'),
                 capital_pool=Decimal('10000'),
                 strategies=[_make_spec(tmp_path)],  # type: ignore[arg-type]
             )
@@ -157,6 +175,8 @@ class TestManifest:
 
         with pytest.raises(ValueError, match='strategies must contain StrategySpec'):
             Manifest(
+                account_id='test_acct',
+                allocated_capital=Decimal('100000'),
                 capital_pool=Decimal('10000'),
                 strategies=(_make_spec(tmp_path), 'not a spec'),  # type: ignore[arg-type]
             )
@@ -166,6 +186,8 @@ class TestManifest:
 
         with pytest.raises(ValueError, match='duplicate strategy_id'):
             Manifest(
+                account_id='test_acct',
+                allocated_capital=Decimal('100000'),
                 capital_pool=Decimal('10000'),
                 strategies=(
                     _make_spec(tmp_path, 'same_id', Decimal('50')),
@@ -178,6 +200,8 @@ class TestManifest:
 
         with pytest.raises(ValueError, match=r'capital_pct sum .* exceeds 100'):
             Manifest(
+                account_id='test_acct',
+                allocated_capital=Decimal('100000'),
                 capital_pool=Decimal('10000'),
                 strategies=(
                     _make_spec(tmp_path, 'a', Decimal('60')),
@@ -189,6 +213,8 @@ class TestManifest:
         '''capital_pct sum of exactly 100 is allowed.'''
 
         manifest = Manifest(
+            account_id='test_acct',
+            allocated_capital=Decimal('100000'),
             capital_pool=Decimal('10000'),
             strategies=(
                 _make_spec(tmp_path, 'a', Decimal('60')),
@@ -202,6 +228,8 @@ class TestManifest:
         '''capital_pct sum under 100 is allowed.'''
 
         manifest = Manifest(
+            account_id='test_acct',
+            allocated_capital=Decimal('100000'),
             capital_pool=Decimal('10000'),
             strategies=(
                 _make_spec(tmp_path, 'a', Decimal('30')),
@@ -215,6 +243,8 @@ class TestManifest:
         '''Single strategy in manifest is allowed.'''
 
         manifest = Manifest(
+            account_id='test_acct',
+            allocated_capital=Decimal('100000'),
             capital_pool=Decimal('10000'),
             strategies=(_make_spec(tmp_path, 'only_one', Decimal('100')),),
         )
@@ -236,6 +266,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: momentum\n'
@@ -254,7 +286,7 @@ class TestLoadManifest:
             f'    capital_pct: 40\n',
         )
 
-        manifest = load_manifest(path, Decimal('20000'))
+        manifest = load_manifest(path)
 
         assert manifest.capital_pool == Decimal('10000')
         assert len(manifest.strategies) == 2
@@ -267,7 +299,7 @@ class TestLoadManifest:
         '''Missing manifest file raises FileNotFoundError.'''
 
         with pytest.raises(FileNotFoundError, match='Manifest file not found'):
-            load_manifest(Path('/nonexistent/manifest.yaml'), Decimal('10000'))
+            load_manifest(Path('/nonexistent/manifest.yaml'))
 
     def test_capital_pool_exceeds_allocated_raises(self, tmp_path: Path) -> None:
         '''capital_pool > allocated_capital raises ValueError.'''
@@ -278,6 +310,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 15000\n'
             f'strategies:\n'
             f'  - id: test\n'
@@ -290,35 +324,69 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='exceeds allocated_capital'):
-            load_manifest(path, Decimal('10000'))
+            load_manifest(path)
 
-    def test_non_finite_allocated_capital_raises(self, tmp_path: Path) -> None:
-        '''Non-finite allocated_capital raises ValueError.'''
+    def test_missing_allocated_capital_raises(self, tmp_path: Path) -> None:
+        '''Missing allocated_capital raises ValueError.'''
 
         path = tmp_path / 'manifest.yaml'
-        exp_dir = tmp_path / 'experiment'
-        exp_dir.mkdir()
-        strategy = tmp_path / 'test.py'
-        strategy.write_text('pass')
-
         _write_yaml(
             path,
-            f'capital_pool: 5000\n'
-            f'strategies:\n'
-            f'  - id: test\n'
-            f'    file: test.py\n'
-            f'    sensors:\n'
-            f'      - experiment: {exp_dir}\n'
-            f'        permutation_ids: [1]\n'
-            f'        interval_seconds: 60\n'
-            f'    capital_pct: 100\n',
+            'account_id: test_acct\n'
+            'capital_pool: 5000\n'
+            'strategies: []\n',
         )
 
-        with pytest.raises(ValueError, match='allocated_capital must be a finite'):
-            load_manifest(path, Decimal('NaN'))
+        with pytest.raises(ValueError, match='missing required field: allocated_capital'):
+            load_manifest(path)
 
-        with pytest.raises(ValueError, match='allocated_capital must be a finite'):
-            load_manifest(path, Decimal('Infinity'))
+    def test_invalid_allocated_capital_raises(self, tmp_path: Path) -> None:
+        '''Non-numeric allocated_capital raises ValueError.'''
+
+        path = tmp_path / 'manifest.yaml'
+        _write_yaml(
+            path,
+            'account_id: test_acct\n'
+            'allocated_capital: not_a_number\n'
+            'capital_pool: 5000\n'
+            'strategies: []\n',
+        )
+
+        with pytest.raises(ValueError, match='allocated_capital is not a valid number'):
+            load_manifest(path)
+
+    def test_non_positive_allocated_capital_raises(self, tmp_path: Path) -> None:
+        '''Zero or negative allocated_capital raises ValueError.'''
+
+        path = tmp_path / 'manifest.yaml'
+        _write_yaml(
+            path,
+            'account_id: test_acct\n'
+            'allocated_capital: 0\n'
+            'capital_pool: 5000\n'
+            'strategies: []\n',
+        )
+
+        with pytest.raises(ValueError, match='allocated_capital must be a finite positive'):
+            load_manifest(path)
+
+    def test_missing_account_id_raises(self, tmp_path: Path) -> None:
+        '''Missing account_id raises ValueError.'''
+
+        path = tmp_path / 'manifest.yaml'
+        _write_yaml(path, 'capital_pool: 10000\nstrategies: []\n')
+
+        with pytest.raises(ValueError, match='missing or invalid required field: account_id'):
+            load_manifest(path)
+
+    def test_blank_account_id_raises(self, tmp_path: Path) -> None:
+        '''Blank account_id raises ValueError.'''
+
+        path = tmp_path / 'manifest.yaml'
+        _write_yaml(path, "account_id: '   '\ncapital_pool: 10000\nstrategies: []\n")
+
+        with pytest.raises(ValueError, match='missing or invalid required field: account_id'):
+            load_manifest(path)
 
     def test_missing_capital_pool_raises(self, tmp_path: Path) -> None:
         '''Missing capital_pool raises ValueError.'''
@@ -329,6 +397,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'strategies:\n'
             f'  - id: test\n'
             f'    file: test.py\n'
@@ -340,25 +410,36 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='missing required field: capital_pool'):
-            load_manifest(path, Decimal('10000'))
+            load_manifest(path)
 
     def test_missing_strategies_raises(self, tmp_path: Path) -> None:
         '''Missing strategies raises ValueError.'''
 
         path = tmp_path / 'manifest.yaml'
-        _write_yaml(path, 'capital_pool: 10000\n')
+        _write_yaml(
+            path,
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
+            'capital_pool: 10000\n',
+        )
 
         with pytest.raises(ValueError, match='missing or empty strategies'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_empty_strategies_raises(self, tmp_path: Path) -> None:
         '''Empty strategies list raises ValueError.'''
 
         path = tmp_path / 'manifest.yaml'
-        _write_yaml(path, 'capital_pool: 10000\nstrategies: []\n')
+        _write_yaml(
+            path,
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
+            'capital_pool: 10000\n'
+            'strategies: []\n',
+        )
 
         with pytest.raises(ValueError, match='missing or empty strategies'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_strategy_missing_id_raises(self, tmp_path: Path) -> None:
         '''Strategy missing id raises ValueError.'''
@@ -369,6 +450,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - file: test.py\n'
@@ -380,7 +463,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='missing required field: id'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_strategy_missing_file_raises(self, tmp_path: Path) -> None:
         '''Strategy missing file raises ValueError.'''
@@ -391,6 +474,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: test\n'
@@ -402,7 +487,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='missing required field: file'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_strategy_missing_sensors_raises(self, tmp_path: Path) -> None:
         '''Strategy missing sensors raises ValueError.'''
@@ -411,6 +496,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test\n'
@@ -419,7 +506,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='missing or empty sensors'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_strategy_missing_capital_pct_raises(self, tmp_path: Path) -> None:
         '''Strategy missing capital_pct raises ValueError.'''
@@ -430,6 +517,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: test\n'
@@ -441,7 +530,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='missing required field: capital_pct'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_malformed_yaml_raises(self, tmp_path: Path) -> None:
         '''Malformed YAML raises yaml.YAMLError.'''
@@ -450,7 +539,7 @@ class TestLoadManifest:
         _write_yaml(path, 'capital_pool: [unclosed')
 
         with pytest.raises(yaml.YAMLError):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_non_mapping_yaml_raises(self, tmp_path: Path) -> None:
         '''Non-mapping YAML raises ValueError.'''
@@ -459,7 +548,7 @@ class TestLoadManifest:
         _write_yaml(path, '- item1\n- item2\n')
 
         with pytest.raises(ValueError, match='must be a YAML mapping'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_duplicate_strategy_id_raises(self, tmp_path: Path) -> None:
         '''Duplicate strategy_id raises ValueError.'''
@@ -470,6 +559,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: same\n'
@@ -489,7 +580,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='duplicate strategy_id'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_capital_pct_sum_over_100_raises(self, tmp_path: Path) -> None:
         '''capital_pct sum > 100 raises ValueError.'''
@@ -502,6 +593,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: a\n'
@@ -521,7 +614,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='exceeds 100'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_strategy_file_not_found_raises(self, tmp_path: Path) -> None:
         '''Missing strategy .py file raises ValueError with path.'''
@@ -532,6 +625,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: missing_file\n'
@@ -544,7 +639,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match=r"file not found.*nonexistent/strategy\.py"):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_strategy_file_syntax_error_raises(self, tmp_path: Path) -> None:
         '''Invalid Python syntax in strategy file raises ValueError.'''
@@ -558,6 +653,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: bad_syntax\n'
@@ -570,7 +667,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match=r'syntax error.*bad_syntax\.py'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_invalid_capital_pool_decimal_raises(self, tmp_path: Path) -> None:
         '''Non-numeric capital_pool raises ValueError.'''
@@ -582,6 +679,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: not_a_number\n'
             f'strategies:\n'
             f'  - id: test\n'
@@ -594,7 +693,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='capital_pool is not a valid number'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_invalid_capital_pct_decimal_raises(self, tmp_path: Path) -> None:
         '''Non-numeric capital_pct raises ValueError.'''
@@ -606,6 +705,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: test\n'
@@ -618,7 +719,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='capital_pct is not a valid number'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_absolute_file_path_raises(self, tmp_path: Path) -> None:
         '''Absolute strategy file path raises ValueError.'''
@@ -629,6 +730,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: absolute\n'
@@ -641,7 +744,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='file must be relative'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_path_traversal_raises(self, tmp_path: Path) -> None:
         '''Strategy file path escaping base raises ValueError.'''
@@ -652,6 +755,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: escape\n'
@@ -664,7 +769,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='escapes base path'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_directory_instead_of_file_raises(self, tmp_path: Path) -> None:
         '''Directory path instead of file raises ValueError.'''
@@ -676,6 +781,8 @@ class TestLoadManifest:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: dir_not_file\n'
@@ -688,7 +795,7 @@ class TestLoadManifest:
         )
 
         with pytest.raises(ValueError, match='file not found'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
 
 class TestLoadManifestTimers:
@@ -703,6 +810,8 @@ class TestLoadManifestTimers:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: strat1\n'
@@ -719,7 +828,7 @@ class TestLoadManifestTimers:
             f'        interval_seconds: 300\n',
         )
 
-        manifest = load_manifest(path, Decimal('20000'))
+        manifest = load_manifest(path)
 
         assert len(manifest.strategies[0].timers) == 2
         assert manifest.strategies[0].timers[0].timer_id == 'trailing_stop'
@@ -735,6 +844,8 @@ class TestLoadManifestTimers:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: strat1\n'
@@ -746,7 +857,7 @@ class TestLoadManifestTimers:
             f'    capital_pct: 100\n',
         )
 
-        manifest = load_manifest(path, Decimal('20000'))
+        manifest = load_manifest(path)
 
         assert manifest.strategies[0].timers == ()
 
@@ -760,6 +871,8 @@ class TestLoadManifestTimers:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: strat1\n'
@@ -774,7 +887,7 @@ class TestLoadManifestTimers:
         )
 
         with pytest.raises(ValueError, match='timer missing required field: id'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_timer_bool_interval_raises(self, tmp_path: Path) -> None:
         '''Timer with bool interval_seconds raises ValueError.'''
@@ -786,6 +899,8 @@ class TestLoadManifestTimers:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: strat1\n'
@@ -801,7 +916,7 @@ class TestLoadManifestTimers:
         )
 
         with pytest.raises(ValueError, match='interval_seconds must be an int'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)
 
     def test_duplicate_timer_id_raises(self, tmp_path: Path) -> None:
         '''Duplicate timer_id raises ValueError.'''
@@ -813,6 +928,8 @@ class TestLoadManifestTimers:
 
         _write_yaml(
             path,
+            f'account_id: test_acct\n'
+            f'allocated_capital: 10000\n'
             f'capital_pool: 10000\n'
             f'strategies:\n'
             f'  - id: strat1\n'
@@ -830,4 +947,4 @@ class TestLoadManifestTimers:
         )
 
         with pytest.raises(ValueError, match='duplicate timer_id'):
-            load_manifest(path, Decimal('20000'))
+            load_manifest(path)

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -60,6 +60,8 @@ def _make_strategy_spec(strategy_id: str = 'test_strategy') -> StrategySpec:
 
 def _make_manifest(strategies: tuple[StrategySpec, ...] | None = None) -> Manifest:
     return Manifest(
+        account_id='test_acct',
+        allocated_capital=Decimal('100000'),
         capital_pool=Decimal('10000'),
         strategies=strategies or (_make_strategy_spec(),),
     )
@@ -199,7 +201,6 @@ class TestSubmitActions:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             stp_mode=STPMode.CANCEL_TAKER,
         )
         state = InstanceState(
@@ -244,7 +245,6 @@ class TestSubmitActions:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             stp_mode=STPMode.CANCEL_TAKER,
         )
         state = InstanceState(
@@ -287,7 +287,6 @@ class TestSubmitActions:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             stp_mode=STPMode.CANCEL_TAKER,
         )
         sequencer = _make_sequencer()
@@ -318,7 +317,6 @@ class TestSubmitActions:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             stp_mode=STPMode.CANCEL_TAKER,
         )
         outbound = MagicMock(spec=['send_command', 'send_abort'])
@@ -340,7 +338,6 @@ class TestSubmitActions:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             stp_mode=STPMode.CANCEL_TAKER,
         )
         state = InstanceState(
@@ -378,7 +375,6 @@ class TestSubmitActions:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             stp_mode=STPMode.CANCEL_TAKER,
         )
         outbound = MagicMock(spec=['send_command', 'send_abort'])
@@ -658,7 +654,6 @@ class TestWaitTerminal:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             stp_mode=STPMode.CANCEL_TAKER,
         )
         q: queue.Queue[TradeOutcome] = queue.Queue()
@@ -711,7 +706,6 @@ class TestWaitTerminal:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             stp_mode=STPMode.CANCEL_TAKER,
         )
         q: queue.Queue[TradeOutcome] = queue.Queue()

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -59,12 +59,14 @@ def _attach_stub_manifest(
     *,
     account_id: str = 'test_acct',
     allocated_capital: Decimal = Decimal('50000'),
+    capital_pool: Decimal | None = None,
 ) -> MagicMock:
     '''Inject a mocked Manifest onto a sequencer to bypass _load_manifest.'''
 
     manifest = MagicMock()
     manifest.account_id = account_id
     manifest.allocated_capital = allocated_capital
+    manifest.capital_pool = capital_pool if capital_pool is not None else allocated_capital
     manifest.strategies = ()
     sequencer._manifest = manifest
     return manifest
@@ -764,7 +766,6 @@ class TestManifestLoading:
             sequencer._load_manifest()
 
         assert 'not found' in exc_info.value.reason.lower()
-
 
 
 class TestStrategyInstantiation:

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -54,18 +54,32 @@ _PLACEHOLDER_MANIFEST = Path('/placeholder/manifest.yaml')
 _PLACEHOLDER_STRATEGIES = Path('/placeholder/strategies')
 
 
+def _attach_stub_manifest(
+    sequencer: StartupSequencer,
+    *,
+    account_id: str = 'test_acct',
+    allocated_capital: Decimal = Decimal('50000'),
+) -> MagicMock:
+    '''Inject a mocked Manifest onto a sequencer to bypass _load_manifest.'''
+
+    manifest = MagicMock()
+    manifest.account_id = account_id
+    manifest.allocated_capital = allocated_capital
+    manifest.strategies = ()
+    sequencer._manifest = manifest
+    return manifest
+
+
 def _make_sequencer(
     state_store: StateStore | None = None,
     manifest_path: Path | None = None,
     strategies_base_path: Path | None = None,
-    allocated_capital: Decimal | None = None,
     strategy_state_path: Path | None = None,
 ) -> StartupSequencer:
     return StartupSequencer(
         state_store=state_store or _make_mock_state_store(),
         manifest_path=manifest_path or _PLACEHOLDER_MANIFEST,
         strategies_base_path=strategies_base_path or _PLACEHOLDER_STRATEGIES,
-        allocated_capital=allocated_capital or Decimal('10000'),
         strategy_state_path=strategy_state_path,
     )
 
@@ -83,7 +97,6 @@ class TestStartupSequencerConstruction:
                 state_store='not a state store',  # type: ignore[arg-type]
                 manifest_path=_PLACEHOLDER_MANIFEST,
                 strategies_base_path=_PLACEHOLDER_STRATEGIES,
-                allocated_capital=Decimal('10000'),
             )
 
     def test_invalid_manifest_path_rejected(self) -> None:
@@ -92,7 +105,6 @@ class TestStartupSequencerConstruction:
                 state_store=_make_mock_state_store(),
                 manifest_path='/placeholder/manifest.yaml',  # type: ignore[arg-type]
                 strategies_base_path=_PLACEHOLDER_STRATEGIES,
-                allocated_capital=Decimal('10000'),
             )
 
     def test_invalid_strategies_base_path_rejected(self) -> None:
@@ -101,43 +113,6 @@ class TestStartupSequencerConstruction:
                 state_store=_make_mock_state_store(),
                 manifest_path=_PLACEHOLDER_MANIFEST,
                 strategies_base_path='/placeholder/strategies',  # type: ignore[arg-type]
-                allocated_capital=Decimal('10000'),
-            )
-
-    def test_invalid_allocated_capital_rejected(self) -> None:
-        with pytest.raises(ValueError, match='must be a finite positive Decimal'):
-            StartupSequencer(
-                state_store=_make_mock_state_store(),
-                manifest_path=_PLACEHOLDER_MANIFEST,
-                strategies_base_path=_PLACEHOLDER_STRATEGIES,
-                allocated_capital=10000,  # type: ignore[arg-type]
-            )
-
-    def test_non_finite_allocated_capital_rejected(self) -> None:
-        with pytest.raises(ValueError, match='must be a finite positive Decimal'):
-            StartupSequencer(
-                state_store=_make_mock_state_store(),
-                manifest_path=_PLACEHOLDER_MANIFEST,
-                strategies_base_path=_PLACEHOLDER_STRATEGIES,
-                allocated_capital=Decimal('Infinity'),
-            )
-
-    def test_zero_allocated_capital_rejected(self) -> None:
-        with pytest.raises(ValueError, match='must be a finite positive Decimal'):
-            StartupSequencer(
-                state_store=_make_mock_state_store(),
-                manifest_path=_PLACEHOLDER_MANIFEST,
-                strategies_base_path=_PLACEHOLDER_STRATEGIES,
-                allocated_capital=Decimal('0'),
-            )
-
-    def test_negative_allocated_capital_rejected(self) -> None:
-        with pytest.raises(ValueError, match='must be a finite positive Decimal'):
-            StartupSequencer(
-                state_store=_make_mock_state_store(),
-                manifest_path=_PLACEHOLDER_MANIFEST,
-                strategies_base_path=_PLACEHOLDER_STRATEGIES,
-                allocated_capital=Decimal('-1000'),
             )
 
 
@@ -148,6 +123,8 @@ class TestStartupSequencerStart:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -180,6 +157,8 @@ class TestStartupSequencerStart:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -205,6 +184,8 @@ class TestStartupSequencerStart:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -231,6 +212,7 @@ class TestStateRecovery:
         mock_store = _make_mock_state_store()
         mock_store.recover.return_value = None
         sequencer = _make_sequencer(state_store=mock_store)
+        _attach_stub_manifest(sequencer)
 
         sequencer._recover_state()
 
@@ -241,6 +223,7 @@ class TestStateRecovery:
         mock_state = MagicMock()
         mock_store.recover.return_value = mock_state
         sequencer = _make_sequencer(state_store=mock_store)
+        _attach_stub_manifest(sequencer)
 
         sequencer._recover_state()
 
@@ -251,8 +234,8 @@ class TestStateRecovery:
         mock_store.recover.return_value = None
         sequencer = _make_sequencer(
             state_store=mock_store,
-            allocated_capital=Decimal('50000'),
         )
+        _attach_stub_manifest(sequencer, allocated_capital=Decimal('50000'))
 
         sequencer._recover_state()
 
@@ -264,6 +247,7 @@ class TestStateRecovery:
         mock_store = _make_mock_state_store()
         mock_store.recover.side_effect = RuntimeError('disk error')
         sequencer = _make_sequencer(state_store=mock_store)
+        _attach_stub_manifest(sequencer)
 
         with pytest.raises(StartupError, match='recover_state') as exc_info:
             sequencer._recover_state()
@@ -302,7 +286,7 @@ class TestExternalIntegrationStubs:
 
         sequencer = _make_sequencer()
         sequencer._praxis_outbound = outbound
-        sequencer._account_id = 'acc_001'
+        _attach_stub_manifest(sequencer, account_id='acc_001')
         sequencer._state = InstanceState(
             capital=CapitalState(capital_pool=Decimal('10000')),
         )
@@ -337,7 +321,7 @@ class TestExternalIntegrationStubs:
 
         sequencer = _make_sequencer()
         sequencer._praxis_outbound = outbound
-        sequencer._account_id = 'acc_001'
+        _attach_stub_manifest(sequencer, account_id='acc_001')
         sequencer._state = InstanceState(
             capital=CapitalState(capital_pool=Decimal('10000')),
         )
@@ -407,6 +391,8 @@ class TestStrategyStateRestoration:
 
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -422,8 +408,8 @@ class TestStrategyStateRestoration:
             strategies_base_path=tmp_path,
             strategy_state_path=strategy_state_path,
         )
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
 
         sequencer._restore_strategy_state()
@@ -436,6 +422,8 @@ class TestStrategyStateRestoration:
 
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -451,8 +439,8 @@ class TestStrategyStateRestoration:
             strategies_base_path=tmp_path,
             strategy_state_path=strategy_state_path,
         )
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
 
         sequencer._restore_strategy_state()
@@ -478,6 +466,8 @@ class TestStrategyStateRestoration:
 
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: ../evil\n'
@@ -493,8 +483,8 @@ class TestStrategyStateRestoration:
             strategies_base_path=tmp_path,
             strategy_state_path=strategy_state_path,
         )
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._runner = MagicMock()
 
         sequencer._restore_strategy_state()
@@ -509,6 +499,8 @@ class TestEventReplay:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -524,8 +516,8 @@ class TestEventReplay:
             manifest_path=manifest_path,
             strategies_base_path=tmp_path,
         )
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
 
         sequencer._replay_strategy_events()
@@ -535,6 +527,8 @@ class TestEventReplay:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -556,8 +550,8 @@ class TestEventReplay:
             manifest_path=manifest_path,
             strategies_base_path=tmp_path,
         )
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
         sequencer._runner.dispatch_event_replay = MagicMock()
 
@@ -570,6 +564,8 @@ class TestEventReplay:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -591,8 +587,8 @@ class TestEventReplay:
             manifest_path=manifest_path,
             strategies_base_path=tmp_path,
         )
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
         sequencer._runner.dispatch_event_replay = MagicMock()
 
@@ -608,6 +604,8 @@ class TestStartupDispatch:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -652,6 +650,8 @@ class TestStartupDispatch:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -676,6 +676,8 @@ class TestStartupDispatch:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -735,6 +737,8 @@ class TestManifestLoading:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 5000\n'
             'capital_pool: 5000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -762,6 +766,7 @@ class TestManifestLoading:
         assert 'not found' in exc_info.value.reason.lower()
 
 
+
 class TestStrategyInstantiation:
 
     def test_instantiate_strategies_creates_runner(self, tmp_path: Path) -> None:
@@ -769,6 +774,8 @@ class TestStrategyInstantiation:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 5000\n'
             'capital_pool: 5000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -801,6 +808,8 @@ class TestStrategyInstantiation:
         strategy_file = tmp_path / 'bad_import.py'
         strategy_file.write_text('import nonexistent_module_xyz_123\n')
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 5000\n'
             'capital_pool: 5000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -838,6 +847,8 @@ class TestCrashOnlyDesign:
         strategy_file = tmp_path / 'strat.py'
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -867,6 +878,8 @@ class TestCrashOnlyDesign:
 
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -883,8 +896,8 @@ class TestCrashOnlyDesign:
             strategies_base_path=tmp_path,
             strategy_state_path=strategy_state_path,
         )
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
         sequencer._runner.dispatch_load = MagicMock()
 
@@ -902,6 +915,8 @@ class TestCrashOnlyDesign:
 
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -918,8 +933,8 @@ class TestCrashOnlyDesign:
             strategies_base_path=tmp_path,
             strategy_state_path=strategy_state_path,
         )
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
         sequencer._runner.dispatch_load = MagicMock()
 
@@ -933,6 +948,8 @@ class TestCrashOnlyDesign:
 
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'
@@ -954,8 +971,8 @@ class TestCrashOnlyDesign:
             manifest_path=manifest_path,
             strategies_base_path=tmp_path,
         )
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
         sequencer._runner.dispatch_event_replay = MagicMock()
 
@@ -971,6 +988,8 @@ class TestCrashOnlyDesign:
 
         strategy_file.write_text(VALID_STRATEGY)
         manifest_path.write_text(
+            'account_id: test_acct\n'
+            'allocated_capital: 10000\n'
             'capital_pool: 10000\n'
             'strategies:\n'
             '  - id: test_strat\n'

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -28,13 +28,12 @@ def _config(stp_mode: STPMode = STPMode.CANCEL_TAKER) -> InstanceConfig:
     return InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
         stp_mode=stp_mode,
     )
 
 
 def _state() -> InstanceState:
-    return InstanceState.from_config(_config())
+    return InstanceState.fresh(Decimal('10000'))
 
 
 def _now() -> datetime:

--- a/tests/test_validator_capital_stage.py
+++ b/tests/test_validator_capital_stage.py
@@ -31,9 +31,8 @@ def _make_context(
     config = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
     )
-    state = InstanceState.from_config(config)
+    state = InstanceState.fresh(Decimal('10000'))
     return ValidationRequestContext(
         strategy_id=strategy_id,
         action=action,

--- a/tests/test_validator_health_platform_limits_stage.py
+++ b/tests/test_validator_health_platform_limits_stage.py
@@ -35,7 +35,6 @@ def _make_context() -> ValidationRequestContext:
     config = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
     )
     return ValidationRequestContext(
         strategy_id='strat_a',
@@ -43,7 +42,7 @@ def _make_context() -> ValidationRequestContext:
         order_notional=Decimal('100'),
         estimated_fees=Decimal('1'),
         strategy_budget=Decimal('5000'),
-        state=InstanceState.from_config(config),
+        state=InstanceState.fresh(Decimal('10000')),
         config=config,
     )
 

--- a/tests/test_validator_intake_stage.py
+++ b/tests/test_validator_intake_stage.py
@@ -31,7 +31,6 @@ def _make_context(**overrides: Any) -> ValidationRequestContext:
     config = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
     )
     defaults: dict[str, Any] = {
         'strategy_id': 'strat_a',
@@ -43,7 +42,7 @@ def _make_context(**overrides: Any) -> ValidationRequestContext:
         'order_notional': Decimal('100'),
         'estimated_fees': Decimal('1'),
         'strategy_budget': Decimal('5000'),
-        'state': InstanceState.from_config(config),
+        'state': InstanceState.fresh(Decimal('10000')),
         'config': config,
     }
     defaults.update(overrides)
@@ -397,7 +396,7 @@ class TestRfcStageOneHooks:
         assert decision.reason_code == 'INTAKE_TRADE_REFERENCE_INVALID'
 
     def test_reference_integrity_exit_size_bound(self) -> None:
-        state = InstanceState.from_config(_make_context().config)
+        state = InstanceState.fresh(Decimal('10000'))
         state.positions['t1'] = Position(
             trade_id='t1',
             strategy_id='strat_a',
@@ -516,10 +515,9 @@ class TestRfcStageOneHooks:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             duplicate_window_ms=1000,
         )
-        state = InstanceState.from_config(config)
+        state = InstanceState.fresh(Decimal('10000'))
 
         times = [
             datetime(2026, 3, 23, 10, 0, 0, tzinfo=timezone.utc),
@@ -548,7 +546,6 @@ class TestRfcStageOneHooks:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
         )
         active_command_ids: set[str] = set()
         hooks = build_default_intake_hooks(
@@ -573,7 +570,6 @@ class TestRfcStageOneHooks:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
         )
         active_command_ids = {'cmd_mod', 'cmd_done'}
         modifiable_command_ids: set[str] = set()
@@ -610,7 +606,6 @@ class TestRfcStageOneHooks:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             max_order_rate=1,
         )
 
@@ -639,7 +634,6 @@ class TestRfcStageOneHooks:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             max_order_rate=2,
         )
 

--- a/tests/test_validator_pipeline_executor.py
+++ b/tests/test_validator_pipeline_executor.py
@@ -30,7 +30,6 @@ def _make_context(**overrides: Any) -> ValidationRequestContext:
     config = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
     )
     defaults: dict[str, Any] = {
         'strategy_id': 'strat_a',
@@ -40,7 +39,7 @@ def _make_context(**overrides: Any) -> ValidationRequestContext:
         'current_order_notional': None,
         'estimated_fees': Decimal('1'),
         'strategy_budget': Decimal('5000'),
-        'state': InstanceState.from_config(config),
+        'state': InstanceState.fresh(Decimal('10000')),
         'config': config,
     }
     defaults.update(overrides)

--- a/tests/test_validator_pipeline_models.py
+++ b/tests/test_validator_pipeline_models.py
@@ -23,7 +23,6 @@ def _make_config() -> InstanceConfig:
     return InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
     )
 
 
@@ -35,7 +34,7 @@ def _make_context(**overrides: Any) -> ValidationRequestContext:
         'order_notional': Decimal('100'),
         'estimated_fees': Decimal('1'),
         'strategy_budget': Decimal('5000'),
-        'state': InstanceState.from_config(config),
+        'state': InstanceState.fresh(Decimal('10000')),
         'config': config,
     }
     defaults.update(overrides)

--- a/tests/test_validator_price_stage.py
+++ b/tests/test_validator_price_stage.py
@@ -25,7 +25,6 @@ def _make_context(**overrides: Any) -> ValidationRequestContext:
     config = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
     )
     defaults: dict[str, Any] = {
         'strategy_id': 'strat_a',
@@ -33,7 +32,7 @@ def _make_context(**overrides: Any) -> ValidationRequestContext:
         'order_notional': Decimal('100'),
         'estimated_fees': Decimal('1'),
         'strategy_budget': Decimal('5000'),
-        'state': InstanceState.from_config(config),
+        'state': InstanceState.fresh(Decimal('10000')),
         'config': config,
     }
     defaults.update(overrides)
@@ -76,7 +75,6 @@ class TestPriceContracts:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
             book_staleness_max_seconds=3,
             max_spread_bps=Decimal('7'),
             price_deviation_max_bps=Decimal('9'),
@@ -94,7 +92,6 @@ class TestPriceContracts:
         config = InstanceConfig(
             account_id='acc_001',
             venue='binance_spot',
-            allocated_capital=Decimal('10000'),
         )
 
         limits = build_price_stage_limits_from_config(config)

--- a/tests/test_validator_risk_stage.py
+++ b/tests/test_validator_risk_stage.py
@@ -28,9 +28,8 @@ def _make_context(
     config = InstanceConfig(
         account_id='acc_001',
         venue='binance_spot',
-        allocated_capital=Decimal('10000'),
     )
-    state = InstanceState.from_config(config)
+    state = InstanceState.fresh(Decimal('10000'))
     state.risk = risk_state or RiskState()
 
     defaults: dict[str, Any] = {

--- a/tests/test_wire_sensors.py
+++ b/tests/test_wire_sensors.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-from decimal import Decimal
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -121,6 +120,8 @@ def _make_manifest_yaml(
 
     pid_str = ', '.join(str(p) for p in pids)
     manifest_path.write_text(
+        f'account_id: test_acct\n'
+        f'allocated_capital: 10000\n'
         f'capital_pool: 10000\n'
         f'strategies:\n'
         f'  - id: test_strat\n'
@@ -146,11 +147,10 @@ class TestWireSensors:
             state_store=_make_mock_state_store(),
             manifest_path=manifest_path,
             strategies_base_path=tmp_path,
-            allocated_capital=Decimal('10000'),
         )
 
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
         sequencer._wire_sensors()
 
@@ -172,11 +172,10 @@ class TestWireSensors:
             state_store=_make_mock_state_store(),
             manifest_path=manifest_path,
             strategies_base_path=tmp_path,
-            allocated_capital=Decimal('10000'),
         )
 
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
         sequencer._wire_sensors()
 
@@ -197,11 +196,10 @@ class TestWireSensors:
             state_store=_make_mock_state_store(),
             manifest_path=manifest_path,
             strategies_base_path=tmp_path,
-            allocated_capital=Decimal('10000'),
         )
 
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
 
         with pytest.raises(StartupError, match='wire_sensors'):
@@ -217,11 +215,10 @@ class TestWireSensors:
             state_store=_make_mock_state_store(),
             manifest_path=manifest_path,
             strategies_base_path=tmp_path,
-            allocated_capital=Decimal('10000'),
         )
 
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
 
         with pytest.raises(StartupError, match='wire_sensors'):
@@ -237,11 +234,10 @@ class TestWireSensors:
             state_store=_make_mock_state_store(),
             manifest_path=manifest_path,
             strategies_base_path=tmp_path,
-            allocated_capital=Decimal('10000'),
         )
 
-        sequencer._recover_state()
         sequencer._load_manifest()
+        sequencer._recover_state()
         sequencer._instantiate_strategies()
         sequencer._wire_sensors()
 


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Makes the strategy `Manifest` the single source of truth for per-instance identity and capital ceiling, collapsing two scattered sources (env vars + `InstanceConfig.allocated_capital`) into one self-describing YAML file per account. Adds required `account_id: str` and `allocated_capital: Decimal` fields to `Manifest` with internal validation that `capital_pool ≤ allocated_capital`. Drops the `allocated_capital` parameter from `load_manifest(path)` and drops both `allocated_capital` and `account_id` constructor parameters from `StartupSequencer` — they now come from the loaded manifest. Reorders the startup sequence to run `_load_manifest` first so `_recover_state`, `_register_with_trading`, and `_reconcile_capital` can read identity and capital from `self._manifest`. Removes the now-unused `allocated_capital` field from `InstanceConfig`. Renames `InstanceState.from_config(config)` → `InstanceState.fresh(allocated_capital)` — the factory never needed `config`, only the ceiling, and dropping it removes the unused `InstanceConfig` dependency from `nexus.core.domain`. Updates every manifest YAML fixture, direct `Manifest(...)` construction, `InstanceConfig(...)` caller, and `InstanceState.fresh(...)` caller across the test suite. Adds `load_manifest` validation tests for missing / invalid / non-positive `allocated_capital` and for missing / blank `account_id`. Bumps to v0.28.0.

Unblocks Praxis #68 multi-account launcher work (enumerating `*.yaml` in `MANIFESTS_DIR`, deriving `account_id` and `allocated_capital` from each manifest, looking up per-account `BINANCE_API_KEY_<ACCOUNT_ID>` / `BINANCE_API_SECRET_<ACCOUNT_ID>` from env).

**Breaking changes for callers:**
- Manifest YAMLs must now declare `account_id:` and `allocated_capital:` alongside the existing `capital_pool:` and `strategies:` blocks
- `load_manifest(path, allocated_capital)` → `load_manifest(path)`
- `StartupSequencer(state_store, manifest_path, strategies_base_path, allocated_capital, ..., account_id=...)` → `StartupSequencer(state_store, manifest_path, strategies_base_path, ...)`
- `InstanceConfig(account_id, venue, allocated_capital, ...)` → `InstanceConfig(account_id, venue, ...)`
- `InstanceState.from_config(config)` → `InstanceState.fresh(allocated_capital)`

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran \`python -m pytest\` locally without errors (1038 passing)
- [ ] I updated \`/docs\` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable