### PR TITLE
fix: drop Limen @v2.4.3 pin to match Praxis (always take latest Limen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.30.1 on 25th of April, 2026
+
+- Drop `@v2.4.3` ref from `vaquum_limen` dependency in `pyproject.toml`; the dependency now reads `vaquum_limen @ git+https://github.com/Vaquum/Limen`. v0.30.0 pinned Limen to `@v2.4.3` to converge with Praxis, but Praxis has since moved to the untagged form, so the two siblings declared the same package with two different URL specifiers — pip's resolver treats those as conflicting packages and fails install with `ResolutionImpossible` for any consumer (e.g. `backtest_simulator`) that pulls both Praxis and Nexus into one venv. Untagging here re-converges the URL strings so pip unifies them, and matches the operator policy "always take the latest Limen"
+
 ## v0.1.0 on 16th of March, 2026
 
 - Add CI pipeline mirroring Praxis: Ruff, Mypy strict, pytest, CodeQL workflows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.30.0"
+version = "0.30.1"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.10"
-dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0", "pyyaml>=6.0", "vaquum_limen @ git+https://github.com/Vaquum/Limen@v2.4.3"]
+dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0", "pyyaml>=6.0", "vaquum_limen @ git+https://github.com/Vaquum/Limen"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

- v0.30.0 pinned `vaquum_limen` to `@v2.4.3` to converge with Praxis. Praxis has since dropped the tag and now declares `vaquum_limen @ git+https://github.com/Vaquum/Limen` (untagged → master), so the two siblings now declare the same package with two different URL specifiers.
- Any consumer that pulls both Praxis and Nexus into one venv (e.g. `backtest_simulator`) trips pip's resolver with `ResolutionImpossible` at install time — pip treats distinct URL strings as distinct packages even when they point at the same repo at the same SHA.
- This drops the `@v2.4.3` ref so the URL matches Praxis's untagged form. pip unifies the two transitive specs, install resolves, and the operator policy "always take the latest Limen" is honoured in both Nexus and Praxis venvs.
- PATCH bump 0.30.0 → 0.30.1.

## Repro of the failure (from `backtest_simulator` PR #15 CI)

```
ERROR: Cannot install backtest_simulator and vaquum-praxis because these package versions have conflicting dependencies.

The conflict is caused by:
    vaquum-praxis 0.44.0 depends on vaquum-limen 2.4.3 (from git+https://github.com/Vaquum/Limen)
    vaquum-nexus 0.30.0 depends on vaquum-limen 2.4.3 (from git+https://github.com/Vaquum/Limen@v2.4.3)
```

Same Limen, two different URL strings → ResolutionImpossible.

## Test plan

- [ ] CI: pr_checks_ruff / pr_checks_mypy / pr_checks_tests / pr_checks_codeql green
- [ ] Post-merge: `pip install backtest_simulator[integration]` resolves on a clean Python 3.12 venv