### PR TITLE
fix: preserve Nexus positions on reconcile divergence; key on pos.trade_id (v0.64.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -807,3 +807,10 @@
 ### Update
 
 - Prune the technical-debt register in [`docs/TechnicalDebt.md`](docs/TechnicalDebt.md): collapse code-verified-resolved (TD-004, TD-005, TD-006, TD-010, TD-011, TD-013, TD-015, TD-016, TD-017, TD-018, TD-023) and Conduit-obsoleted (TD-019, TD-020, TD-021, TD-022, TD-087, TD-088, TD-089) entries to heading-only status markers, and mark TD-051 RESOLVED (`_reduce_position` already nets exit fees at [`outcome_processor.py`](nexus/infrastructure/praxis_connector/outcome_processor.py) via `realized_pnl = gross_pnl - actual_fees`)
+
+## v0.64.0 on 16th of June, 2026
+
+### Fix
+
+- Stop boot reconciliation from silently deleting a Nexus position absent from the Praxis snapshot. `_reconcile_capital` previously evicted such positions ("Praxis truth wins") and checkpointed the deletion, so a restart could discard a live position and orphan the venue holding. It now preserves the position and fails closed (raises [`StartupError`](nexus/startup/error.py)) so the divergence is investigated rather than resolved by data loss. Pairs with the Praxis fix that stops entry fills from emitting `TradeClosed` (which made Praxis under-report open positions on replay)
+- Match Praxis positions on `pos.trade_id` rather than unpacking the snapshot tuple key in `_reconcile_capital`. Praxis keys positions `(trade_id, account_id)` but reconcile read element `[1]` (the account_id) as the trade_id, so every Praxis position mis-bucketed and never matched the Nexus side

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -996,3 +996,16 @@ Inside the terminal-release path, `order_fill` calls `_adjust_strategy_deployed(
 **When to fix**: Never on its own. Roll into TD-093 if/when the branch is being touched anyway; otherwise the two-call shape mirrors the natural read order (apply fee delta, then apply residual release) and is easier to reason about.
 
 **Migration**: Combine the two `_adjust_strategy_deployed` calls in the terminal-release branch into one with the summed delta. Strictly cosmetic.
+
+---
+
+## TD-095: Boot reconcile fails closed even on a position the venue legitimately closed
+
+**Origin**: Reconcile durability fix (preserve-not-evict), Greybeard pre-PR review
+**Severity**: Low (a restart racing a close is rare; failing closed is safer than silent loss)
+**Module**: `nexus/startup/sequencer.py`
+
+`_reconcile_capital` raises `StartupError` for any Nexus position absent from the Praxis snapshot, preserving it rather than deleting. This correctly prevents orphaning a venue holding when Praxis under-reported the position. But it cannot distinguish that from a position the venue legitimately closed whose terminal outcome Nexus had not processed before a restart — the latter now halts startup instead of reconciling, so an unattended restart cannot self-recover from that previously-handled case.
+
+**When to fix**: If restart-during-close races prove frequent during the soak.
+**Migration**: Have Praxis expose whether a `trade_id` has a recorded terminal close (`TradeClosed` / terminal outcome). Reconcile then applies a Praxis-recorded close to Nexus state, and fails closed only when Praxis has no record of the position at all (the genuine orphan / data-loss case).

--- a/nexus/infrastructure/praxis_connector/praxis_outbound.py
+++ b/nexus/infrastructure/praxis_connector/praxis_outbound.py
@@ -361,7 +361,10 @@ class PraxisOutbound:
             account_id: Account identifier to query.
 
         Returns:
-            Positions keyed by (account_id, trade_id) tuples.
+            Positions keyed by (trade_id, account_id) tuples. Consumers
+            should match on `pos.trade_id` rather than tuple position —
+            the key ordering is a Praxis-internal detail, and reading it
+            positionally is what previously mis-bucketed every position.
 
         Raises:
             RuntimeError: If pull_positions_fn is not configured.

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -381,6 +381,34 @@ class StartupSequencer:
         except Exception as e:
             raise StartupError('reconcile_capital', f'failed to parse Praxis positions: {e}') from e
 
+        nexus_only_trade_ids = [
+            trade_id for trade_id in self._state.positions
+            if trade_id not in praxis_by_trade_id
+        ]
+        if nexus_only_trade_ids:
+            nexus_only = {
+                trade_id: {
+                    'strategy_id': self._state.positions[trade_id].strategy_id,
+                    'size': str(self._state.positions[trade_id].size),
+                    'entry_price': str(self._state.positions[trade_id].entry_price),
+                }
+                for trade_id in nexus_only_trade_ids
+            }
+            _log.error(
+                'boot reconciliation found Nexus positions absent from the '
+                'Praxis snapshot; preserving Nexus state and failing closed '
+                'rather than deleting live positions — a silent deletion here '
+                'would orphan the venue holding the position. Investigate the '
+                'divergence (e.g. a Praxis replay that did not rebuild the '
+                'position) before restarting',
+                nexus_only=nexus_only,
+            )
+            raise StartupError(
+                'reconcile_capital',
+                'Nexus-only positions not present in Praxis snapshot: '
+                f'{sorted(nexus_only_trade_ids)}',
+            )
+
         praxis_total_notional = _ZERO
 
         for trade_id, praxis_pos in praxis_by_trade_id.items():
@@ -440,34 +468,6 @@ class StartupSequencer:
                 nexus_pos.avg_cost_basis = fallback_price
 
             praxis_total_notional += qty * basis_price
-
-        nexus_only_trade_ids = [
-            trade_id for trade_id in self._state.positions
-            if trade_id not in praxis_by_trade_id
-        ]
-        if nexus_only_trade_ids:
-            nexus_only = {
-                trade_id: {
-                    'strategy_id': self._state.positions[trade_id].strategy_id,
-                    'size': str(self._state.positions[trade_id].size),
-                    'entry_price': str(self._state.positions[trade_id].entry_price),
-                }
-                for trade_id in nexus_only_trade_ids
-            }
-            _log.error(
-                'boot reconciliation found Nexus positions absent from the '
-                'Praxis snapshot; preserving Nexus state and failing closed '
-                'rather than deleting live positions — a silent deletion here '
-                'would orphan the venue holding the position. Investigate the '
-                'divergence (e.g. a Praxis replay that did not rebuild the '
-                'position) before restarting',
-                nexus_only=nexus_only,
-            )
-            raise StartupError(
-                'reconcile_capital',
-                'Nexus-only positions not present in Praxis snapshot: '
-                f'{sorted(nexus_only_trade_ids)}',
-            )
 
         old_notional = self._state.capital.position_notional
 

--- a/nexus/startup/sequencer.py
+++ b/nexus/startup/sequencer.py
@@ -29,7 +29,6 @@ from nexus.strategy.runner import StrategyRunner
 
 _ZERO = Decimal(0)
 _HUNDRED = Decimal('100')
-_POSITION_KEY_LENGTH = 2
 _log = structlog.get_logger()
 
 __all__ = ['SignalBinding', 'StartupSequencer']
@@ -371,17 +370,14 @@ class StartupSequencer:
 
         try:
             for key, pos in praxis_positions.items():
-                if not isinstance(key, tuple) or len(key) != _POSITION_KEY_LENGTH:
-                    _log.warning('skipping Praxis position with unexpected key', key=repr(key))
-                    continue
-                _, trade_id = key
-                if isinstance(trade_id, str):
-                    praxis_by_trade_id[trade_id] = pos
-                else:
+                trade_id = getattr(pos, 'trade_id', None)
+                if not isinstance(trade_id, str):
                     _log.warning(
-                        'skipping Praxis position with non-string trade_id',
-                        trade_id=repr(trade_id),
+                        'skipping Praxis position without a string trade_id',
+                        key=repr(key),
                     )
+                    continue
+                praxis_by_trade_id[trade_id] = pos
         except Exception as e:
             raise StartupError('reconcile_capital', f'failed to parse Praxis positions: {e}') from e
 
@@ -449,16 +445,28 @@ class StartupSequencer:
             trade_id for trade_id in self._state.positions
             if trade_id not in praxis_by_trade_id
         ]
-        for trade_id in nexus_only_trade_ids:
-            evicted = self._state.positions.pop(trade_id)
-            _log.warning(
-                'evicting Nexus-only position not present in Praxis snapshot — '
-                'Praxis truth wins; the per_strategy_deployed rebuild downstream '
-                'will not include this stale entry',
-                trade_id=trade_id,
-                strategy_id=evicted.strategy_id,
-                size=str(evicted.size),
-                entry_price=str(evicted.entry_price),
+        if nexus_only_trade_ids:
+            nexus_only = {
+                trade_id: {
+                    'strategy_id': self._state.positions[trade_id].strategy_id,
+                    'size': str(self._state.positions[trade_id].size),
+                    'entry_price': str(self._state.positions[trade_id].entry_price),
+                }
+                for trade_id in nexus_only_trade_ids
+            }
+            _log.error(
+                'boot reconciliation found Nexus positions absent from the '
+                'Praxis snapshot; preserving Nexus state and failing closed '
+                'rather than deleting live positions — a silent deletion here '
+                'would orphan the venue holding the position. Investigate the '
+                'divergence (e.g. a Praxis replay that did not rebuild the '
+                'position) before restarting',
+                nexus_only=nexus_only,
+            )
+            raise StartupError(
+                'reconcile_capital',
+                'Nexus-only positions not present in Praxis snapshot: '
+                f'{sorted(nexus_only_trade_ids)}',
             )
 
         old_notional = self._state.capital.position_notional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.63.1"
+version = "0.64.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -609,6 +609,7 @@ class TestExternalIntegrationStubs:
             sequencer._reconcile_capital()
 
         assert 'trade_a' in sequencer._state.positions
+        assert 'trade_b' not in sequencer._state.positions
 
     def test_reconcile_capital_skips_praxis_position_without_strategy_id(self) -> None:
         '''Praxis positions lacking strategy_id are not imported AND do not

--- a/tests/test_startup_sequencer.py
+++ b/tests/test_startup_sequencer.py
@@ -455,13 +455,11 @@ class TestExternalIntegrationStubs:
         assert sequencer._state.capital.position_notional == Decimal('100000')
         assert sequencer._state.positions['shared_trade'].avg_cost_basis == Decimal('50000')
 
-    def test_reconcile_capital_evicts_nexus_only_position(self) -> None:
-        '''A Nexus position that Praxis no longer carries (e.g. closed
-        via Praxis WS path between our last checkpoint and this boot)
-        is evicted, and `position_notional` is recomputed from the
-        Praxis snapshot only. Prevents the
-        attribution-mismatch denial that the per-strategy deployed
-        rebuild downstream would otherwise trigger.'''
+    def test_reconcile_capital_fails_closed_on_nexus_only_position(self) -> None:
+        '''A Nexus position absent from the Praxis snapshot must not be
+        silently deleted — that would orphan the venue holding. Reconcile
+        fails closed (raises StartupError) and preserves the position so a
+        subsequent consistent boot can recover it.'''
 
         outbound = MagicMock()
         outbound.pull_positions.return_value = {}
@@ -485,10 +483,10 @@ class TestExternalIntegrationStubs:
         )
         sequencer._state = state
 
-        sequencer._reconcile_capital()
+        with pytest.raises(StartupError):
+            sequencer._reconcile_capital()
 
-        assert 'stale_trade' not in sequencer._state.positions
-        assert sequencer._state.capital.position_notional == Decimal('0')
+        assert 'stale_trade' in sequencer._state.positions
 
     def test_reconcile_capital_keeps_position_present_in_both(self) -> None:
         '''A position present in both Nexus and Praxis stays put
@@ -528,10 +526,51 @@ class TestExternalIntegrationStubs:
 
         assert 'shared_trade' in sequencer._state.positions
 
-    def test_reconcile_capital_evicts_nexus_only_keeps_praxis_only(self) -> None:
+    def test_reconcile_capital_matches_on_pos_trade_id_not_tuple_order(self) -> None:
+        '''Praxis keys positions `(trade_id, account_id)`; reconcile must
+        match on `pos.trade_id`, not on a tuple position. A position
+        present in both must reconcile cleanly (no spurious fail-closed),
+        regardless of the snapshot key ordering.'''
+
+        praxis_pos = MagicMock()
+        praxis_pos.account_id = 'acc_001'
+        praxis_pos.trade_id = 'shared_trade'
+        praxis_pos.symbol = 'BTCUSDT'
+        praxis_pos.side = OrderSide.BUY
+        praxis_pos.qty = Decimal('0.5')
+        praxis_pos.avg_entry_price = Decimal('50000')
+        praxis_pos.strategy_id = 'momentum'
+
+        outbound = MagicMock()
+        outbound.pull_positions.return_value = {
+            ('shared_trade', 'acc_001'): praxis_pos,
+        }
+
+        sequencer = _make_sequencer()
+        sequencer._praxis_outbound = outbound
+        _attach_stub_manifest(sequencer, account_id='acc_001')
+        state = InstanceState(
+            capital=CapitalState(capital_pool=Decimal('10000')),
+        )
+        state.positions['shared_trade'] = Position(
+            trade_id='shared_trade',
+            strategy_id='momentum',
+            symbol='BTCUSDT',
+            side=OrderSide.BUY,
+            size=Decimal('0.5'),
+            entry_price=Decimal('50000'),
+        )
+        sequencer._state = state
+
+        sequencer._reconcile_capital()
+
+        assert 'shared_trade' in sequencer._state.positions
+
+    def test_reconcile_capital_fails_closed_preserving_nexus_only(self) -> None:
         '''Mixed scenario — Nexus has trade_a only, Praxis has trade_b
-        only. After reconcile, trade_a is evicted, trade_b is imported,
-        position_notional reflects trade_b only.'''
+        only. The Praxis-only position imports, but the Nexus-only trade_a
+        makes reconcile fail closed (StartupError) and stay preserved
+        rather than being silently deleted.'''
 
         praxis_pos = MagicMock()
         praxis_pos.account_id = 'acc_001'
@@ -566,11 +605,10 @@ class TestExternalIntegrationStubs:
         )
         sequencer._state = state
 
-        sequencer._reconcile_capital()
+        with pytest.raises(StartupError):
+            sequencer._reconcile_capital()
 
-        assert 'trade_a' not in sequencer._state.positions
-        assert 'trade_b' in sequencer._state.positions
-        assert sequencer._state.capital.position_notional == Decimal('40000')
+        assert 'trade_a' in sequencer._state.positions
 
     def test_reconcile_capital_skips_praxis_position_without_strategy_id(self) -> None:
         '''Praxis positions lacking strategy_id are not imported AND do not


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Fixes the Nexus half of a restart durability bug where a process restart dropped open positions: boot reconciliation silently deleted any Nexus position the Praxis snapshot lacked, orphaning the venue holding.

### Preserve, don't evict

`_reconcile_capital` previously evicted Nexus positions absent from the Praxis snapshot ("Praxis truth wins") and checkpointed the deletion. On a restart that discarded a live position while the venue still held it. It now **preserves** the position and **fails closed** (raises `StartupError`) so the divergence is investigated rather than resolved by data loss. Pairs with the Praxis change ([Vaquum/Praxis#155](https://github.com/Vaquum/Praxis/pull/155)) that stops entry fills from emitting `TradeClosed`, which is what made Praxis under-report open positions on replay.

### Key on `pos.trade_id`

The reconcile parse loop matched Praxis positions by unpacking the snapshot tuple key and reading element `[1]`. Praxis keys positions `(trade_id, account_id)`, so it read the **account_id** as the trade_id and every Praxis position mis-bucketed and never matched the Nexus side. It now matches on `pos.trade_id` directly, independent of key ordering.

TD-095 records a follow-up: distinguish a venue-recorded close (apply it) from a lost position (fail closed), so a restart racing a legitimate close can self-recover.

## Tests

Rewrote the two eviction tests to the fail-closed contract (raises `StartupError`, position preserved) and added a keying regression test that feeds the real `(trade_id, account_id)` snapshot order. `ruff` + `mypy` clean, **1,447 tests pass**. Bumps 0.63.1 → 0.64.0.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [ ] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable