### PR TITLE
refactor: move snapshot-lock ownership into StateStore (v0.61.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -755,3 +755,19 @@
 ### Fix
 
 - Fix the timing-flaky `test_broken_pool_submit_does_not_kill_scheduler` in [`tests/test_predict_loop.py`](tests/test_predict_loop.py): poll for the IPC refcount drain with a deadline instead of a fixed sleep ([#89](https://github.com/Vaquum/Nexus/issues/89))
+
+## v0.61.0 on 13th of June, 2026
+
+### NOTE
+
+- Completes the snapshot-lock ownership move begun in v0.60.0. v0.60.0 added the opt-in `StateSnapshotLocks` bundle but left it unwired, because enabling it conflicts with the two sites that already wrap `StateStore.checkpoint()` in the same locks: once the store acquires `positions_lock` + `capital_lock` internally, an external wrap re-acquires non-reentrant locks and self-deadlocks. This release moves snapshot-serialization locking fully into `StateStore` and deletes both external checkpoint wraps. `_final_checkpoint` and `SnapshotScheduler._checkpoint` now call `checkpoint()` bare; the store owns the locking when the launcher builds it with the bundle. The `state.risk.lock is positions_lock` identity that the wraps used to enforce (so `positions_lock` also covered `state.risk.per_strategy` serialization) now belongs at the launcher composition point where the bundle is built — not in these loops, which no longer serialize state. `ShutdownSequencer` keeps `positions_lock` only for its direct `state.positions` access (`_dispatch_shutdown`, `_submit_exit`), which the bundle does not cover ([#92](https://github.com/Vaquum/Nexus/issues/92))
+
+### Update
+
+- Update [`ShutdownSequencer._final_checkpoint`](nexus/startup/shutdown_sequencer.py) to call `state_store.checkpoint()` directly with no `positions_lock` / `capital_lock` wrap — `StateStore` owns the snapshot locks via its `StateSnapshotLocks` bundle and acquires them in the same chain order inside `checkpoint()`, so an external wrap would re-acquire the same non-reentrant locks and self-deadlock. FINAL-MAJOR-05 coverage (`state.positions` / `risk.per_strategy` / `capital.per_strategy_deployed` serialization cannot race a live OutcomeLoop worker) is preserved by the bundle plus the launcher's `state.risk.lock is positions_lock` wiring
+- Remove the `capital_controller` parameter from [`ShutdownSequencer`](nexus/startup/shutdown_sequencer.py): it was used only by the deleted `_final_checkpoint` wrap. The `state.risk.lock is positions_lock` and `capital_controller`-required construction guards are removed with it — the identity is now enforced at the launcher where the bundle is built. `positions_lock` stays for the direct `state.positions` iteration sites
+- Remove the `positions_lock` and `capital_lock_cm` parameters from [`SnapshotScheduler`](nexus/infrastructure/snapshot_scheduler.py) and its construction guards: `_checkpoint` now calls `state_store.checkpoint()` bare (the store owns the locks), so the scheduler no longer needs them
+
+### Add
+
+- Add 1 test to [`tests/test_shutdown_sequencer.py`](tests/test_shutdown_sequencer.py): a real `StateStore` built with the `StateSnapshotLocks` bundle completes `_final_checkpoint` without deadlocking (the store acquires the locks the method no longer wraps), plus a test that `_final_checkpoint` holds no external `positions_lock` during the store call and that the sequencer accepts `positions_lock` without enforcing the `state.risk.lock` identity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -770,4 +770,4 @@
 
 ### Add
 
-- Add 1 test to [`tests/test_shutdown_sequencer.py`](tests/test_shutdown_sequencer.py): a real `StateStore` built with the `StateSnapshotLocks` bundle completes `_final_checkpoint` without deadlocking (the store acquires the locks the method no longer wraps), plus a test that `_final_checkpoint` holds no external `positions_lock` during the store call and that the sequencer accepts `positions_lock` without enforcing the `state.risk.lock` identity
+- Add tests to [`tests/test_shutdown_sequencer.py`](tests/test_shutdown_sequencer.py): a real `StateStore` built with the `StateSnapshotLocks` bundle completes `_final_checkpoint` without deadlocking (the store acquires the locks the method no longer wraps); `_final_checkpoint` holds no external `positions_lock` during the store call; and the sequencer accepts `positions_lock` without enforcing the `state.risk.lock` identity

--- a/nexus/infrastructure/snapshot_scheduler.py
+++ b/nexus/infrastructure/snapshot_scheduler.py
@@ -7,11 +7,14 @@ capital reconciliation (conditional) and at graceful shutdown, leaving
 the WAL to grow unbounded between restarts and every read of
 `snapshot.bin` between restarts stale.
 
-The snapshot-serialization locks (`positions_lock` + `capital_lock`)
-are owned by `StateStore` via its `StateSnapshotLocks` bundle and are
-acquired inside `checkpoint()`, so this loop calls `checkpoint()`
-directly — wrapping it would re-acquire the same non-reentrant locks
-and self-deadlock.
+Snapshot-serialization locking is owned by `StateStore`: when it is
+built with a `StateSnapshotLocks` bundle (as the launcher does for the
+multi-threaded runtime), `checkpoint()` acquires `positions_lock` +
+`capital_lock` itself, so this loop calls `checkpoint()` directly —
+wrapping it would re-acquire the same non-reentrant locks and
+self-deadlock. Without the bundle (single-threaded test paths) the
+store does not lock and none is needed; configuring it is the caller's
+responsibility.
 '''
 
 from __future__ import annotations
@@ -123,7 +126,7 @@ class SnapshotScheduler:
             self._schedule_locked()
 
     def _checkpoint(self) -> None:
-        '''Call `state_store.checkpoint()`; the store owns the locks.
+        '''Call `state_store.checkpoint()`; the store owns any locking.
 
         A failure here must not abort the loop — disk-full, transient
         I/O error, or msgpack failure are all logged at ERROR and the
@@ -131,11 +134,13 @@ class SnapshotScheduler:
         happens on a failed checkpoint) so no state is lost; the next
         successful checkpoint catches up.
 
-        The snapshot-serialization locks are acquired inside
-        `checkpoint()` (`StateStore`'s `StateSnapshotLocks` bundle), so
-        this loop does not wrap the call — a racing `stop()` between the
-        `_tick` entry check and the checkpoint completing simply writes
-        one extra snapshot; duplicate checkpoints are harmless.
+        This loop does not wrap the call: when the store was built with
+        a `StateSnapshotLocks` bundle it acquires the snapshot locks
+        inside `checkpoint()`, and wrapping would re-acquire them and
+        self-deadlock; without the bundle no locking happens either way.
+        A racing `stop()` between the `_tick` entry check and the
+        checkpoint completing simply writes one extra snapshot;
+        duplicate checkpoints are harmless.
         '''
 
         try:

--- a/nexus/infrastructure/snapshot_scheduler.py
+++ b/nexus/infrastructure/snapshot_scheduler.py
@@ -7,26 +7,17 @@ capital reconciliation (conditional) and at graceful shutdown, leaving
 the WAL to grow unbounded between restarts and every read of
 `snapshot.bin` between restarts stale.
 
-The checkpoint must observe the same lock chain as the rest of the
-state-mutation path:
-
-    command_registry_lock -> positions_lock -> CapitalController._lock
-                                            -> wal_lock
-
-`state_store.checkpoint()` acquires `wal_lock` internally. This loop
-holds `positions_lock` and `CapitalController._lock` around the call
-so the snapshot captures a consistent point-in-time view of
-`state.positions`, `state.risk.per_strategy`, and
-`state.capital.per_strategy_deployed` (same lock pattern as
-`shutdown_sequencer._checkpoint_state` at `shutdown_sequencer.py:935`).
+The snapshot-serialization locks (`positions_lock` + `capital_lock`)
+are owned by `StateStore` via its `StateSnapshotLocks` bundle and are
+acquired inside `checkpoint()`, so this loop calls `checkpoint()`
+directly — wrapping it would re-acquire the same non-reentrant locks
+and self-deadlock.
 '''
 
 from __future__ import annotations
 
 import logging
 import threading
-from collections.abc import Callable
-from contextlib import AbstractContextManager, nullcontext
 
 from nexus.core.domain.instance_state import InstanceState
 from nexus.infrastructure.state_store import StateStore
@@ -46,15 +37,6 @@ class SnapshotScheduler:
             Recommended 60-600s; default 300 (5 min). Smaller intervals
             shrink the WAL replay-on-recovery window at the cost of more
             disk I/O per hour.
-        positions_lock: Optional `threading.Lock` shared with PredictLoop /
-            OutcomeProcessor / ShutdownSequencer (the same object stored
-            at `state.risk.lock`). Held around `checkpoint()` so the
-            snapshot does not capture a partially-mutated state. None
-            falls back to `nullcontext()` for legacy single-threaded
-            test paths.
-        capital_lock_cm: Optional callable returning a context manager
-            for `CapitalController._lock`. Held around `checkpoint()`
-            for the same reason. None falls back to `nullcontext()`.
     '''
 
     def __init__(
@@ -62,8 +44,6 @@ class SnapshotScheduler:
         state_store: StateStore,
         state: InstanceState,
         interval_seconds: float = 300.0,
-        positions_lock: threading.Lock | None = None,
-        capital_lock_cm: Callable[[], AbstractContextManager[None]] | None = None,
     ) -> None:
         if (
             isinstance(interval_seconds, bool)
@@ -73,45 +53,9 @@ class SnapshotScheduler:
             msg = 'SnapshotScheduler.interval_seconds must be a positive number'
             raise ValueError(msg)
 
-        if positions_lock is not None and (
-            not hasattr(state.risk, 'lock')
-            or state.risk.lock is not positions_lock
-        ):
-            risk_lock = getattr(state.risk, 'lock', '<missing>')
-            msg = (
-                'SnapshotScheduler requires `state.risk.lock is positions_lock` '
-                'whenever `positions_lock` is supplied. `checkpoint()` → '
-                '`serialize_state()` iterates `state.risk.per_strategy` and '
-                '`state.capital.per_strategy_deployed` under positions_lock; '
-                'consistency with OutcomeProcessor (writes per_strategy under '
-                '`state.risk.lock_cm()`) requires the same lock object. Without '
-                'identity-equal locks the serializer iterates `per_strategy` '
-                'unguarded against new-strategy inserts (FINAL-MAJOR-05 race). '
-                f'Got positions_lock={positions_lock!r}, '
-                f'state.risk.lock={risk_lock!r}.'
-            )
-            raise RuntimeError(msg)
-
-        if positions_lock is not None and capital_lock_cm is None:
-            msg = (
-                'SnapshotScheduler requires `capital_lock_cm` whenever '
-                '`positions_lock` is supplied. `checkpoint()` → '
-                '`serialize_state()` iterates `state.capital.per_strategy_deployed` '
-                'and the capital aggregate notional fields; without holding '
-                "CapitalController._lock the capital-side `dictionary changed "
-                'size during iteration` race against a still-alive '
-                'OutcomeProcessor worker remains reachable. The positions_lock '
-                'and capital_lock_cm form a lock-cluster — partial wiring is '
-                'a silent miswire. Mirrors '
-                '`shutdown_sequencer.py:206-216` enforcement.'
-            )
-            raise RuntimeError(msg)
-
         self._state_store = state_store
         self._state = state
         self._interval_seconds = float(interval_seconds)
-        self._positions_lock = positions_lock
-        self._capital_lock_cm = capital_lock_cm
         self._timer: threading.Timer | None = None
         self._running = False
         self._lock = threading.Lock()
@@ -179,7 +123,7 @@ class SnapshotScheduler:
             self._schedule_locked()
 
     def _checkpoint(self) -> None:
-        '''Acquire the lock chain and call `state_store.checkpoint()`.
+        '''Call `state_store.checkpoint()`; the store owns the locks.
 
         A failure here must not abort the loop — disk-full, transient
         I/O error, or msgpack failure are all logged at ERROR and the
@@ -187,24 +131,14 @@ class SnapshotScheduler:
         happens on a failed checkpoint) so no state is lost; the next
         successful checkpoint catches up.
 
-        The scheduler's internal `_lock` is intentionally NOT acquired
-        inside the heavy lock chain — that would add `_lock` between
-        `CapitalController._lock` and `wal_lock` in the documented
-        ordering. A racing `stop()` between the `_tick` entry check
-        and the checkpoint completing simply writes one extra
-        snapshot; duplicate checkpoints are harmless (no ratchet
-        semantics to defeat).
+        The snapshot-serialization locks are acquired inside
+        `checkpoint()` (`StateStore`'s `StateSnapshotLocks` bundle), so
+        this loop does not wrap the call — a racing `stop()` between the
+        `_tick` entry check and the checkpoint completing simply writes
+        one extra snapshot; duplicate checkpoints are harmless.
         '''
 
-        positions_cm: AbstractContextManager[bool | None] = (
-            self._positions_lock if self._positions_lock is not None else nullcontext()
-        )
-        capital_cm: AbstractContextManager[bool | None] = (
-            self._capital_lock_cm() if self._capital_lock_cm is not None else nullcontext()
-        )
-
         try:
-            with positions_cm, capital_cm:
-                self._state_store.checkpoint(self._state)
+            self._state_store.checkpoint(self._state)
         except Exception:  # noqa: BLE001 - checkpoint failure must not abort the loop
             _log.exception('snapshot checkpoint failed; next tick will retry')

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -89,7 +89,8 @@ class ShutdownSequencer:
             mid-snapshot, and `_submit_exit` increments `pending_exit`
             under it. None disables the guard (legacy single-threaded
             shutdown paths). The final-checkpoint snapshot is no longer
-            guarded here — `StateStore` owns the snapshot locks (see
+            guarded here — snapshot locking is owned by `StateStore`
+            when it is built with a `StateSnapshotLocks` bundle (see
             `_final_checkpoint`).
     '''
 
@@ -858,16 +859,20 @@ class ShutdownSequencer:
         '''Save final snapshot and truncate WAL.
 
         Calls `StateStore.checkpoint` to persist current state and
-        truncate the WAL before exit. The snapshot-serialization locks
-        (`positions_lock` + `capital_lock`) are owned by `StateStore`
-        via its `StateSnapshotLocks` bundle, so they are acquired inside
-        `checkpoint()` — this method must NOT wrap the call, or it would
-        re-acquire the same non-reentrant locks and self-deadlock.
-        FINAL-MAJOR-05 coverage (a snapshot cannot race a still-alive
-        OutcomeLoop worker mutating `state.positions` / `risk.per_strategy`
-        / `capital.per_strategy_deployed`) is preserved by the bundle;
-        the launcher's `state.risk.lock is positions_lock` wiring is what
-        makes `positions_lock` cover `risk.per_strategy`.
+        truncate the WAL before exit. Snapshot-serialization locking is
+        owned by `StateStore`: when it is built with a
+        `StateSnapshotLocks` bundle (as the launcher does for the
+        multi-threaded runtime), `checkpoint()` acquires `positions_lock`
+        + `capital_lock` itself, so this method must NOT wrap the call —
+        it would re-acquire the same non-reentrant locks and
+        self-deadlock. With the bundle configured, FINAL-MAJOR-05
+        coverage (a snapshot cannot race a still-alive OutcomeLoop worker
+        mutating `state.positions` / `risk.per_strategy` /
+        `capital.per_strategy_deployed`) is preserved, with the
+        launcher's `state.risk.lock is positions_lock` wiring making
+        `positions_lock` cover `risk.per_strategy`. Without the bundle
+        (single-threaded paths) the store does not lock and none is
+        needed; configuring it is the launcher's responsibility.
         '''
 
         self._state_store.checkpoint(self._state)

--- a/nexus/startup/shutdown_sequencer.py
+++ b/nexus/startup/shutdown_sequencer.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING
 
 import structlog
 
-from nexus.core.capital_controller.capital_controller import CapitalController
 from nexus.core.domain.enums import OperationalMode, OrderSide
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.domain.operational_mode import ModeState
@@ -87,25 +86,11 @@ class ShutdownSequencer:
             `state.positions.values()` under the lock (MAJOR-S) so a
             timed-out OutcomeLoop join cannot trigger
             `RuntimeError: dictionary changed size during iteration`
-            mid-snapshot and abort the shutdown before
-            `_persist_strategy_state` / `_final_checkpoint` run. None
-            disables the guard (legacy single-threaded shutdown paths).
-            When supplied, the launcher MUST also wire
-            `state.risk.lock = positions_lock` (same object) AND pass
-            `capital_controller` — `__init__` raises `RuntimeError`
-            otherwise so the FINAL-MAJOR-05 lock cluster cannot
-            silently degrade.
-        capital_controller: Optional `CapitalController` whose `_lock`
-            is acquired by `_final_checkpoint` so the snapshot
-            serializer iterations of `state.capital.per_strategy_deployed`
-            and reads of the aggregate notional fields
-            (`in_flight_order_notional`, `working_order_notional`,
-            `position_notional`, `reservation_notional`, `fee_reserve`)
-            cannot race a still-alive OutcomeLoop worker (FINAL-MAJOR-05).
-            Required when `positions_lock` is supplied; `__init__`
-            raises `RuntimeError` if positions_lock is provided
-            without it. None disables the guard (legacy
-            single-threaded shutdown paths).
+            mid-snapshot, and `_submit_exit` increments `pending_exit`
+            under it. None disables the guard (legacy single-threaded
+            shutdown paths). The final-checkpoint snapshot is no longer
+            guarded here — `StateStore` owns the snapshot locks (see
+            `_final_checkpoint`).
     '''
 
     def __init__(
@@ -126,7 +111,6 @@ class ShutdownSequencer:
         outcome_processor: OutcomeProcessor | None = None,
         non_pending_outcome_handler: Callable[[TradeOutcome], None] | None = None,
         positions_lock: threading.Lock | None = None,
-        capital_controller: CapitalController | None = None,
     ) -> None:
         if not isinstance(runner, StrategyRunner):
             msg = 'runner must be a StrategyRunner instance'
@@ -183,37 +167,6 @@ class ShutdownSequencer:
         self._exit_contexts: dict[str, OrderContext] = {}
         self._non_pending_outcome_handler = non_pending_outcome_handler
         self._positions_lock = positions_lock
-        self._capital_controller = capital_controller
-
-        if positions_lock is not None and (
-            not hasattr(state.risk, 'lock')
-            or state.risk.lock is not positions_lock
-        ):
-            risk_lock = getattr(state.risk, 'lock', '<missing>')
-            msg = (
-                'ShutdownSequencer requires `state.risk.lock is positions_lock` '
-                'whenever `positions_lock` is supplied so a single acquisition '
-                'in `_final_checkpoint` covers both `state.positions` AND '
-                '`state.risk.per_strategy` iteration. Without identity-equal '
-                'locks the snapshot serializer would iterate `per_strategy` '
-                'unguarded against new-strategy inserts from a still-alive '
-                'OutcomeLoop worker (FINAL-MAJOR-05 race remains reachable). '
-                f'Got positions_lock={positions_lock!r}, '
-                f'state.risk.lock={risk_lock!r}.'
-            )
-            raise RuntimeError(msg)
-
-        if positions_lock is not None and capital_controller is None:
-            msg = (
-                'ShutdownSequencer requires `capital_controller` whenever '
-                '`positions_lock` is supplied. `_final_checkpoint` needs the '
-                'controller lock to freeze `state.capital.per_strategy_deployed` '
-                'and the aggregate notional fields during snapshot serialization. '
-                'Without it the capital-side `dictionary changed size during '
-                'iteration` race against a still-alive OutcomeLoop worker '
-                'remains reachable — the lock-cluster fix is only partial.'
-            )
-            raise RuntimeError(msg)
 
     def shutdown(self) -> None:
         '''Execute the full shutdown sequence.'''
@@ -904,43 +857,20 @@ class ShutdownSequencer:
     def _final_checkpoint(self) -> None:
         '''Save final snapshot and truncate WAL.
 
-        Calls StateStore.checkpoint to persist current state
-        and truncate the WAL before exit.
-
-        FINAL-MAJOR-05: holds positions_lock + CapitalController._lock
-        across the snapshot serialization so the
-        `serialize_state` iterations of `state.positions`,
-        `state.risk.per_strategy`, and `state.capital.per_strategy_deployed`
-        cannot race a still-alive OutcomeLoop worker (after
-        `_stop_outcome_loop`'s join_timeout) writing those dicts;
-        the CapitalController lock also covers the aggregate field
-        reads (`in_flight_order_notional`, `working_order_notional`,
-        `position_notional`, `reservation_notional`, `fee_reserve`)
-        so the snapshot is internally consistent (closes R17-A
-        TD-054 transitively). state_store.checkpoint internally
-        acquires `_wal_lock` (FINAL-MAJOR-04). Lock-order:
-        positions_lock → CapitalController._lock → _wal_lock.
-
-        Requires the launcher to wire `state.risk.lock = positions_lock`
-        (same lock identity) so a single acquisition covers both
-        `state.positions` and `state.risk.per_strategy`. Enforced at
-        construction time by `__init__`; `state.risk.lock_cm()` cannot
-        be added to the chain here because `threading.Lock` is
-        non-reentrant and would deadlock if it IS positions_lock.
+        Calls `StateStore.checkpoint` to persist current state and
+        truncate the WAL before exit. The snapshot-serialization locks
+        (`positions_lock` + `capital_lock`) are owned by `StateStore`
+        via its `StateSnapshotLocks` bundle, so they are acquired inside
+        `checkpoint()` — this method must NOT wrap the call, or it would
+        re-acquire the same non-reentrant locks and self-deadlock.
+        FINAL-MAJOR-05 coverage (a snapshot cannot race a still-alive
+        OutcomeLoop worker mutating `state.positions` / `risk.per_strategy`
+        / `capital.per_strategy_deployed`) is preserved by the bundle;
+        the launcher's `state.risk.lock is positions_lock` wiring is what
+        makes `positions_lock` cover `risk.per_strategy`.
         '''
 
-        positions_cm = (
-            self._positions_lock
-            if self._positions_lock is not None
-            else nullcontext()
-        )
-        capital_cm = (
-            self._capital_controller.lock_cm()
-            if self._capital_controller is not None
-            else nullcontext()
-        )
-        with positions_cm, capital_cm:
-            self._state_store.checkpoint(self._state)
+        self._state_store.checkpoint(self._state)
 
     def _deregister(self) -> None:
         '''Deregister this account from Trading sub-system via PraxisOutbound.'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.60.0"
+version = "0.61.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import queue
 import tempfile
+import threading
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -35,6 +36,7 @@ from nexus.strategy.context import StrategyContext
 from nexus.strategy.runner import StrategyRunner
 
 _PLACEHOLDER_PATH = Path('/placeholder/strategy_state')
+_DEADLOCK_TIMEOUT_SECONDS = 5.0
 _EXP_DIR_HANDLE = tempfile.TemporaryDirectory()
 _EXP_DIR = Path(_EXP_DIR_HANDLE.name)
 
@@ -44,7 +46,9 @@ def _make_mock_runner() -> MagicMock:
 
 
 def _make_mock_state_store() -> MagicMock:
-    return MagicMock(spec=StateStore)
+    store = MagicMock(spec=StateStore)
+    store.owns_snapshot_locks = False
+    return store
 
 
 def _make_instance_state() -> InstanceState:
@@ -279,7 +283,6 @@ class TestDispatchShutdown:
             state=state,
             strategy_state_path=_PLACEHOLDER_PATH,
             positions_lock=lock,
-            capital_controller=CapitalController(state.capital),
         )
 
         stop_event = _t.Event()
@@ -610,6 +613,68 @@ class TestFinalCheckpoint:
         sequencer._final_checkpoint()
 
         state_store.checkpoint.assert_called_once_with(state)
+
+    def test_does_not_hold_positions_lock_externally(self) -> None:
+        positions_lock = threading.Lock()
+        state = _make_instance_state()
+        state.risk.lock = positions_lock
+        state_store = _make_mock_state_store()
+
+        held: dict[str, bool] = {}
+        state_store.checkpoint.side_effect = lambda _s: held.update(
+            positions=positions_lock.locked(),
+        )
+
+        sequencer = ShutdownSequencer(
+            runner=_make_mock_runner(),
+            manifest=_make_manifest(),
+            state_store=state_store,
+            state=state,
+            strategy_state_path=_PLACEHOLDER_PATH,
+            positions_lock=positions_lock,
+        )
+
+        sequencer._final_checkpoint()
+
+        state_store.checkpoint.assert_called_once_with(state)
+        assert held == {'positions': False}
+
+    def test_real_store_with_bundle_does_not_deadlock(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from nexus.infrastructure.state_store import (
+            StateSnapshotLocks,
+            StateStore,
+        )
+
+        positions_lock = threading.Lock()
+        state = _make_instance_state()
+        state.risk.lock = positions_lock
+        capital_controller = CapitalController(state.capital)
+        state_store = StateStore(
+            tmp_path,
+            snapshot_locks=StateSnapshotLocks(
+                positions_lock=positions_lock,
+                capital_lock=capital_controller.lock_cm(),
+            ),
+        )
+
+        sequencer = ShutdownSequencer(
+            runner=_make_mock_runner(),
+            manifest=_make_manifest(),
+            state_store=state_store,
+            state=state,
+            strategy_state_path=_PLACEHOLDER_PATH,
+            positions_lock=positions_lock,
+        )
+
+        worker = threading.Thread(target=sequencer._final_checkpoint)
+        worker.start()
+        worker.join(timeout=_DEADLOCK_TIMEOUT_SECONDS)
+
+        assert not worker.is_alive()
+        assert state_store.recover() is not None
 
 
 class TestShutdownSequence:
@@ -1575,7 +1640,6 @@ class TestSubmitExitMissingPositionRace:
             shutdown_timeout=0.01,
             config=config,
             positions_lock=positions_lock,
-            capital_controller=CapitalController(state.capital),
         )
 
         action = Action(
@@ -1984,277 +2048,42 @@ class TestNonPendingOutcomeHandler:
         sequencer._wait_terminal()
 
 
-class TestFinalMajor05CheckpointLockCoverage:
-    '''FINAL-MAJOR-05: `_final_checkpoint` invokes
-    `state_store.checkpoint -> save_snapshot -> serialize_state`
-    which iterates `state.positions`, `state.risk.per_strategy`,
-    `state.capital.per_strategy_deployed`, and reads CapitalState
-    aggregates on the shutdown thread. If `_stop_outcome_loop`
-    join_timeout left the OutcomeLoop alive, those iterations race
-    dict mutations and aggregate writes — `RuntimeError: dictionary
-    changed size during iteration` escapes `_final_checkpoint` and
-    the persisted shutdown HALTED mode is lost.
-
-    Post-fix `_final_checkpoint` acquires positions_lock +
-    CapitalController._lock around the checkpoint call. The
-    StateStore-internal `_wal_lock` is acquired by
-    `state_store.checkpoint` itself (FINAL-MAJOR-04). Lock-order:
-    positions_lock -> CapitalController._lock -> _wal_lock.
+class TestFinalCheckpointLockOwnership:
+    '''The snapshot-serialization locks moved into `StateStore` (the
+    `StateSnapshotLocks` bundle), so `_final_checkpoint` no longer
+    wraps the checkpoint and the sequencer no longer enforces
+    `state.risk.lock is positions_lock` — that identity is asserted at
+    the launcher composition point where the bundle is built. The
+    sequencer keeps `positions_lock` only for its direct
+    `state.positions` access in `_dispatch_shutdown` / `_submit_exit`.
     '''
 
-    def test_final_checkpoint_acquires_positions_and_capital_locks(
+    def test_positions_lock_accepted_without_risk_lock_identity(
         self, tmp_path: Path,
     ) -> None:
-        '''Pin the lock-acquisition: while a held positions_lock and
-        held CapitalController._lock would block other writers, the
-        checkpoint call still runs to completion under both. Verifies
-        that the wrapping is in place by asserting state_store.checkpoint
-        is reached once after the locks are acquired.
-        '''
-
-        import threading
-        from decimal import Decimal
-
-        state = InstanceState(
-            capital=CapitalState(capital_pool=Decimal('10000')),
-        )
-        positions_lock = threading.Lock()
-        state.risk.lock = positions_lock
-        controller = CapitalController(state.capital)
-        state_store = _make_mock_state_store()
-
-        sequencer = ShutdownSequencer(
-            runner=_make_mock_runner(),
-            manifest=_make_manifest(),
-            state_store=state_store,
-            state=state,
-            strategy_state_path=tmp_path,
-            positions_lock=positions_lock,
-            capital_controller=controller,
-        )
-
-        sequencer._final_checkpoint()
-
-        state_store.checkpoint.assert_called_once_with(state)
-
-    def test_final_checkpoint_locks_serialize_no_iteration_error(
-        self, tmp_path: Path,
-    ) -> None:
-        '''A foreground writer thread tight-loops dict mutations on
-        state.positions and state.risk.per_strategy while shutdown
-        thread runs _final_checkpoint. Pre-fix the unprotected
-        serialization would race; post-fix it serialises behind the
-        locks and completes without RuntimeError.
-        '''
-
-        import threading
-        from decimal import Decimal
-
-        from nexus.core.domain.position import Position
-        from nexus.core.domain.risk_state import StrategyRiskState
-
-        state = InstanceState(
-            capital=CapitalState(capital_pool=Decimal('100000')),
-        )
-        positions_lock = threading.Lock()
-        state.risk.lock = positions_lock
-        controller = CapitalController(state.capital)
-        state_store = StateStore(tmp_path)
-
-        sequencer = ShutdownSequencer(
-            runner=_make_mock_runner(),
-            manifest=_make_manifest(),
-            state_store=state_store,
-            state=state,
-            strategy_state_path=tmp_path,
-            positions_lock=positions_lock,
-            capital_controller=controller,
-        )
-
-        stop_event = threading.Event()
-        errors: list[Exception] = []
-
-        def writer() -> None:
-            i = 0
-            try:
-                while not stop_event.is_set():
-                    with positions_lock:
-                        trade_id = f't_{i}'
-                        state.positions[trade_id] = Position(
-                            trade_id=trade_id,
-                            strategy_id='strat_a',
-                            symbol='BTCUSDT',
-                            side=OrderSide.BUY,
-                            size=Decimal('1'),
-                            entry_price=Decimal('100'),
-                            avg_cost_basis=Decimal('100'),
-                        )
-                        state.risk.per_strategy[f's_{i}'] = StrategyRiskState(
-                            strategy_id=f's_{i}',
-                        )
-                    i += 1
-            except Exception as exc:
-                errors.append(exc)
-
-        def checkpointer() -> None:
-            try:
-                for _ in range(10):
-                    sequencer._final_checkpoint()
-            except Exception as exc:
-                errors.append(exc)
-            finally:
-                stop_event.set()
-
-        threads = [
-            threading.Thread(target=writer, daemon=True),
-            threading.Thread(target=checkpointer, daemon=True),
-        ]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join(timeout=15)
-
-        alive = [t.name for t in threads if t.is_alive()]
-        assert not alive, f'threads did not finish: {alive}'
-        assert not errors, (
-            f'race during locked checkpoint: {errors[:3]}'
-        )
-
-
-class TestShutdownSequencerLockIdentityGuard:
-    '''PR #55 round-6 review: when `positions_lock` is supplied,
-    `state.risk.lock` MUST be the same object. The earlier guard
-    only rejected the case where `state.risk.lock` was a DIFFERENT
-    lock and let the `state.risk.lock is None` case slip through —
-    leaving `_final_checkpoint` to iterate `state.risk.per_strategy`
-    unguarded against new-strategy inserts from a still-alive
-    OutcomeLoop worker (FINAL-MAJOR-05 race remains reachable).
-    Tightened guard: positions_lock supplied → state.risk.lock IS
-    positions_lock or RuntimeError.
-    '''
-
-    def test_init_rejects_positions_lock_when_risk_lock_is_none(
-        self, tmp_path: Path,
-    ) -> None:
-        '''positions_lock supplied AND state.risk.lock is None →
-        RuntimeError. Pre-fix this slipped through silently.
-        '''
-
-        import threading
-        from decimal import Decimal
-
-        state = InstanceState(
-            capital=CapitalState(capital_pool=Decimal('10000')),
-        )
-        positions_lock = threading.Lock()
-
-        with pytest.raises(RuntimeError, match=r'state\.risk\.lock is positions_lock'):
-            ShutdownSequencer(
-                runner=_make_mock_runner(),
-                manifest=_make_manifest(),
-                state_store=_make_mock_state_store(),
-                state=state,
-                strategy_state_path=tmp_path,
-                positions_lock=positions_lock,
-            )
-
-    def test_init_rejects_positions_lock_when_risk_lock_is_different_object(
-        self, tmp_path: Path,
-    ) -> None:
-        '''positions_lock supplied AND state.risk.lock is a different
-        lock object → RuntimeError.
-        '''
-
-        import threading
-        from decimal import Decimal
-
-        state = InstanceState(
-            capital=CapitalState(capital_pool=Decimal('10000')),
-        )
-        positions_lock = threading.Lock()
+        state = _make_instance_state()
         state.risk.lock = threading.Lock()
+        positions_lock = threading.Lock()
 
-        with pytest.raises(RuntimeError, match=r'state\.risk\.lock is positions_lock'):
-            ShutdownSequencer(
-                runner=_make_mock_runner(),
-                manifest=_make_manifest(),
-                state_store=_make_mock_state_store(),
-                state=state,
-                strategy_state_path=tmp_path,
-                positions_lock=positions_lock,
-            )
-
-    def test_init_allows_no_positions_lock(self, tmp_path: Path) -> None:
-        '''positions_lock=None bypasses the guard entirely (legacy
-        single-threaded test paths).
-        '''
-
-        from decimal import Decimal
-
-        state = InstanceState(
-            capital=CapitalState(capital_pool=Decimal('10000')),
-        )
-
-        ShutdownSequencer(
+        sequencer = ShutdownSequencer(
             runner=_make_mock_runner(),
             manifest=_make_manifest(),
             state_store=_make_mock_state_store(),
             state=state,
+            strategy_state_path=tmp_path,
+            positions_lock=positions_lock,
+        )
+
+        assert sequencer is not None
+
+    def test_init_allows_no_positions_lock(self, tmp_path: Path) -> None:
+        sequencer = ShutdownSequencer(
+            runner=_make_mock_runner(),
+            manifest=_make_manifest(),
+            state_store=_make_mock_state_store(),
+            state=_make_instance_state(),
             strategy_state_path=tmp_path,
             positions_lock=None,
         )
 
-    def test_init_allows_identity_equal_locks(self, tmp_path: Path) -> None:
-        '''positions_lock supplied AND state.risk.lock IS positions_lock
-        AND capital_controller is supplied → no error. The expected
-        wiring path.
-        '''
-
-        import threading
-        from decimal import Decimal
-
-        state = InstanceState(
-            capital=CapitalState(capital_pool=Decimal('10000')),
-        )
-        positions_lock = threading.Lock()
-        state.risk.lock = positions_lock
-
-        ShutdownSequencer(
-            runner=_make_mock_runner(),
-            manifest=_make_manifest(),
-            state_store=_make_mock_state_store(),
-            state=state,
-            strategy_state_path=tmp_path,
-            positions_lock=positions_lock,
-            capital_controller=CapitalController(state.capital),
-        )
-
-    def test_init_rejects_positions_lock_when_capital_controller_is_none(
-        self, tmp_path: Path,
-    ) -> None:
-        '''PR #55 round-7: positions_lock supplied AND state.risk.lock
-        wired correctly BUT capital_controller is None → RuntimeError.
-        Pre-fix this slipped through; `_final_checkpoint` would then
-        iterate `state.capital.per_strategy_deployed` without the
-        controller lock and the FINAL-MAJOR-05 capital-side race
-        remains reachable.
-        '''
-
-        import threading
-        from decimal import Decimal
-
-        state = InstanceState(
-            capital=CapitalState(capital_pool=Decimal('10000')),
-        )
-        positions_lock = threading.Lock()
-        state.risk.lock = positions_lock
-
-        with pytest.raises(RuntimeError, match=r'capital_controller'):
-            ShutdownSequencer(
-                runner=_make_mock_runner(),
-                manifest=_make_manifest(),
-                state_store=_make_mock_state_store(),
-                state=state,
-                strategy_state_path=tmp_path,
-                positions_lock=positions_lock,
-            )
+        assert sequencer is not None

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -675,7 +675,7 @@ class TestFinalCheckpoint:
             except BaseException as exc:
                 errors.append(exc)
 
-        worker = threading.Thread(target=run_checkpoint)
+        worker = threading.Thread(target=run_checkpoint, daemon=True)
         worker.start()
         worker.join(timeout=_DEADLOCK_TIMEOUT_SECONDS)
 

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -669,11 +669,20 @@ class TestFinalCheckpoint:
             positions_lock=positions_lock,
         )
 
-        worker = threading.Thread(target=sequencer._final_checkpoint)
+        errors: list[BaseException] = []
+
+        def run_checkpoint() -> None:
+            try:
+                sequencer._final_checkpoint()
+            except BaseException as exc:
+                errors.append(exc)
+
+        worker = threading.Thread(target=run_checkpoint)
         worker.start()
         worker.join(timeout=_DEADLOCK_TIMEOUT_SECONDS)
 
-        assert not worker.is_alive()
+        assert not worker.is_alive(), '_final_checkpoint deadlocked'
+        assert not errors, f'_final_checkpoint raised: {errors}'
         assert state_store.recover() is not None
 
 

--- a/tests/test_shutdown_sequencer.py
+++ b/tests/test_shutdown_sequencer.py
@@ -46,9 +46,7 @@ def _make_mock_runner() -> MagicMock:
 
 
 def _make_mock_state_store() -> MagicMock:
-    store = MagicMock(spec=StateStore)
-    store.owns_snapshot_locks = False
-    return store
+    return MagicMock(spec=StateStore)
 
 
 def _make_instance_state() -> InstanceState:

--- a/tests/test_snapshot_scheduler.py
+++ b/tests/test_snapshot_scheduler.py
@@ -9,7 +9,6 @@ timer thread and reaches checkpoint().
 from __future__ import annotations
 
 import threading
-from contextlib import nullcontext
 from decimal import Decimal
 from pathlib import Path
 
@@ -35,76 +34,6 @@ def test_invalid_interval_rejected(tmp_path: Path) -> None:
             state=state,
             interval_seconds=0,
         )
-
-
-def test_lock_identity_mismatch_rejected_at_construction(tmp_path: Path) -> None:
-    '''When positions_lock is supplied, state.risk.lock must be the
-    SAME object. A mis-wired launcher passing a different lock would
-    let SnapshotScheduler iterate state.risk.per_strategy unguarded
-    against OutcomeProcessor's new-strategy inserts (FINAL-MAJOR-05
-    race). Mirrors ShutdownSequencer's identical guard at
-    shutdown_sequencer.py:188-204.
-    '''
-
-    state = _make_state()
-    store = StateStore(base_path=tmp_path)
-    positions_lock = threading.Lock()
-    state.risk.lock = threading.Lock()
-
-    with pytest.raises(RuntimeError, match=r'state\.risk\.lock is positions_lock'):
-        SnapshotScheduler(
-            state_store=store,
-            state=state,
-            positions_lock=positions_lock,
-        )
-
-
-def test_lock_identity_match_accepted(tmp_path: Path) -> None:
-    state = _make_state()
-    store = StateStore(base_path=tmp_path)
-    positions_lock = threading.Lock()
-    state.risk.lock = positions_lock
-
-    SnapshotScheduler(
-        state_store=store,
-        state=state,
-        positions_lock=positions_lock,
-        capital_lock_cm=lambda: nullcontext(),
-    )
-
-
-def test_capital_lock_cm_required_when_positions_lock_supplied(tmp_path: Path) -> None:
-    '''Mirrors ShutdownSequencer's lock-cluster invariant
-    (`shutdown_sequencer.py:206-216`): positions_lock and
-    capital_lock_cm form a pair — supplying only one is a silent
-    miswire that leaves the capital-side `dictionary changed size
-    during iteration` race against a still-alive OutcomeProcessor
-    reachable.
-    '''
-
-    state = _make_state()
-    store = StateStore(base_path=tmp_path)
-    positions_lock = threading.Lock()
-    state.risk.lock = positions_lock
-
-    with pytest.raises(RuntimeError, match=r'capital_lock_cm'):
-        SnapshotScheduler(
-            state_store=store,
-            state=state,
-            positions_lock=positions_lock,
-        )
-
-
-def test_no_positions_lock_accepts_any_risk_lock(tmp_path: Path) -> None:
-    '''Single-threaded test paths don't supply positions_lock; the
-    identity guard must not fire when positions_lock is None.
-    '''
-
-    state = _make_state()
-    store = StateStore(base_path=tmp_path)
-    state.risk.lock = threading.Lock()
-
-    SnapshotScheduler(state_store=store, state=state)
 
 
 def test_bool_interval_rejected(tmp_path: Path) -> None:
@@ -133,53 +62,6 @@ def test_tick_once_writes_snapshot_file(tmp_path: Path) -> None:
 
     assert snap_path.exists()
     assert snap_path.stat().st_size > 0
-
-
-def test_tick_once_holds_positions_and_capital_locks(tmp_path: Path) -> None:
-    '''Pin the lock-chain contract: the checkpoint call must run
-    *inside* the positions_lock and the capital_lock_cm.
-    '''
-
-    state = _make_state()
-    store = StateStore(base_path=tmp_path)
-    positions_lock = threading.Lock()
-    state.risk.lock = positions_lock
-
-    capital_lock_acquired = threading.Event()
-    capital_lock_released = threading.Event()
-
-    class _CapitalLock:
-        def __enter__(self) -> None:
-            capital_lock_acquired.set()
-
-        def __exit__(self, *_args: object) -> None:
-            capital_lock_released.set()
-
-    def capital_lock_cm() -> _CapitalLock:
-        return _CapitalLock()
-
-    checkpoints_seen: list[bool] = []
-    original_checkpoint = store.checkpoint
-
-    def spying_checkpoint(s: InstanceState) -> None:
-        checkpoints_seen.append(positions_lock.locked() and capital_lock_acquired.is_set())
-        original_checkpoint(s)
-
-    store.checkpoint = spying_checkpoint  # type: ignore[method-assign]
-
-    scheduler = SnapshotScheduler(
-        state_store=store,
-        state=state,
-        positions_lock=positions_lock,
-        capital_lock_cm=capital_lock_cm,
-    )
-
-    scheduler.tick_once()
-
-    assert checkpoints_seen == [True], (
-        'checkpoint() must run while positions_lock is held and capital_lock_cm is in __enter__'
-    )
-    assert capital_lock_released.is_set()
 
 
 def test_checkpoint_exception_swallowed(tmp_path: Path) -> None:
@@ -260,30 +142,20 @@ def test_tick_once_writes_even_when_loop_is_stopped(tmp_path: Path) -> None:
     state = _make_state()
     store = StateStore(base_path=tmp_path)
 
-    inside_lock_chain = threading.Event()
-    proceed_to_checkpoint = threading.Event()
+    inside_checkpoint = threading.Event()
+    proceed_to_finish = threading.Event()
     checkpoint_calls: list[int] = []
 
-    class _BlockingCapitalLock:
-        def __enter__(self) -> None:
-            inside_lock_chain.set()
-            assert proceed_to_checkpoint.wait(timeout=2), (
-                'main thread did not release the capital-lock barrier within 2s'
-            )
-
-        def __exit__(self, *_args: object) -> None:
-            return None
-
-    def spying_checkpoint(_s: InstanceState) -> None:
+    def blocking_checkpoint(_s: InstanceState) -> None:
+        inside_checkpoint.set()
+        assert proceed_to_finish.wait(timeout=2), (
+            'main thread did not release the checkpoint barrier within 2s'
+        )
         checkpoint_calls.append(1)
 
-    store.checkpoint = spying_checkpoint  # type: ignore[method-assign]
+    store.checkpoint = blocking_checkpoint  # type: ignore[method-assign]
 
-    scheduler = SnapshotScheduler(
-        state_store=store,
-        state=state,
-        capital_lock_cm=_BlockingCapitalLock,
-    )
+    scheduler = SnapshotScheduler(state_store=store, state=state)
 
     worker_thread = threading.Thread(
         target=scheduler.tick_once,
@@ -291,10 +163,10 @@ def test_tick_once_writes_even_when_loop_is_stopped(tmp_path: Path) -> None:
     )
     worker_thread.start()
 
-    assert inside_lock_chain.wait(timeout=2)
+    assert inside_checkpoint.wait(timeout=2)
     scheduler.start()
     scheduler.stop()
-    proceed_to_checkpoint.set()
+    proceed_to_finish.set()
     worker_thread.join(timeout=2)
 
     assert not worker_thread.is_alive()


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

Closes [#92](https://github.com/Vaquum/Nexus/issues/92).

## What does this PR change?

Completes the snapshot-lock ownership move begun in v0.60.0. v0.60.0 added the opt-in `StateSnapshotLocks` bundle to [`StateStore`](nexus/infrastructure/state_store.py) but left it unwired, because enabling it conflicts with the two sites that already wrap `StateStore.checkpoint()` in the same locks: once the store acquires `positions_lock` + `capital_lock` internally, an external wrap re-acquires the same **non-reentrant** locks and self-deadlocks.

This PR moves snapshot-serialization locking fully into `StateStore` and deletes both external checkpoint wraps:

- [`ShutdownSequencer._final_checkpoint`](nexus/startup/shutdown_sequencer.py) and [`SnapshotScheduler._checkpoint`](nexus/infrastructure/snapshot_scheduler.py) now call `checkpoint()` bare. The store owns the locking when the launcher builds it with the bundle.
- The now-unused `capital_controller` parameter is removed from `ShutdownSequencer`, and `positions_lock` / `capital_lock_cm` from `SnapshotScheduler`, along with their construction guards. `ShutdownSequencer` keeps `positions_lock` only for its direct `state.positions` access (`_dispatch_shutdown`'s snapshot read, `_submit_exit`'s `pending_exit` write), which the bundle does not cover.

FINAL-MAJOR-05 coverage (a snapshot cannot race a still-alive OutcomeLoop worker mutating `state.positions` / `risk.per_strategy` / `capital.per_strategy_deployed`) is preserved by the bundle. The `state.risk.lock is positions_lock` identity that the wraps used to enforce — so `positions_lock` also covers `risk.per_strategy` serialization — moves to the launcher composition point where the bundle is built (companion Praxis change, with a mismatch assertion + test). `state_store.py` itself is unchanged; only callers change.

## Tests

`tests/test_shutdown_sequencer.py`: removed the obsolete external-wrap / construction-guard tests; added a real-`StateStore`-with-bundle `_final_checkpoint` that completes without deadlocking (worker-thread exceptions are captured and asserted), a test that `_final_checkpoint` holds no external `positions_lock` during the store call, and a test that the sequencer accepts `positions_lock` without enforcing the `state.risk.lock` identity. `tests/test_snapshot_scheduler.py`: removed the guard / wrap tests; the stop-race test now blocks inside `checkpoint`.

`ruff` + `mypy` clean, **1,505 tests pass** / 17 skipped. Bumps version 0.60.0 → 0.61.0. Net −559/+140 lines (mostly deletion).

## Rollout

Nexus-side change only; it is a behavioral no-op until the companion Praxis PR pins v0.61.0 and builds `StateStore` with the bundle. Both sides are merged first, then deployed together, with paired monkeypatch validation on the paper-trade host per the runtime-shape-change rule.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [ ] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable