### PR TITLE
fix: EXIT ACKs no-op the capital lifecycle instead of failing order_ack (v0.58.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,3 +714,17 @@
 ### Fix
 
 - Closes [Vaquum/Nexus#82](https://github.com/Vaquum/Nexus/issues/82). Companion Praxis-side fix at [Vaquum/Praxis#142](https://github.com/Vaquum/Praxis/issues/142) — the launcher changes that compute `intended_full_close`, carry it through `_build_order_context`, and call `OutcomeProcessor.close_as_dust` in the rejection branch ship there. Nexus alone is dormant until that companion lands (the new field defaults to `False` so behavior is unchanged on every existing caller).
+
+## v0.58.0 on 10th of June, 2026
+
+### NOTE
+
+- During the Praxis v0.76.0 paper-trade validation (epoch 22, 2026-06-10), once outcome processing kept pace with strategy ticks, every EXIT ACK surfaced as `order_ack failed: order '<command_id>' not found` — 232+ failures in under an hour. Root cause: `CapitalController.order_ack` transitions a `TrackedOrder` from IN_FLIGHT to WORKING, but `TrackedOrder`s are only created by `send_order` from a capital reservation, and EXIT commands never reserve capital. The failure is structural — an EXIT ACK can never find an order record. It predates this release; the historical `OutcomeLoop` queue lag simply meant EXIT ACKs were rarely processed promptly enough for the failure to surface in volume.
+
+### Update
+
+- Update [`OutcomeProcessor._handle_ack`](nexus/infrastructure/praxis_connector/outcome_processor.py) to accept the `OrderContext` and return a no-op success for `is_entry=False` outcomes — the venue acknowledged the sell and there is no capital lifecycle to transition. ENTER ACKs are unchanged: they still call `CapitalController.order_ack` and transition IN_FLIGHT to WORKING. The no-op success also restores the normal `OutcomeAcked` spine append on the Praxis side, so EXIT ACK outcomes no longer accumulate un-acked in the event spine and replay cleanly at boot
+
+### Add
+
+- Add 3 tests to [`tests/test_outcome_processor.py::TestOutcomeProcessorAck`](tests/test_outcome_processor.py): EXIT ACK returns success with `capital_updated=False`; EXIT ACK leaves `in_flight_order_notional` and `working_order_notional` untouched while an unrelated ENTER order is in flight; ENTER ACK still transitions the full reserved total from in-flight to working

--- a/nexus/infrastructure/praxis_connector/outcome_processor.py
+++ b/nexus/infrastructure/praxis_connector/outcome_processor.py
@@ -133,7 +133,7 @@ class OutcomeProcessor:
             )
 
         if outcome.outcome_type == TradeOutcomeType.ACK:
-            result = self._handle_ack(outcome)
+            result = self._handle_ack(outcome, context)
         elif outcome.outcome_type in (
             TradeOutcomeType.PARTIAL, TradeOutcomeType.FILLED,
         ):
@@ -149,7 +149,34 @@ class OutcomeProcessor:
 
         return result
 
-    def _handle_ack(self, outcome: TradeOutcome) -> ProcessResult:
+    def _handle_ack(
+        self,
+        outcome: TradeOutcome,
+        context: OrderContext,
+    ) -> ProcessResult:
+        '''Acknowledge a venue-accepted order against the capital lifecycle.
+
+        ENTER orders carry a capital reservation that `send_order` converted
+        into an IN_FLIGHT `TrackedOrder`; their ACK transitions that order to
+        WORKING via `CapitalController.order_ack`. EXIT orders never reserve
+        capital, so no `TrackedOrder` exists for them — their ACK is a
+        no-op success rather than a structural `order not found` failure.
+
+        Args:
+            outcome: Inbound ACK outcome from the Trading sub-system.
+            context: Metadata identifying the order side.
+
+        Returns:
+            ProcessResult with `capital_updated=True` only when an ENTER
+            order transitioned IN_FLIGHT to WORKING.
+        '''
+
+        if not context.is_entry:
+            return ProcessResult(
+                success=True,
+                outcome_type=outcome.outcome_type,
+            )
+
         result = self._capital.order_ack(outcome.command_id)
 
         if not result.success:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.57.0"
+version = "0.58.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.10"
-dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0", "pyyaml>=6.0", "vaquum_limen @ git+https://github.com/Vaquum/Limen@v4.0.1"]
+dependencies = ["structlog>=24.0", "orjson>=3.10", "msgpack>=1.0", "pyyaml>=6.0", "vaquum_limen @ git+https://github.com/Vaquum/Limen@06815fabd238d470e50b129b24d12e79f9a69995"]
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_outcome_processor.py
+++ b/tests/test_outcome_processor.py
@@ -144,6 +144,72 @@ class TestOutcomeProcessorAck:
         assert result.error_reason is not None
         assert 'order_ack failed' in result.error_reason
 
+    def test_exit_ack_noop_success(self) -> None:
+        proc, _, _, _, _tmp = _make_processor()
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.ACK,
+            timestamp=_now(),
+        )
+
+        result = proc.process(outcome, _exit_context())
+        assert result.success is True
+        assert result.outcome_type == TradeOutcomeType.ACK
+        assert result.capital_updated is False
+        assert result.position_updated is False
+
+    def test_exit_ack_does_not_touch_capital(self) -> None:
+        proc, ctrl, _, _, _tmp = _make_processor()
+        _setup_in_flight_order(ctrl, 'cmd_enter')
+
+        in_flight_before = ctrl._state.in_flight_order_notional
+        working_before = ctrl._state.working_order_notional
+
+        outcome = TradeOutcome(
+            outcome_id='out_exit_ack',
+            command_id='cmd_exit',
+            outcome_type=TradeOutcomeType.ACK,
+            timestamp=_now(),
+        )
+
+        ctx = OrderContext(
+            command_id='cmd_exit',
+            strategy_id='strat_001',
+            trade_id='trade_001',
+            side=OrderSide.SELL,
+            order_size=Decimal('0.01'),
+            order_notional=Decimal('100'),
+            estimated_fees=Decimal('1'),
+            is_entry=False,
+        )
+
+        result = proc.process(outcome, ctx)
+        assert result.success is True
+        assert ctrl._state.in_flight_order_notional == in_flight_before
+        assert ctrl._state.working_order_notional == working_before
+
+    def test_entry_ack_still_transitions_capital(self) -> None:
+        proc, ctrl, _, _, _tmp = _make_processor()
+        _setup_in_flight_order(ctrl)
+
+        in_flight_before = ctrl._state.in_flight_order_notional
+        assert in_flight_before > _ZERO
+
+        outcome = TradeOutcome(
+            outcome_id='out_001',
+            command_id='cmd_001',
+            outcome_type=TradeOutcomeType.ACK,
+            timestamp=_now(),
+        )
+
+        result = proc.process(outcome, _entry_context())
+        assert result.success is True
+        assert result.capital_updated is True
+        assert ctrl._state.in_flight_order_notional == _ZERO
+        assert ctrl._state.working_order_notional == in_flight_before
+
 
 class TestOutcomeProcessorFill:
     def test_fill_success(self) -> None:


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

EXIT ACK outcomes structurally fail `order_ack failed: order '<command_id>' not found` because `CapitalController.order_ack` transitions a `TrackedOrder` from IN_FLIGHT to WORKING — and `TrackedOrder`s are only created by `send_order` from a capital reservation, which EXIT commands never make. The failure predates this release: the historical `OutcomeLoop` queue lag meant EXIT ACKs were rarely processed promptly enough to surface in volume. Once outcome processing kept pace with strategy ticks during the Praxis paper-trade validation on 2026-06-10, 232+ failures surfaced in under an hour.

### `fix:` `_handle_ack` becomes context-aware; EXIT ACKs are a no-op success

[`OutcomeProcessor._handle_ack`](nexus/infrastructure/praxis_connector/outcome_processor.py) now accepts the `OrderContext` and returns success without touching the capital controller when `context.is_entry` is `False` — the venue acknowledged the sell and there is no capital lifecycle to transition. ENTER ACKs are unchanged: they still call `CapitalController.order_ack` and transition IN_FLIGHT to WORKING with `capital_updated=True`.

The no-op success also restores the normal `OutcomeAcked` spine append on the Praxis side (the launcher only appends the ack on `result.success`), so EXIT ACK outcomes no longer accumulate un-acked in the event spine and replay cleanly at boot.

## Validation on prod paper-trade

Deployed to the Praxis paper-trade host (binsim backend) as a mounted-module patch and observed for a full trading cycle (epoch 22, 2026-06-10): **1,284 SELL fills processed with zero `order_ack` failures**, versus 232+ failures in the equivalent window of the prior epoch running without the fix. ENTER ACK capital transitions verified intact in the same window (zero mutation failures across 4,600+ commands).

## Tests

3 new cases in [`tests/test_outcome_processor.py::TestOutcomeProcessorAck`](tests/test_outcome_processor.py):

- `test_exit_ack_noop_success` — EXIT ACK returns `success=True` with `capital_updated=False` and `position_updated=False`
- `test_exit_ack_does_not_touch_capital` — EXIT ACK leaves `in_flight_order_notional` and `working_order_notional` untouched while an unrelated ENTER order is in flight
- `test_entry_ack_still_transitions_capital` — ENTER ACK still moves the full reserved total from in-flight to working (guarded by an explicit `in_flight_before > _ZERO` precondition so the assertion cannot pass trivially)

`ruff` clean, `mypy` clean (75 source files), **1,491 tests pass** / 17 skipped (was 1,488 / 17).

Bumps version 0.57.0 → 0.58.0. Companion Praxis-side changes (synchronous accounting at the outcome route boundary + dust-close gate) ship separately and will pin this release.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [ ] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable