### PR TITLE
docs: technical-debt register cleanup — mark resolved and Conduit-obsoleted entries (v0.63.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -801,3 +801,9 @@
 ### Remove
 
 - Remove the `vaquum_limen` dependency and the runtime Limen path: `WiredSensor` / `SensorSpec`, [`nexus.strategy.signal_producer`](nexus/strategy/signal_producer.py), [`nexus.startup.sensor_cache`](nexus/startup/sensor_cache.py), [`nexus.startup.warm_cache`](nexus/startup/warm_cache.py), the `PredictLoop` `ProcessPoolExecutor` + market-data IPC, and the sensor disk cache. Add `polars` and `numpy` as direct dependencies (previously transitive through `vaquum_limen`)
+
+## v0.63.1 on 16th of June, 2026
+
+### Update
+
+- Prune the technical-debt register in [`docs/TechnicalDebt.md`](docs/TechnicalDebt.md): collapse code-verified-resolved (TD-004, TD-005, TD-006, TD-010, TD-011, TD-013, TD-015, TD-016, TD-017, TD-018, TD-023) and Conduit-obsoleted (TD-019, TD-020, TD-021, TD-022, TD-087, TD-088, TD-089) entries to heading-only status markers, and mark TD-051 RESOLVED (`_reduce_position` already nets exit fees at [`outcome_processor.py`](nexus/infrastructure/praxis_connector/outcome_processor.py) via `realized_pnl = gross_pnl - actual_fees`)

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -53,48 +53,15 @@ Several lifecycle methods return `False` for failure paths (for example, missing
 
 ---
 
-## TD-004: All timestamps must be UTC
-
-**Origin**: 7.3 (event dispatch types)
-**Severity**: High
-**Modules**:
-- `nexus/strategy/signal.py`
-- `nexus/infrastructure/praxis_connector/trade_outcome.py`
-- `nexus/infrastructure/strategy_event.py`
-- `nexus/core/capital_controller/reservation.py`
-- `nexus/core/capital_controller/tracked_order.py`
-- `nexus/infrastructure/praxis_connector/trade_command.py`
-
-Current validation checks for tz-awareness (`tzinfo is not None`) but does not enforce UTC specifically. A timestamp with `tzinfo=+05:00` passes validation but violates the UTC-only convention.
-
-**When to fix**: ASAP
-**Migration**: Replace tz-awareness checks with explicit UTC checks (`timestamp.tzinfo == timezone.utc`).
+## TD-004: All timestamps must be UTC — RESOLVED
 
 ---
 
-## TD-005: StartupSequencer._register_with_trading is a stub
-
-**Origin**: 9.1.3 (external integration stubs)
-**Severity**: High (no Trading sub-system registration)
-**Module**: `nexus/startup/sequencer.py`
-
-`_register_with_trading()` logs a warning and does nothing. The Manager instance does not register with the Trading sub-system (Praxis), meaning Praxis has no knowledge of active Manager instances.
-
-**When to fix**: When Praxis Connector is built.
-**Migration**: Implement actual registration via Praxis Connector API. Remove this entry when done.
+## TD-005: StartupSequencer._register_with_trading is a stub — RESOLVED
 
 ---
 
-## TD-006: StartupSequencer._reconcile_capital is a stub
-
-**Origin**: 9.1.3 (external integration stubs)
-**Severity**: High (no capital reconciliation)
-**Module**: `nexus/startup/sequencer.py`
-
-`_reconcile_capital()` logs a warning and does nothing. Capital state is not reconciled against Trading sub-system positions on startup, meaning Manager may have stale or incorrect capital/position data.
-
-**When to fix**: When Reconciler is built.
-**Migration**: Implement actual reconciliation via Reconciler. Remove this entry when done.
+## TD-006: StartupSequencer._reconcile_capital is a stub — RESOLVED
 
 ---
 
@@ -104,29 +71,11 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 ---
 
-## TD-010: StartupSequencer._register_timers is a stub
-
-**Origin**: 9.1.6 (runtime setup stubs)
-**Severity**: Medium (no timer callbacks)
-**Module**: `nexus/startup/sequencer.py`
-
-`_register_timers()` logs a warning and does nothing. Strategy timers are not registered, meaning on_timer callbacks will not fire.
-
-**When to fix**: When timer system is built.
-**Migration**: Implement timer registration. Remove this entry when done.
+## TD-010: StartupSequencer._register_timers is a stub — RESOLVED
 
 ---
 
-## TD-011: StartupSequencer._determine_mode always sets ACTIVE
-
-**Origin**: 9.1.7 (startup dispatch)
-**Severity**: Medium (no health-based mode selection)
-**Module**: `nexus/startup/sequencer.py`
-
-`_determine_mode()` always sets ACTIVE without checking health. Should set REDUCE_ONLY if health degraded, HALTED if critical.
-
-**When to fix**: When health monitoring is built.
-**Migration**: Implement health check and mode selection logic. Remove this entry when done.
+## TD-011: StartupSequencer._determine_mode always sets ACTIVE — RESOLVED
 
 ---
 
@@ -143,16 +92,7 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 ---
 
-## TD-013: ShutdownSequencer._stop_signals is a stub
-
-**Origin**: 9.2.2 (shutdown sequence)
-**Severity**: High (signals continue during shutdown)
-**Module**: `nexus/startup/shutdown_sequencer.py`
-
-~~`_stop_signals()` logs a warning and does nothing.~~ RESOLVED
-
-**Status**: Implemented in v0.25.0 (X.1.2.5). `_stop_signals()` calls `PredictLoop.stop()` to cancel all sensor timers before shutdown proceeds.
-**Migration**: Implement signal unsubscription. Remove this entry when done.
+## TD-013: ShutdownSequencer._stop_signals is a stub — RESOLVED
 
 ---
 
@@ -169,67 +109,19 @@ Current validation checks for tz-awareness (`tzinfo is not None`) but does not e
 
 ---
 
-## TD-015: ShutdownSequencer._submit_actions lacks Validator/Connector
-
-**Origin**: 9.2.4 (shutdown sequence)
-**Severity**: High (shutdown EXIT actions not submitted)
-**Module**: `nexus/startup/shutdown_sequencer.py`
-
-`_submit_actions()` filters actions to EXIT/ABORT but cannot validate or submit them. No ValidationPipeline or OutboundConnector is wired in. EXIT actions from on_shutdown are logged but not executed.
-
-**When to fix**: When Action dataclass has full fields (TD-023) and shutdown integration is built.
-**Migration**: Add validator and connector parameters to ShutdownSequencer. Validate filtered actions through pipeline, submit valid ones via connector. Remove this entry when done.
+## TD-015: ShutdownSequencer._submit_actions lacks Validator/Connector — RESOLVED
 
 ---
 
-## TD-016: _wait_terminal lacks ABORT escalation
-
-**Origin**: 9.2.5 (shutdown sequence), updated X.1.4.2
-**Severity**: Medium (timeout logs warning but does not force-close)
-**Module**: `nexus/startup/shutdown_sequencer.py`
-
-`_wait_terminal()` now polls PraxisInbound for terminal outcomes with a configurable timeout. However, when timeout expires with commands still pending, it only logs a warning. The RFC specifies ABORT escalation: remaining in-flight commands should be force-aborted via PraxisOutbound, then wait again with a shorter timeout. This requires Action fields (TD-023) to construct ABORT TradeCommands.
-
-**When to fix**: When TD-023 (Action fields) is resolved.
-**Migration**: On timeout, submit ABORT for each pending command via PraxisOutbound, then re-enter wait loop with shorter deadline.
+## TD-016: _wait_terminal lacks ABORT escalation — RESOLVED
 
 ---
 
-## TD-017: StrategySpec allows whitespace-padded strategy_id
-
-**Origin**: 9.2 review (manifest validation gap)
-**Severity**: Medium (potential collision after normalization)
-**Module**: `nexus/infrastructure/manifest.py`
-
-`StrategySpec.__post_init__` validates that `strategy_id.strip()` is non-empty but does not normalize or reject surrounding whitespace. This permits entries like `'s1'` and `' s1 '` to both pass validation as distinct strategies. Downstream code (StartupSequencer, ShutdownSequencer, StrategyRunner) uses `.strip()` on lookup, causing these entries to collide silently — actions and state get attributed to the wrong strategy.
-
-**When to fix**: Before multi-strategy deployments.
-**Migration**: Tighten `StrategySpec.__post_init__` to either (a) strip-and-store the normalized value, or (b) reject strategy_id with leading/trailing whitespace. Validate uniqueness after normalization. Remove this entry when done.
+## TD-017: StrategySpec allows whitespace-padded strategy_id — RESOLVED
 
 ---
 
-## TD-018: Performance bottlenecks in O(N) Python loops and Decimal arithmetic
-
-**Origin**: 10.1 (performance audit)
-**Severity**: Medium (scaling risk)
-**Modules**:
-- `nexus/infrastructure/loss_derivation.py`
-- `nexus/infrastructure/state_store.py`
-- `nexus/infrastructure/wal.py`
-- `nexus/core/validator/intake_stage.py`
-- `nexus/core/capital_controller/capital_controller.py`
-
-Several hot paths and recovery routines use linear O(N) scans and manual dictionary cleanups in pure Python, which will bottleneck as event volume and strategy counts scale. Specifically:
-- `derive_rolling_losses` performs iterative `Decimal` arithmetic over all events in the WAL.
-- `WriteAheadLog.read_all` (called by `StateStore.recover`) performs sequential record-by-record reads over the WAL file.
-- `make_duplicate_order_hook` and `_purge_expired` perform full dictionary scans on every call to find stale entries.
-
-**When to fix**: Before high-frequency trading (HFT) or large-scale multi-strategy deployments.
-**Migration**:
-- ~~Replace O(N) dictionary/list scans~~ RESOLVED in v0.26.0 (X.2.3.1) — `_purge_expired` uses heapq, `make_duplicate_order_hook` uses deque.
-- `derive_rolling_losses` Decimal arithmetic is already O(n) single-pass with early exits. Float aggregation rejected — RFC requires Decimal precision for financial calculations. No further optimization needed unless event volume exceeds 100k per recovery.
-- `WriteAheadLog.read_all` reads sequentially with length-prefixed records — no skip-ahead possible without reading headers. Memory-mapping doesn't help for variable-length records. Marginal optimization; real fix is incremental updates (below) that avoid full WAL reads.
-- ~~Incremental rolling loss updates~~ RESOLVED by TD-002 (X.1.1.4) — snapshot preserves rolling losses, `truncate_keeping_events` retains post-checkpoint events only, recovery re-derives from delta events not full WAL.
+## TD-018: Performance bottlenecks in O(N) Python loops and Decimal arithmetic — RESOLVED
 
 ---
 
@@ -289,16 +181,7 @@ When the manifest changes experiment directories or permutation IDs, Sensors sho
 
 ---
 
-## TD-023: Action dataclass lacks trade fields
-
-**Origin**: MMVP-X.1 command flow (X.1.3.3)
-**Severity**: High (strategies cannot express tradeable decisions)
-**Module**: `nexus/strategy/action.py`
-
-`Action` only has `action_type` (ENTER, EXIT, MODIFY, ABORT). The RFC specifies additional fields required for trade execution: `direction` (BUY/SELL), `size` (base asset quantity), `execution_mode` (SingleShot, Bracket, TWAP, etc.), `order_type` (Market, Limit, etc.), `execution_params` (mode-specific), `deadline` (timeout seconds), `trade_id` (for EXIT/MODIFY/ABORT), `maker_preference`, `reference_price`. Without these fields, the Action → ValidationPipeline → TradeCommand → Praxis submission chain cannot function. The shutdown action submission (TD-015) and the live strategy action flow both depend on this.
-
-**When to fix**: Before end-to-end strategy → trade execution.
-**Migration**: Add RFC-specified fields to Action dataclass. Update ValidationPipeline to validate the new fields. Update `translate_to_trade_command` to map from the enriched Action.
+## TD-023: Action dataclass lacks trade fields — RESOLVED
 
 ---
 

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -434,17 +434,7 @@ The contract documented in `bridge_to_capital`'s docstring is replicated open-co
 
 ---
 
-## TD-051: Realized PnL excludes exit fees; latent inconsistency with future fee_rate change
-
-**Origin**: Round-14 8-pass aggregation
-**Severity**: Low (currently safe — couples with TD-030 in Praxis fee_rate=0)
-**Module**: `nexus/infrastructure/praxis_connector/outcome_processor.py:400`
-
-`realized_pnl = side_multiplier * (fill_price - entry_price) * fill_size` — gross PnL, no exit-fee subtraction. `outcome.actual_fees` is available but unused for EXIT. Documented at `capital_controller.py:608-614` (order_exit docstring) as a deliberate design choice. Combined with Praxis TD-030 (translator fee_rate=0), the gap is currently zero, but a future fee_rate change without updating `_reduce_position` would silently inflate `strategy_realized_pnl` by total exit fees.
-
-**When to fix**: When Praxis TD-030 is addressed (fee_rate flips non-zero), OR when a deployment needs strict realized-PnL accounting.
-**Migration**: Update `_reduce_position` to subtract `outcome.actual_fees` from `realized_pnl`, OR add a `realized_fees` ledger per the existing `order_exit` docstring suggestion.
-
+## TD-051: Realized PnL excludes exit fees; latent inconsistency with future fee_rate change — RESOLVED
 
 ---
 

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -125,59 +125,19 @@ Several lifecycle methods return `False` for failure paths (for example, missing
 
 ---
 
-## TD-019: Cohort (multi-decoder aggregation) not supported
-
-**Origin**: MMVP-X.1 signal flow design (X.1.2.1)
-**Severity**: Medium (single-decoder Trainer path works, Cohort deferred)
-**Module**: `nexus/startup/sequencer.py`
-
-Nexus trains Sensors via `Trainer(experiment_dir).train(permutation_ids)` — this produces one Sensor per permutation ID from a single SFD experiment. Limen's Cohort system (RegimeDiversifiedOpinionPools) aggregates predictions across multiple decoders/regimes into a single callable, but Cohort is not yet ready in Limen.
-
-When Cohort becomes available, Nexus must support a second path in the manifest where a strategy references a Cohort rather than individual Trainer permutations. The Cohort callable exposes the same `predict()` interface as Sensor, so the downstream dispatch (Signal → strategy) is unchanged.
-
-**When to fix**: When Limen Cohort is production-ready.
-**Migration**: Add `cohort` as an alternative to `experiment` + `permutation_ids` in the manifest `sensors` schema. Implement Cohort instantiation path in StartupSequencer alongside the existing Trainer path.
+## TD-019: Cohort (multi-decoder aggregation) not supported — OBSOLETE (superseded by Conduit migration)
 
 ---
 
-## TD-020: No experiment directory sandboxing per account
-
-**Origin**: MMVP-X.1 manifest schema (X.1.2.1)
-**Severity**: High (access control gap)
-**Module**: `nexus/infrastructure/manifest.py`
-
-`SensorSpec.experiment_dir` accepts any path on disk. A manifest can reference any experiment directory, regardless of which account ran that experiment. In a multi-account process, account A's manifest could point to account B's experiments, or to experiments the account owner never ran. There is no validation that an account is authorized to use a given experiment.
-
-**When to fix**: Before multi-tenant or multi-account production deployment.
-**Migration**: Introduce per-account experiment directory allowlists or a scoped base path per account (e.g. `{base}/{account_id}/experiments/`). Validate during manifest load that all `experiment_dir` paths fall within the account's allowed scope. Reject manifests that reference experiments outside the account's sandbox.
+## TD-020: No experiment directory sandboxing per account — OBSOLETE (superseded by Conduit migration)
 
 ---
 
-## TD-021: PredictLoop uses stub market data provider
-
-**Origin**: MMVP-X.1 predict loop (X.1.2.4)
-**Severity**: High (no real market data flows to Sensors)
-**Module**: `nexus/strategy/predict_loop.py`
-
-`PredictLoop` accepts a `market_data_provider: Callable[[int], pl.DataFrame]` that returns a rolling DataFrame of bars for a given kline_size. No concrete provider exists — the predict loop works but has nothing to call in production.
-
-The concrete provider depends on Praxis TD-016 #3 (shared market data poller) which fetches klines per unique kline_size using `binancial.compute.get_spot_klines`. The kline_size for each sensor is in the Limen manifest's `data_source_config.params['kline_size']` — already extracted by `PredictLoop._extract_kline_size()`.
-
-**When to fix**: When Praxis TD-016 #3 (shared market data poller) is built.
-**Migration**: Implement the concrete market data provider that wraps the shared poller's rolling DataFrames. Wire it into PredictLoop construction during Nexus instance startup.
+## TD-021: PredictLoop uses stub market data provider — OBSOLETE (superseded by Conduit migration)
 
 ---
 
-## TD-022: Sensor hot reload not implemented
-
-**Origin**: MMVP-X.1 signal flow (X.1.2.6)
-**Severity**: Medium (requires process restart to change sensors)
-**Modules**: `nexus/startup/sequencer.py`, `nexus/strategy/predict_loop.py`
-
-When the manifest changes experiment directories or permutation IDs, Sensors should be re-trained and the predict loop restarted without process restart. This requires: manifest file watching, diffing old vs new SensorSpecs, stopping the predict loop, re-running `_wire_sensors` with updated specs, restarting the loop with new WiredSensors. The RFC describes a full hot reload system with tier-1/tier-2/tier-3 change classification — none of this infrastructure exists yet.
-
-**When to fix**: When manifest hot reload infrastructure is built.
-**Migration**: Implement manifest file watcher, change diffing, and Sensor re-training via `importlib` reload. Integrate with PredictLoop start/stop lifecycle.
+## TD-022: Sensor hot reload not implemented — OBSOLETE (superseded by Conduit migration)
 
 ---
 
@@ -958,47 +918,17 @@ Both changes together close the window. Option (1) alone is preferred where feas
 
 ---
 
-## TD-087: `reconstruct_sensor` raises bare `KeyError` for an unseeded `_worker_data` dir — indistinguishable from a per-sensor reconstruction failure
-
-**Origin**: Greybeard pre-PR review (#72 parallel/cache wiring)
-**Severity**: Low (internal invariant — only fires on a worker-seeding bug, not on normal input)
-**Module**: `nexus/startup/sensor_cache.py` (`reconstruct_sensor`); pool path `nexus/startup/warm_cache.py` `warm_cache` (was `nexus/startup/sequencer.py` `_reconstruct_pooled` through v0.52.0; moved to the pre-launch warmer in v0.52.1 as the launcher no longer runs a pool).
-
-`reconstruct_sensor` does `data = _worker_data[experiment_dir_str]`. If a worker's `_worker_data` was not seeded with that dir (a programming error in how `init_worker`'s `data_by_dir` is built), the bare `KeyError` propagates out of the future and the pooled caller catches it in the per-sensor isolation handler, logging it as `"sensor wiring failed"`. A seeding bug — which would mis-wire *every* sensor for that dir — is then indistinguishable from a genuine per-permutation `ReconstructionError`, and the account could silently start with a whole dir's sensors quarantined. Today the dirs seeded into `data_by_dir` (now in `warm_cache.warm_cache`) are derived from the same `misses` set the tasks come from, so the key is always present; the gap is purely diagnostic.
-
-**When to fix**: When a second experiment-dir source or a non-trivial `data_by_dir` construction path is added (raising the chance of a seeding mismatch), or if a quarantine-everything-for-a-dir incident is observed.
-
-**Migration**: In `reconstruct_sensor`, distinguish a missing-seed `KeyError` from a reconstruction failure (e.g. raise a typed `RuntimeError('worker data not seeded for <dir>')`), and have the pooled caller in `warm_cache.warm_cache` surface that as a hard warmer-exit error rather than per-sensor isolation, since it indicates a programming error, not a bad permutation.
+## TD-087: `reconstruct_sensor` raises bare `KeyError` for an unseeded `_worker_data` dir — indistinguishable from a per-sensor reconstruction failure — OBSOLETE (superseded by Conduit migration)
 
 ---
 
-## TD-088: pool initializer broadcasts every dir's `_data` to every worker — O(num_dirs × num_workers) memory for multi-dir manifests
-
-**Origin**: Copilot PR #73 review (#72 parallel/cache wiring)
-**Severity**: Low today (current deploys wire a single experiment_dir); material only for manifests spanning several large bundles
-**Module**: `nexus/startup/warm_cache.py` `warm_cache` (was `nexus/startup/sequencer.py` `_reconstruct_pooled` through v0.52.0; moved to the pre-launch warmer in v0.52.1)
-
-`warm_cache` builds `data_by_dir = {dir: loader._data for dir in miss_dirs}` and passes the whole map to `ProcessPoolExecutor(initializer=init_worker, initargs=(data_by_dir,))`. Each worker therefore receives — pickled at pool startup and held resident — the frozen `_data` (~160 MB for the BTC 15m bundle) for *every* experiment_dir with misses, not just the dirs whose tasks it happens to run. Memory and pool-startup pickling cost scale as O(num_dirs × num_workers). A single-dir manifest (today's deploys) replicates one bundle per worker, which is unavoidable since every worker may draw a task for that dir; the blow-up only bites a manifest that wires sensors from multiple large bundles at once.
-
-**When to fix**: When a manifest wires sensors from multiple large experiment_dirs under process-parallel reconstruction.
-
-**Migration**: Shard reconstruction by dir — either a separate `ProcessPoolExecutor` per experiment_dir (each seeded with only its own `_data`), or a worker `initializer` that lazily loads a dir's `_data` on first use behind a small per-worker LRU, so a worker holds only the bundles it actually touches.
+## TD-088: pool initializer broadcasts every dir's `_data` to every worker — O(num_dirs × num_workers) memory for multi-dir manifests — OBSOLETE (superseded by Conduit migration)
 
 ---
 
-## TD-089: PredictLoop test executor runs done-callbacks inline, not on a separate thread
+## TD-089: PredictLoop test executor runs done-callbacks inline, not on a separate thread — OBSOLETE (superseded by Conduit migration)
 
-**Origin**: Greybeard pre-PR review of `fix/wire-pool-spawn-start-method` (v0.53.0 process-pool predict executor)
-**Severity**: Low (test fidelity only; production correctness verified by real spawn-pool smoke test)
-**Module**: `tests/test_predict_loop.py` `_SyncExecutor`
-
-`_SyncExecutor.submit` returns a completed `concurrent.futures.Future`. When `_submit_one` then calls `future.add_done_callback(_on_done)` on a future that is already done, the callback fires **inline in the calling thread** (the scheduler thread). The production `ProcessPoolExecutor` invokes done-callbacks on a separate result-handler thread, so the parent-side dispatch chain (`_log_signal` -> `context_provider` -> `dispatch_signal` -> `action_submit`) actually runs concurrent with the scheduler thread's next iteration. The test double therefore cannot exercise any cross-thread race between scheduling and result handling — for example, a `stop()` racing against an in-flight callback, or two callbacks contending for `self._lock` while the scheduler is mid-poll.
-
-The `MagicMock`-sensor + spawn-pickle-boundary constraint forced this seam; the test executor is the only practical way to exercise parent-side behavior without spawning real workers (which would also bypass the mocks and try to load a real bundle from disk). Real-pool coverage is limited to the smoke test in the session that ships the change (and the prod runtime itself).
-
-**When to fix**: When a concurrency defect in the parent-side scheduler/callback interaction is suspected or reported, or when adding a feature that meaningfully changes lock scope in `_handle_predict_result`, `_submit_one`, or `_maybe_unlink_ipc`.
-
-**Migration**: Add a second test double that submits to a thread-based executor and fires `add_done_callback` from a worker thread (or use a real `ThreadPoolExecutor` patched in place of `ProcessPoolExecutor`); use it for the lock/race-sensitive subset of tests while keeping the synchronous `_SyncExecutor` for the dispatch-chain tests that don't need cross-thread fidelity. An integration test against a real spawn pool with a recorded bundle on disk would be even stronger but requires CI infrastructure to ship a small fixture bundle.
+---
 
 ## TD-090: `serialize_state` snapshot is shallow — `Position` / `StrategyModeState` field-level torn reads still possible
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.63.0"
+version = "0.63.1"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Audits the technical-debt register against the current code and collapses the entries that no longer represent live debt to **heading-only status markers** (the `## TD-NNN:` heading is retained so the TD numbers are never reused; the stale bodies are removed). Documentation + release metadata only — no runtime code or behaviour change.

### Resolved (verified absent in current source)

TD-004 (`tzinfo` UTC checks), TD-005 / TD-006 (sequencer `_register_with_trading` / `_reconcile_capital` implemented), TD-010 / TD-011 (timer registration, `REDUCE_ONLY` default), TD-013 / TD-015 / TD-016 (shutdown stop-signals / submit-actions / ABORT escalation), TD-017 (`strategy_id` strip validation), TD-018 (heapq purge, incremental WAL retention), TD-023 (`Action` trade fields).

### Obsolete (subject code deleted/rewritten by the Furnace-Conduit migration)

TD-019 / TD-020 / TD-021 / TD-022 (cohort aggregation, per-account experiment dirs, stub market-data provider, sensor hot-reload — replaced by the single-process Conduit `PredictLoop` + `SignalSpec`) and TD-087 / TD-088 / TD-089 (`reconstruct_sensor`, pool-initializer broadcast, predict-loop process-pool test — `sensor_cache.py` / `warm_cache.py` were deleted).

### TD-051 marked RESOLVED

The realized-PnL exit-fee subtraction it asked for is already present: `_reduce_position` computes `realized_pnl = gross_pnl - outcome.actual_fees` ([`outcome_processor.py`](nexus/infrastructure/praxis_connector/outcome_processor.py)) and `_grow_position` folds entry fees into `avg_cost_basis`. It is inert only while the upstream outcome bridge emits a zero fee, which the companion Praxis change ([Vaquum/Praxis#154](https://github.com/Vaquum/Praxis/pull/154)) fixes.

## Tests

No code changed, so no test or behaviour change — the diff is the TD register plus the version/CHANGELOG metadata. Entry count is unchanged (83); every collapsed entry retains its `## TD-NNN:` heading. Patch-bumps version 0.63.0 → 0.63.1 with a CHANGELOG entry (per repo convention, every PR bumps + records a line).

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable