### PR TITLE
feat: thread an injectable clock through CapitalController (v0.67.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -838,3 +838,10 @@
 
 - Make the outcome-dedup durable so a boot replay cannot double-apply an already-applied outcome (Nexus#86 / TD-086). `OutcomeProcessor` previously held the processed `outcome_id`s in a process-local set, lost on restart; combined with the mutation being persisted by the launcher's `append_mutation`, a replay of an un-acked-but-already-applied outcome (process killed between `append_mutation` and the Praxis `OutcomeAcked`) re-entered `_handle_fill` and mutated capital and position a second time. The dedup sets now live on [`InstanceState`](nexus/core/domain/instance_state.py) (`processed_outcome_ids`, `processed_dust_close_ids`), so the successful id is persisted atomically with the mutation it guards and restored by `StateStore.recover`; the replay is recognised and returns a no-op success. The same durability now also covers `close_as_dust`. Serialized via the existing `wal_codec` v1 payload with `.get` back-compat, so pre-upgrade snapshots load unchanged
 - Perform the durable dedup-set writes under `positions_lock` (the lock domain `serialize_state` reads under, matching the `account_dust` precedent) instead of only `_dedup_lock`, so a concurrent `SnapshotScheduler.checkpoint()` cannot serialize the set mid-write; the check+add stays atomic under the nested `_dedup_lock` (preserving the PR #83 concurrent-same-id guarantee). A narrow checkpoint-interleave window between the capital mutation and the dedup add remains, tracked in TD-086 (record-before-mutate)
+
+## v0.67.0 on 22nd of June, 2026
+
+### Add
+
+- Add an injectable `clock` to [`CapitalController`](nexus/core/capital_controller/capital_controller.py): reservation creation, the reservation-expiry check, and the expiry purge now read the current UTC time from a supplied source rather than the wall clock. It defaults to wall time so the live path is unchanged; a deterministic replay injects a cursor advanced per bar so reservations expire on simulated time
+- Add `TestInjectedClock` to [`tests/test_capital_controller.py`](tests/test_capital_controller.py): a reservation's `expires_at` is computed from the injected clock and `_purge_expired` honours it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -844,4 +844,4 @@
 ### Add
 
 - Add an injectable `clock` to [`CapitalController`](nexus/core/capital_controller/capital_controller.py): reservation creation, the reservation-expiry check, and the expiry purge now read the current UTC time from a supplied source rather than the wall clock. It defaults to wall time so the live path is unchanged; a deterministic replay injects a cursor advanced per bar so reservations expire on simulated time
-- Add `TestInjectedClock` to [`tests/test_capital_controller.py`](tests/test_capital_controller.py): a reservation's `expires_at` is computed from the injected clock and `_purge_expired` honours it
+- Add `TestInjectedClock` to [`tests/test_capital_controller.py`](tests/test_capital_controller.py): a reservation's `expires_at` is computed from the injected clock, and both `_purge_expired` and `send_order`'s expiry check honour it

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -10,7 +10,7 @@ import heapq
 import logging
 import threading
 import uuid
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
@@ -33,6 +33,12 @@ from nexus.core.domain.position import Position
 __all__ = ['CapitalController']
 
 _logger = logging.getLogger(__name__)
+
+
+def _utc_now() -> datetime:
+    '''Return the current UTC time.'''
+
+    return datetime.now(tz=timezone.utc)
 
 MAX_ALLOCATION_PER_TRADE_PCT = Decimal('0.15')
 MAX_CAPITAL_UTILIZATION_PCT = Decimal('0.80')
@@ -74,6 +80,7 @@ class CapitalController:
         capital_state: CapitalState,
         *,
         max_allocation_per_trade_pct: Decimal = MAX_ALLOCATION_PER_TRADE_PCT,
+        clock: Callable[[], datetime] = _utc_now,
     ) -> None:
         if not isinstance(max_allocation_per_trade_pct, Decimal):
             msg = (
@@ -95,6 +102,7 @@ class CapitalController:
             raise ValueError(msg)
         self._state = capital_state
         self._max_allocation_per_trade_pct = max_allocation_per_trade_pct
+        self._clock = clock
         self._lock = threading.Lock()
         self._reservations: dict[str, Reservation] = {}
         self._expiry_heap: list[tuple[datetime, str]] = []
@@ -395,7 +403,7 @@ class CapitalController:
                     ),
                 )
 
-            now = datetime.now(tz=timezone.utc)
+            now = self._clock()
             reservation = Reservation(
                 reservation_id=str(uuid.uuid4()),
                 strategy_id=strategy_id,
@@ -466,7 +474,7 @@ class CapitalController:
 
     def _purge_expired(self, now: datetime | None = None) -> None:
         if now is None:
-            now = datetime.now(tz=timezone.utc)
+            now = self._clock()
 
         while self._expiry_heap and self._expiry_heap[0][0] <= now:
             _, rid = heapq.heappop(self._expiry_heap)
@@ -535,7 +543,7 @@ class CapitalController:
             raise ValueError(msg)
 
         with self._lock:
-            now = datetime.now(tz=timezone.utc)
+            now = self._clock()
 
             if order_id in self._orders:
                 msg = f'order_id already tracked: {order_id}'

--- a/nexus/core/capital_controller/capital_controller.py
+++ b/nexus/core/capital_controller/capital_controller.py
@@ -73,6 +73,7 @@ class CapitalController:
     Args:
         capital_state: Mutable capital state to guard.
         max_allocation_per_trade_pct: Cap on `order_notional / capital_pool`. Defaults to `MAX_ALLOCATION_PER_TRADE_PCT`.
+        clock: Callable returning the current UTC time (timezone-aware), used for reservation expiry timestamps and the `send_order` / purge expiry checks. Defaults to wall time; a deterministic replay injects a cursor so reservations expire on simulated time.
     '''
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.66.0"
+version = "0.67.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -2251,3 +2251,40 @@ class TestFeeReserveSubUlpClampToZero:
             f'sub-ULP negative drift not clamped: '
             f'fee_reserve={ctrl._state.fee_reserve}'
         )
+
+
+class TestInjectedClock:
+    def test_reservation_expiry_uses_injected_clock(self) -> None:
+        fixed = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        cs = CapitalState(capital_pool=_POOL)
+        ctrl = CapitalController(cs, clock=lambda: fixed)
+
+        result = ctrl.check_and_reserve(
+            strategy_id='strat_a',
+            order_notional=Decimal('100'),
+            estimated_fees=Decimal('1'),
+            strategy_budget=Decimal('5000'),
+            ttl_seconds=60,
+        )
+
+        assert result.reservation is not None
+        assert result.reservation.expires_at == fixed + timedelta(seconds=60)
+
+    def test_purge_expired_uses_injected_clock(self) -> None:
+        moment = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        cs = CapitalState(capital_pool=_POOL)
+        ctrl = CapitalController(cs, clock=lambda: moment)
+
+        result = ctrl.check_and_reserve(
+            strategy_id='strat_a',
+            order_notional=Decimal('100'),
+            estimated_fees=Decimal('1'),
+            strategy_budget=Decimal('5000'),
+            ttl_seconds=60,
+        )
+        assert result.reservation is not None
+
+        moment = moment + timedelta(seconds=61)
+        ctrl._purge_expired()
+
+        assert ctrl._state.reservation_notional == _ZERO

--- a/tests/test_capital_controller.py
+++ b/tests/test_capital_controller.py
@@ -2288,3 +2288,23 @@ class TestInjectedClock:
         ctrl._purge_expired()
 
         assert ctrl._state.reservation_notional == _ZERO
+
+    def test_send_order_expiry_uses_injected_clock(self) -> None:
+        moment = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        cs = CapitalState(capital_pool=_POOL)
+        ctrl = CapitalController(cs, clock=lambda: moment)
+
+        result = ctrl.check_and_reserve(
+            strategy_id='strat_a',
+            order_notional=Decimal('100'),
+            estimated_fees=Decimal('1'),
+            strategy_budget=Decimal('5000'),
+            ttl_seconds=60,
+        )
+        assert result.reservation is not None
+
+        moment = moment + timedelta(seconds=61)
+        send = ctrl.send_order(result.reservation.reservation_id, 'ORD-1')
+
+        assert send.success is False
+        assert 'expired' in send.reason


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Adds an injectable `clock` to `CapitalController` so its time reads come from a supplied UTC source rather than the wall clock. This is the Nexus half of the Praxis replay engine (Vaquum/Praxis#122): a deterministic replay drives every component on one simulated cursor, so capital reservations must expire on simulated time, not wall time.

### Change

- `CapitalController.__init__` takes a keyword-only `clock: Callable[[], datetime]` defaulting to wall time, so the live path is unchanged.
- The three time reads — reservation creation (`check_and_reserve`), the expiry purge (`_purge_expired`), and `send_order` — now read `self._clock()`.

Without this, reservations created and checked within one real second would never appear expired even after simulated time advances past their TTL, so a replay's capital decisions would diverge from live.

## Tests

Two new tests (`TestInjectedClock` in `test_capital_controller.py`): a reservation's `expires_at` is computed from the injected clock, and `_purge_expired` honours it. `ruff` + `mypy` clean, the capital-controller suite passes. Bumps 0.66.0 → 0.67.0.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable
