### PR TITLE
fix: poll for IPC refcount drain in the broken-pool resilience test

### DIFF
--- a/tests/test_predict_loop.py
+++ b/tests/test_predict_loop.py
@@ -531,6 +531,15 @@ class TestPredictLoopResilience:
             assert loop._scheduler_thread is not None
             assert loop._scheduler_thread.is_alive()
             assert runner.dispatch_signal.called is False
+
+            deadline = time.monotonic() + 2.0
+
+            while (
+                any(count != 0 for count in loop._ipc_refs.values())
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.02)
+
             assert all(count == 0 for count in loop._ipc_refs.values())
 
             loop.stop()


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Closes #89. `test_broken_pool_submit_does_not_kill_scheduler` asserted the `_ipc_refs` rollback immediately after observing the submit attempt; on loaded CI runners the scheduler thread's rollback can land after the fixed wait, failing the run (observed 2026-06-10, passed on rerun, passes locally consistently). The assertion now polls for the refcount drain with a 2s deadline before asserting the final state — the same pattern as the `OutcomeLoop` retry tests.

Test-only change: no CHANGELOG entry / version bump per house convention for non-code changes.

`ruff` clean; 14 predict-loop tests pass.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [ ] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [ ] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [ ] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [ ] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable