### PR TITLE
fix: snap sub-ULP capital residues so restart recovery cannot brick (v0.65.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -814,3 +814,15 @@
 
 - Stop boot reconciliation from silently deleting a Nexus position absent from the Praxis snapshot. `_reconcile_capital` previously evicted such positions ("Praxis truth wins") and checkpointed the deletion, so a restart could discard a live position and orphan the venue holding. It now preserves the position and fails closed (raises [`StartupError`](nexus/startup/error.py)) so the divergence is investigated rather than resolved by data loss. Pairs with the Praxis fix that stops entry fills from emitting `TradeClosed` (which made Praxis under-report open positions on replay)
 - Match Praxis positions on `pos.trade_id` rather than unpacking the snapshot tuple key in `_reconcile_capital`. Praxis keys positions `(trade_id, account_id)` but reconcile read element `[1]` (the account_id) as the trade_id, so every Praxis position mis-bucketed and never matched the Nexus side
+
+## v0.65.0 on 16th of June, 2026
+
+### Add
+
+- Add `test_decode_capital_state_snaps_subulp_negative_residue` and `test_decode_capital_state_rejects_meaningful_negative` to [`tests/test_wal_codec.py`](tests/test_wal_codec.py)
+- Add TD-096 recording the structural follow-up (collapse the two-step terminal residual release in `order_fill` into one exact decrement)
+
+### Fix
+
+- Snap sub-ULP Decimal residues in `CapitalController` capital aggregates to zero so a restart cannot brick on recovery. After a fee-bearing terminal fill, the reserve/release arithmetic (proportional-fee division in `TrackedOrder.remaining_total`) could leave `working_order_notional` at a sub-ULP negative (e.g. `-1E-27`); `CapitalState.__post_init__` rejects any negative, so `deserialize_state` failed and the instance crash-looped on boot. `order_fill` now snaps `working_order_notional`, `fee_reserve`, and `per_strategy_deployed` residues within `_SUB_ULP_TOLERANCE` to zero (the `fee_reserve` snap previously handled only tiny negatives; `_adjust_strategy_deployed` now treats sub-tolerance magnitudes as zero rather than logging a false underflow). Latent until the Praxis fee fix made `actual_fees` non-zero
+- Add a narrow recovery shim in `wal_codec._decode_capital_state`: snap sub-tolerance negative persisted aggregates to zero before constructing `CapitalState`, so snapshots already carrying a residue boot. The `CapitalState` non-negative invariant stays strict — only sub-`_SUB_ULP_TOLERANCE` negatives are snapped; meaningful negatives still raise

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -1009,3 +1009,16 @@ Inside the terminal-release path, `order_fill` calls `_adjust_strategy_deployed(
 
 **When to fix**: If restart-during-close races prove frequent during the soak.
 **Migration**: Have Praxis expose whether a `trade_id` has a recorded terminal close (`TradeClosed` / terminal outcome). Reconcile then applies a Praxis-recorded close to Nexus state, and fails closed only when Praxis has no record of the position at all (the genuine orphan / data-loss case).
+
+---
+
+## TD-096: order_fill releases terminal residual in two steps
+
+**Origin**: Capital sub-ULP residue fix (pre-PR review)
+**Severity**: Low (residue now snapped to zero; this is cleanliness, not correctness)
+**Module**: `nexus/core/capital_controller/capital_controller.py`
+
+For a terminal fill with `new_remaining > 0`, `order_fill` releases the working aggregate as `fill_with_estimated` plus `terminal_residual`, which algebraically sum to `pre_fill_remaining` but, via `TrackedOrder.remaining_total`'s proportional-fee Decimal division, can leave a sub-ULP residue in `working_order_notional`. The residue is now snapped to zero within `_SUB_ULP_TOLERANCE`, so the non-negative invariant holds; the two-step release shape is retained.
+
+**When to fix**: Opportunistically.
+**Migration**: For terminal fills, decrement `working_order_notional` by `pre_fill_remaining` in one exact operation instead of the two-step `fill_with_estimated` + `terminal_residual`.

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -26,6 +26,7 @@ from nexus.core.capital_controller.tracked_order import (
     OrderLifecycleState,
     TrackedOrder,
 )
+from nexus.core.domain.capital_state import SUB_ULP_TOLERANCE as _SUB_ULP_TOLERANCE
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.position import Position
 
@@ -56,7 +57,8 @@ _ONE_HUNDRED = Decimal('100')
 # any meaningful money increment; at extreme scales (sub-cent
 # trades or notional > 10^15) it would need to become relative.
 # Tracked as a TD entry; not load-bearing for current scope.
-_SUB_ULP_TOLERANCE = Decimal('1E-12')
+# `_SUB_ULP_TOLERANCE` is imported from `capital_state` (single source,
+# also used by the WAL codec's recovery clamp).
 
 
 class CapitalController:
@@ -945,10 +947,7 @@ class CapitalController:
             self._state.position_notional += fill_notional + actual_fees
             self._state.fee_reserve += fee_delta
 
-            if (
-                self._state.fee_reserve < _ZERO
-                and abs(self._state.fee_reserve) <= _SUB_ULP_TOLERANCE
-            ):
+            if abs(self._state.fee_reserve) <= _SUB_ULP_TOLERANCE:
                 self._state.fee_reserve = _ZERO
 
             if fee_delta != _ZERO:
@@ -957,6 +956,9 @@ class CapitalController:
             if terminal and new_remaining > _ZERO:
                 self._state.working_order_notional -= terminal_residual
                 self._adjust_strategy_deployed(order.strategy_id, -terminal_residual)
+
+            if abs(self._state.working_order_notional) <= _SUB_ULP_TOLERANCE:
+                self._state.working_order_notional = _ZERO
 
             return LifecycleResult(success=True)
 
@@ -1086,6 +1088,10 @@ class CapitalController:
         current = self._state.per_strategy_deployed.get(strategy_id, _ZERO)
         updated = current + delta
 
+        if abs(updated) <= _SUB_ULP_TOLERANCE:
+            self._state.per_strategy_deployed.pop(strategy_id, None)
+            return
+
         if updated < _ZERO:
             _logger.warning(
                 'Per-strategy deployed underflow: strategy=%s current=%s delta=%s updated=%s',
@@ -1094,10 +1100,6 @@ class CapitalController:
                 delta,
                 updated,
             )
-            self._state.per_strategy_deployed.pop(strategy_id, None)
-            return
-
-        if updated == _ZERO:
             self._state.per_strategy_deployed.pop(strategy_id, None)
             return
 

--- a/nexus/core/domain/capital_state.py
+++ b/nexus/core/domain/capital_state.py
@@ -10,9 +10,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from decimal import Decimal
 
-__all__ = ['CapitalState']
+__all__ = ['SUB_ULP_TOLERANCE', 'CapitalState']
 
 _ZERO = Decimal(0)
+SUB_ULP_TOLERANCE = Decimal('1E-12')
 
 
 @dataclass

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -184,9 +184,8 @@ def _decode_capital_state(d: dict[str, Any]) -> CapitalState:
         fee_reserve=_clamp_subulp_negative(Decimal(d['fee_reserve'])),
         reservation_notional=_clamp_subulp_negative(Decimal(d['reservation_notional'])),
         per_strategy_deployed={
-            strategy_id: clamped
+            strategy_id: _clamp_subulp_negative(Decimal(deployed))
             for strategy_id, deployed in d.get('per_strategy_deployed', {}).items()
-            if (clamped := _clamp_subulp_negative(Decimal(deployed))) != _ZERO
         },
     )
 

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 
 import msgpack
 
+from nexus.core.domain.capital_state import SUB_ULP_TOLERANCE as _SUB_ULP_TOLERANCE
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode, OrderSide
 from nexus.core.domain.instance_state import InstanceState
@@ -27,6 +28,25 @@ __all__ = [
     'serialize_event',
     'serialize_state',
 ]
+
+_ZERO = Decimal(0)
+
+
+def _clamp_subulp_negative(value: Decimal) -> Decimal:
+    '''Snap a sub-tolerance negative aggregate to zero, else return as-is.
+
+    Capital reserve/release arithmetic can leave a sub-ULP negative
+    Decimal residue (e.g. `-1E-27`) in a field that must stay
+    non-negative. Persisting it bricks recovery because
+    `CapitalState.__post_init__` rejects any negative. Snap only residues
+    within `_SUB_ULP_TOLERANCE`; a meaningful negative is left intact so
+    the domain invariant still rejects genuinely-broken state.
+    '''
+
+    if -_SUB_ULP_TOLERANCE <= value < _ZERO:
+        return _ZERO
+
+    return value
 
 _CODEC_VERSION_1 = 1
 _CODEC_VERSION_LATEST = _CODEC_VERSION_1
@@ -158,13 +178,13 @@ def _decode_capital_state(d: dict[str, Any]) -> CapitalState:
 
     return CapitalState(
         capital_pool=Decimal(d['capital_pool']),
-        position_notional=Decimal(d['position_notional']),
-        working_order_notional=Decimal(d['working_order_notional']),
-        in_flight_order_notional=Decimal(d['in_flight_order_notional']),
-        fee_reserve=Decimal(d['fee_reserve']),
-        reservation_notional=Decimal(d['reservation_notional']),
+        position_notional=_clamp_subulp_negative(Decimal(d['position_notional'])),
+        working_order_notional=_clamp_subulp_negative(Decimal(d['working_order_notional'])),
+        in_flight_order_notional=_clamp_subulp_negative(Decimal(d['in_flight_order_notional'])),
+        fee_reserve=_clamp_subulp_negative(Decimal(d['fee_reserve'])),
+        reservation_notional=_clamp_subulp_negative(Decimal(d['reservation_notional'])),
         per_strategy_deployed={
-            strategy_id: Decimal(deployed)
+            strategy_id: _clamp_subulp_negative(Decimal(deployed))
             for strategy_id, deployed in d.get('per_strategy_deployed', {}).items()
         },
     )

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -184,8 +184,9 @@ def _decode_capital_state(d: dict[str, Any]) -> CapitalState:
         fee_reserve=_clamp_subulp_negative(Decimal(d['fee_reserve'])),
         reservation_notional=_clamp_subulp_negative(Decimal(d['reservation_notional'])),
         per_strategy_deployed={
-            strategy_id: _clamp_subulp_negative(Decimal(deployed))
+            strategy_id: clamped
             for strategy_id, deployed in d.get('per_strategy_deployed', {}).items()
+            if (clamped := _clamp_subulp_negative(Decimal(deployed))) != _ZERO
         },
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.64.0"
+version = "0.65.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -955,3 +955,37 @@ class TestAccountDustRoundtrip:
 
         restored = deserialize_state(legacy_data)
         assert restored.account_dust == {}
+
+
+def test_decode_capital_state_snaps_subulp_negative_residue() -> None:
+    '''A sub-ULP negative residue in a non-negative aggregate is snapped
+    to zero on decode so recovery does not brick on a persisted residue
+    (e.g. working_order_notional == -1E-27 from fee-division rounding).'''
+
+    decoded = wal_codec._decode_capital_state({
+        'capital_pool': '80000',
+        'position_notional': '6005.999999999999999999999999',
+        'working_order_notional': '-1E-27',
+        'in_flight_order_notional': '0',
+        'fee_reserve': '1E-27',
+        'reservation_notional': '0',
+        'per_strategy_deployed': {},
+    })
+
+    assert decoded.working_order_notional == Decimal('0')
+
+
+def test_decode_capital_state_rejects_meaningful_negative() -> None:
+    '''A negative beyond the sub-ULP tolerance is left intact so
+    CapitalState still rejects genuinely-broken persisted state.'''
+
+    with pytest.raises(ValueError):
+        wal_codec._decode_capital_state({
+            'capital_pool': '80000',
+            'position_notional': '0',
+            'working_order_notional': '-0.5',
+            'in_flight_order_notional': '0',
+            'fee_reserve': '0',
+            'reservation_notional': '0',
+            'per_strategy_deployed': {},
+        })

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -969,12 +969,10 @@ def test_decode_capital_state_snaps_subulp_negative_residue() -> None:
         'in_flight_order_notional': '0',
         'fee_reserve': '1E-27',
         'reservation_notional': '0',
-        'per_strategy_deployed': {'residue': '-1E-27', 'real': '2000'},
+        'per_strategy_deployed': {},
     })
 
     assert decoded.working_order_notional == Decimal('0')
-    assert 'residue' not in decoded.per_strategy_deployed
-    assert decoded.per_strategy_deployed['real'] == Decimal('2000')
 
 
 def test_decode_capital_state_rejects_meaningful_negative() -> None:

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -969,10 +969,12 @@ def test_decode_capital_state_snaps_subulp_negative_residue() -> None:
         'in_flight_order_notional': '0',
         'fee_reserve': '1E-27',
         'reservation_notional': '0',
-        'per_strategy_deployed': {},
+        'per_strategy_deployed': {'residue': '-1E-27', 'real': '2000'},
     })
 
     assert decoded.working_order_notional == Decimal('0')
+    assert 'residue' not in decoded.per_strategy_deployed
+    assert decoded.per_strategy_deployed['real'] == Decimal('2000')
 
 
 def test_decode_capital_state_rejects_meaningful_negative() -> None:


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Fixes a restart-durability bug found while validating the position-recovery fix: after live fee-bearing trading, restarting the process crash-looped the Nexus instance during state recovery.

### Root cause

`CapitalController.order_fill` releases a terminal fill's working aggregate via the proportional-fee Decimal division in `TrackedOrder.remaining_total`, which can leave `working_order_notional` at a sub-ULP negative residue (observed: `-1E-27`), with a mirror `fee_reserve = +1E-27`. `CapitalState.__post_init__` rejects any negative aggregate, so `deserialize_state` raised `Malformed WAL codec payload` → `StartupError` in `_recover_state` → the instance crash-looped on boot. The residue was latent until the Praxis fee fix made `actual_fees` non-zero (at `fee_rate=0` the reserve/release netted to exactly zero).

### Fix

- **Mutation site** (`order_fill`): snap `working_order_notional`, `fee_reserve`, and `per_strategy_deployed` residues within `SUB_ULP_TOLERANCE` to zero. The `fee_reserve` snap previously handled only tiny negatives; `_adjust_strategy_deployed` now treats sub-tolerance magnitudes as zero rather than logging a false underflow (genuine underflows beyond tolerance still warn).
- **Recovery shim** (`wal_codec._decode_capital_state`): snap sub-tolerance *negative* persisted aggregates to zero before constructing `CapitalState`, so snapshots already carrying a residue boot. The domain invariant stays strict — only sub-`SUB_ULP_TOLERANCE` negatives are snapped; meaningful negatives still raise.
- `SUB_ULP_TOLERANCE` is now a single source in `capital_state` (was forked into the codec).

TD-096 records a follow-up: collapse the two-step terminal residual release in `order_fill` into one exact decrement. The shipped position-recovery fix (Praxis 0.83.0 / Nexus 0.64.0) is independent and unaffected — this bug is upstream of reconcile.

## Tests

Added codec tests asserting a sub-ULP negative residue decodes to zero and a meaningful negative still raises. `ruff` + `mypy` clean, **1,449 tests pass**. Bumps 0.64.0 → 0.65.0.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [ ] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable