### PR TITLE
feat: operational mode controller with halt holds and risk breakers (v0.68.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -850,9 +850,9 @@
 
 ### Add
 
-- Add `ModeController` arbitrating operational mode against sticky manual and risk halt holds, as the sole writer of `state.mode`
+- Add `ModeController` arbitrating operational mode against sticky manual and risk halt holds; it writes `state.mode` on the health-and-hold-arbitrated path. It is not yet the process-wide sole writer — `StartupSequencer` and `ShutdownSequencer` still set `state.mode` directly, and wiring the controller into the launcher (construction, `reconcile` before startup drain, `on_halt`, routing shutdown/manual through holds) is tracked as follow-on live-safety work; this release is the library only
 - Add `HaltHold` / `OperationalHolds` on `InstanceState.mode_holds`, persisted through the WAL codec with backward-compatible decode
-- Add `RiskBreakerThresholds` and `ModeController.evaluate_risk` for daily-loss and drawdown circuit-breakers evaluated on the health tick
+- Add `RiskBreakerThresholds` and `ModeController.evaluate_risk` for daily-loss and drawdown circuit-breakers evaluated on the health tick. Breakers trip on a strict breach (`observed > limit`, matching `risk_stage`), read `RiskState` under `state.risk.lock_cm()` so the per-strategy sum and drawdown reads are consistent against concurrent `OutcomeProcessor` / `MtmLoop` writers, and reject non-positive thresholds (`None` disables a breaker)
 - Add `ModeController.reconcile` to re-derive the mode on restart before startup actions drain
 - Add an optional `on_halt` callback fired outside the lock when the mode transitions to HALTED
 - Route `HealthLoop` mode writes through an optional `ModeController`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -845,3 +845,15 @@
 
 - Add an injectable `clock` to [`CapitalController`](nexus/core/capital_controller/capital_controller.py): reservation creation, the reservation-expiry check, and the expiry purge now read the current UTC time from a supplied source rather than the wall clock. It defaults to wall time so the live path is unchanged; a deterministic replay injects a cursor advanced per bar so reservations expire on simulated time
 - Add `TestInjectedClock` to [`tests/test_capital_controller.py`](tests/test_capital_controller.py): a reservation's `expires_at` is computed from the injected clock, and both `_purge_expired` and `send_order`'s expiry check honour it
+
+## v0.68.0 on 9th of July, 2026
+
+### Add
+
+- Add `ModeController` arbitrating operational mode against sticky manual and risk halt holds, as the sole writer of `state.mode`
+- Add `HaltHold` / `OperationalHolds` on `InstanceState.mode_holds`, persisted through the WAL codec with backward-compatible decode
+- Add `RiskBreakerThresholds` and `ModeController.evaluate_risk` for daily-loss and drawdown circuit-breakers evaluated on the health tick
+- Add `ModeController.reconcile` to re-derive the mode on restart before startup actions drain
+- Add an optional `on_halt` callback fired outside the lock when the mode transitions to HALTED
+- Route `HealthLoop` mode writes through an optional `ModeController`
+- Parse per-account `risk_controls` from the manifest into `RiskBreakerThresholds`

--- a/nexus/core/domain/instance_state.py
+++ b/nexus/core/domain/instance_state.py
@@ -12,7 +12,11 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 
 from nexus.core.domain.capital_state import CapitalState
-from nexus.core.domain.operational_mode import ModeState, StrategyModeState
+from nexus.core.domain.operational_mode import (
+    ModeState,
+    OperationalHolds,
+    StrategyModeState,
+)
 from nexus.core.domain.position import Position
 from nexus.core.domain.risk_state import RiskState
 
@@ -28,6 +32,10 @@ class InstanceState:
         risk: Instance-level and per-strategy risk metrics.
         positions: Open positions keyed by trade_id.
         mode: Instance-level operational mode.
+        mode_holds: Non-health reasons (operator halt, risk breakers) that
+            hold the instance in HALTED independently of the health-derived
+            mode. Written only by `ModeController`; persisted so a halt and
+            its cause survive restarts.
         strategy_modes: Per-strategy operational modes keyed by strategy_id.
         account_dust: Per-symbol base-asset residue from sub-lot
             position closes, keyed by symbol. Populated by
@@ -57,6 +65,7 @@ class InstanceState:
     risk: RiskState = field(default_factory=RiskState)
     positions: dict[str, Position] = field(default_factory=dict)
     mode: ModeState = field(default_factory=ModeState)
+    mode_holds: OperationalHolds = field(default_factory=OperationalHolds)
     strategy_modes: dict[str, StrategyModeState] = field(default_factory=dict)
     account_dust: dict[str, Decimal] = field(default_factory=dict)
     processed_outcome_ids: set[str] = field(default_factory=set)

--- a/nexus/core/domain/operational_mode.py
+++ b/nexus/core/domain/operational_mode.py
@@ -1,7 +1,8 @@
 '''Operational mode state for instance and per-strategy tracking.
 
-Mutable dataclasses holding current mode and what triggered
-the most recent transition.
+Mutable dataclasses holding the current mode and the driver behind it.
+`trigger` names the current driver and updates whenever the driver
+changes; `transitioned_at` moves only when the mode value changes.
 '''
 
 from __future__ import annotations
@@ -80,8 +81,12 @@ class ModeState:
 
     Args:
         mode: Current operational mode.
-        trigger: What caused the most recent mode transition.
-        transitioned_at: When the most recent transition occurred.
+        trigger: What currently drives the mode ('manual', 'risk',
+            'health', ...). Updated whenever the driver changes, even if
+            the mode value does not — a HALTED instance moving from a
+            manual to a risk hold keeps mode HALTED but changes trigger.
+        transitioned_at: When the mode value last changed. Not updated
+            when only the trigger changes.
     '''
 
     mode: OperationalMode = OperationalMode.ACTIVE

--- a/nexus/core/domain/operational_mode.py
+++ b/nexus/core/domain/operational_mode.py
@@ -21,7 +21,10 @@ class HaltHold:
     Args:
         active: Whether this reason currently holds the instance halted.
         reason: Short description of why the hold was placed.
-        since: When the hold was placed, or `None` when inactive.
+        since: When the hold was placed, or `None` when no timestamp was
+            recorded. The ModeController sets it on every hold it places;
+            it is not required to be set when `active` is True (a hold
+            decoded or constructed without a timestamp keeps `None`).
     '''
 
     active: bool = False

--- a/nexus/core/domain/operational_mode.py
+++ b/nexus/core/domain/operational_mode.py
@@ -11,7 +11,64 @@ from datetime import datetime
 
 from nexus.core.domain.enums import OperationalMode
 
-__all__ = ['ModeState', 'StrategyModeState']
+__all__ = ['HaltHold', 'ModeState', 'OperationalHolds', 'StrategyModeState']
+
+
+@dataclass
+class HaltHold:
+    '''A single reason an instance is held in HALTED, sticky until cleared.
+
+    Args:
+        active: Whether this reason currently holds the instance halted.
+        reason: Short description of why the hold was placed.
+        since: When the hold was placed, or `None` when inactive.
+    '''
+
+    active: bool = False
+    reason: str = ''
+    since: datetime | None = None
+
+    def __post_init__(self) -> None:
+        '''Validate invariants at construction time.'''
+
+        if not isinstance(self.active, bool):
+            msg = 'HaltHold.active must be a bool'
+            raise ValueError(msg)
+
+        if not isinstance(self.reason, str):
+            msg = 'HaltHold.reason must be a string'
+            raise ValueError(msg)
+
+        if self.since is not None and not isinstance(self.since, datetime):
+            msg = 'HaltHold.since must be a datetime or None'
+            raise ValueError(msg)
+
+
+@dataclass
+class OperationalHolds:
+    '''The non-health reasons that hold an instance in HALTED.
+
+    Each hold is independent: a health-derived recovery cannot lift a
+    hold, and clearing one hold does not clear the others.
+
+    Args:
+        manual_hold: Hold placed by a manual halt.
+        risk_daily_loss: Hold placed when the daily-loss breaker trips.
+        risk_drawdown: Hold placed when the drawdown breaker trips.
+    '''
+
+    manual_hold: HaltHold = field(default_factory=HaltHold)
+    risk_daily_loss: HaltHold = field(default_factory=HaltHold)
+    risk_drawdown: HaltHold = field(default_factory=HaltHold)
+
+    def any_active(self) -> bool:
+        '''Return whether any hold currently forces HALTED.'''
+
+        return (
+            self.manual_hold.active
+            or self.risk_daily_loss.active
+            or self.risk_drawdown.active
+        )
 
 
 @dataclass

--- a/nexus/core/domain/risk_breaker_thresholds.py
+++ b/nexus/core/domain/risk_breaker_thresholds.py
@@ -1,0 +1,40 @@
+'''Configured limits that trip the risk breakers.'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+__all__ = ['RiskBreakerThresholds']
+
+_ZERO = Decimal('0')
+
+
+@dataclass
+class RiskBreakerThresholds:
+    '''Configured limits that trip the risk breakers; `None` disables one.
+
+    Args:
+        max_daily_loss: Account 24h loss that trips the daily-loss breaker.
+        max_drawdown_pct: Peak total-drawdown fraction that trips the
+            drawdown breaker.
+        max_drawdown: Peak total-drawdown amount that trips the drawdown
+            breaker.
+    '''
+
+    max_daily_loss: Decimal | None = None
+    max_drawdown_pct: Decimal | None = None
+    max_drawdown: Decimal | None = None
+
+    def __post_init__(self) -> None:
+        '''Validate that configured thresholds are finite and non-negative.'''
+
+        for field_name in ('max_daily_loss', 'max_drawdown_pct', 'max_drawdown'):
+            value = getattr(self, field_name)
+
+            if value is None:
+                continue
+
+            if not isinstance(value, Decimal) or not value.is_finite() or value < _ZERO:
+                msg = f'RiskBreakerThresholds.{field_name} must be a finite non-negative Decimal or None'
+                raise ValueError(msg)

--- a/nexus/core/domain/risk_breaker_thresholds.py
+++ b/nexus/core/domain/risk_breaker_thresholds.py
@@ -36,5 +36,5 @@ class RiskBreakerThresholds:
                 continue
 
             if not isinstance(value, Decimal) or not value.is_finite() or value < _ZERO:
-                msg = f'RiskBreakerThresholds.{field_name} must be a finite non-negative Decimal or None'
+                msg = f"RiskBreakerThresholds.{field_name} must be a finite non-negative Decimal or None"
                 raise ValueError(msg)

--- a/nexus/core/domain/risk_breaker_thresholds.py
+++ b/nexus/core/domain/risk_breaker_thresholds.py
@@ -10,7 +10,7 @@ __all__ = ['RiskBreakerThresholds']
 _ZERO = Decimal('0')
 
 
-@dataclass
+@dataclass(frozen=True)
 class RiskBreakerThresholds:
     '''Configured limits that trip the risk breakers; `None` disables one.
 

--- a/nexus/core/domain/risk_breaker_thresholds.py
+++ b/nexus/core/domain/risk_breaker_thresholds.py
@@ -27,7 +27,7 @@ class RiskBreakerThresholds:
     max_drawdown: Decimal | None = None
 
     def __post_init__(self) -> None:
-        '''Validate that configured thresholds are finite and non-negative.'''
+        '''Validate that configured thresholds are finite and positive.'''
 
         for field_name in ('max_daily_loss', 'max_drawdown_pct', 'max_drawdown'):
             value = getattr(self, field_name)
@@ -35,6 +35,6 @@ class RiskBreakerThresholds:
             if value is None:
                 continue
 
-            if not isinstance(value, Decimal) or not value.is_finite() or value < _ZERO:
-                msg = f"RiskBreakerThresholds.{field_name} must be a finite non-negative Decimal or None"
+            if not isinstance(value, Decimal) or not value.is_finite() or value <= _ZERO:
+                msg = f"RiskBreakerThresholds.{field_name} must be a finite positive Decimal or None"
                 raise ValueError(msg)

--- a/nexus/core/health_loop.py
+++ b/nexus/core/health_loop.py
@@ -149,6 +149,9 @@ class HealthLoop:
             except Exception:  # noqa: BLE001 - decay refresh failure must not abort tick
                 _log.exception('rolling-loss refresh failed')
 
+        if self._mode_controller is not None:
+            self._mode_controller.evaluate_risk()
+
         try:
             snapshot = self._snapshot_provider()
         except Exception:  # noqa: BLE001 - intentional catch-all for provider

--- a/nexus/core/health_loop.py
+++ b/nexus/core/health_loop.py
@@ -173,8 +173,7 @@ class HealthLoop:
             previous_mode = self._state.mode.mode
 
             if self._mode_controller is not None:
-                self._mode_controller.evaluate_risk(notify=False)
-                self._mode_controller.apply_health_mode(new_mode, notify=False)
+                self._mode_controller.apply_health_and_risk(new_mode, notify=False)
 
             else:
                 self._write_health_mode(new_mode)

--- a/nexus/core/health_loop.py
+++ b/nexus/core/health_loop.py
@@ -16,9 +16,11 @@ import threading
 from collections.abc import Callable
 from datetime import datetime, timezone
 
+from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.domain.operational_mode import ModeState
 from nexus.core.health_evaluator import HealthEvaluator, HealthSnapshot
+from nexus.core.mode_controller import ModeController
 
 __all__ = ['HealthLoop']
 
@@ -50,6 +52,7 @@ class HealthLoop:
         state: InstanceState,
         interval_seconds: float = 5.0,
         rolling_loss_refresher: Callable[[InstanceState], None] | None = None,
+        mode_controller: ModeController | None = None,
     ) -> None:
         if (
             isinstance(interval_seconds, bool)
@@ -67,6 +70,7 @@ class HealthLoop:
         self._running = False
         self._lock = threading.Lock()
         self._rolling_loss_refresher = rolling_loss_refresher
+        self._mode_controller = mode_controller
 
     @property
     def running(self) -> bool:
@@ -161,17 +165,32 @@ class HealthLoop:
             if respect_running and not self._running:
                 return
 
-            current_mode = self._state.mode.mode
-            if new_mode == current_mode:
-                return
+            previous_mode = self._state.mode.mode
 
-            self._state.mode = ModeState(
-                mode=new_mode,
-                trigger=_HEALTH_TRIGGER,
-                transitioned_at=datetime.now(tz=timezone.utc),
-            )
+            if self._mode_controller is not None:
+                changed = self._mode_controller.apply_health_mode(new_mode)
+
+            else:
+                changed = self._write_health_mode(new_mode)
+
+            resulting_mode = self._state.mode.mode
+
+        if not changed:
+            return
 
         _log.info(
             'operational mode transition (health)',
-            extra={'from': current_mode.value, 'to': new_mode.value},
+            extra={'from': previous_mode.value, 'to': resulting_mode.value},
         )
+
+    def _write_health_mode(self, new_mode: OperationalMode) -> bool:
+        if new_mode == self._state.mode.mode:
+            return False
+
+        self._state.mode = ModeState(
+            mode=new_mode,
+            trigger=_HEALTH_TRIGGER,
+            transitioned_at=datetime.now(tz=timezone.utc),
+        )
+
+        return True

--- a/nexus/core/health_loop.py
+++ b/nexus/core/health_loop.py
@@ -149,9 +149,6 @@ class HealthLoop:
             except Exception:  # noqa: BLE001 - decay refresh failure must not abort tick
                 _log.exception('rolling-loss refresh failed')
 
-        if self._mode_controller is not None:
-            self._mode_controller.evaluate_risk()
-
         try:
             snapshot = self._snapshot_provider()
         except Exception:  # noqa: BLE001 - intentional catch-all for provider
@@ -171,19 +168,28 @@ class HealthLoop:
             previous_mode = self._state.mode.mode
 
             if self._mode_controller is not None:
-                changed = self._mode_controller.apply_health_mode(new_mode)
+                self._mode_controller.evaluate_risk(notify=False)
+                self._mode_controller.apply_health_mode(new_mode, notify=False)
 
             else:
-                changed = self._write_health_mode(new_mode)
+                self._write_health_mode(new_mode)
 
             resulting_mode = self._state.mode.mode
+            resulting_trigger = self._state.mode.trigger
 
-        if not changed:
+        if self._mode_controller is not None:
+            self._mode_controller.notify_pending_halt()
+
+        if resulting_mode == previous_mode:
             return
 
         _log.info(
-            'operational mode transition (health)',
-            extra={'from': previous_mode.value, 'to': resulting_mode.value},
+            'operational mode transition',
+            extra={
+                'from': previous_mode.value,
+                'to': resulting_mode.value,
+                'trigger': resulting_trigger,
+            },
         )
 
     def _write_health_mode(self, new_mode: OperationalMode) -> bool:

--- a/nexus/core/health_loop.py
+++ b/nexus/core/health_loop.py
@@ -171,6 +171,7 @@ class HealthLoop:
                 return
 
             previous_mode = self._state.mode.mode
+            previous_trigger = self._state.mode.trigger
 
             if self._mode_controller is not None:
                 self._mode_controller.apply_health_and_risk(new_mode, notify=False)
@@ -184,7 +185,7 @@ class HealthLoop:
         if self._mode_controller is not None:
             self._mode_controller.notify_pending_halt()
 
-        if resulting_mode == previous_mode:
+        if resulting_mode == previous_mode and resulting_trigger == previous_trigger:
             return
 
         _log.info(

--- a/nexus/core/health_loop.py
+++ b/nexus/core/health_loop.py
@@ -43,6 +43,11 @@ class HealthLoop:
             Best-effort: any exception is logged at WARN and the rest of
             the tick proceeds — a single bad refresh never aborts the
             health-evaluation loop. None disables the refresh side-effect.
+        mode_controller: Optional ModeController. When supplied, each tick
+            routes the mode write through it (risk breakers then health
+            mode) so a halt hold is honoured; the halt callback drains
+            after this loop's lock is released. Its lock must not be this
+            loop's lock. None uses the direct health-only mode write.
     '''
 
     def __init__(

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -82,7 +82,8 @@ class ModeController:
                 `notify_pending_halt` once that lock is released.
 
         Returns:
-            Whether the mode changed.
+            Whether the mode value changed; a trigger-only recompute
+            returns False.
         '''
 
         with self._lock:
@@ -111,7 +112,8 @@ class ModeController:
                 `notify_pending_halt`.
 
         Returns:
-            Whether the mode changed.
+            Whether the mode value changed; a trigger-only recompute
+            returns False.
         '''
 
         with self._lock, self._state.risk.lock_cm():
@@ -128,32 +130,62 @@ class ModeController:
         return changed
 
     def set_manual_halt(self, reason: str) -> bool:
-        '''Place the manual hold and recommit the mode.'''
+        '''Place the manual hold and recommit the mode.
+
+        Returns:
+            Whether the mode value changed; a trigger-only recompute
+            returns False.
+        '''
 
         return self._set_hold('manual_hold', reason)
 
     def clear_manual_halt(self) -> bool:
-        '''Lift the manual hold and recommit; never writes ACTIVE directly.'''
+        '''Lift the manual hold and recommit; never writes ACTIVE directly.
+
+        Returns:
+            Whether the mode value changed; a trigger-only recompute
+            returns False.
+        '''
 
         return self._clear_hold('manual_hold')
 
     def set_daily_loss_halt(self, reason: str) -> bool:
-        '''Place the daily-loss hold and recommit the mode.'''
+        '''Place the daily-loss hold and recommit the mode.
+
+        Returns:
+            Whether the mode value changed; a trigger-only recompute
+            returns False.
+        '''
 
         return self._set_hold('risk_daily_loss', reason)
 
     def clear_daily_loss_halt(self) -> bool:
-        '''Lift the daily-loss hold and recommit the mode.'''
+        '''Lift the daily-loss hold and recommit the mode.
+
+        Returns:
+            Whether the mode value changed; a trigger-only recompute
+            returns False.
+        '''
 
         return self._clear_hold('risk_daily_loss')
 
     def set_drawdown_halt(self, reason: str) -> bool:
-        '''Place the drawdown hold and recommit the mode.'''
+        '''Place the drawdown hold and recommit the mode.
+
+        Returns:
+            Whether the mode value changed; a trigger-only recompute
+            returns False.
+        '''
 
         return self._set_hold('risk_drawdown', reason)
 
     def clear_drawdown_halt(self) -> bool:
-        '''Lift the drawdown hold and recommit the mode.'''
+        '''Lift the drawdown hold and recommit the mode.
+
+        Returns:
+            Whether the mode value changed; a trigger-only recompute
+            returns False.
+        '''
 
         return self._clear_hold('risk_drawdown')
 

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -21,6 +21,7 @@ from nexus.core.domain.risk_breaker_thresholds import RiskBreakerThresholds
 __all__ = ['ModeController']
 
 _HALTED = OperationalMode.HALTED
+_HEALTH_TRIGGER = 'health'
 _ZERO = Decimal('0')
 
 
@@ -110,6 +111,24 @@ class ModeController:
         with self._lock:
             self._evaluate_daily_loss_locked()
             self._evaluate_drawdown_locked()
+
+    def reconcile(self) -> None:
+        '''Re-derive the mode after a restart, before trading resumes.
+
+        Seeds the health mode from a recovered health-driven mode so a
+        health halt is not lifted, re-trips the risk breakers from the
+        recovered RiskState, and recommits — so a halt that outlived a
+        crash is in force before any startup actions drain.
+        '''
+
+        with self._lock:
+
+            if self._state.mode.trigger == _HEALTH_TRIGGER:
+                self._health_mode = self._state.mode.mode
+
+            self._evaluate_daily_loss_locked()
+            self._evaluate_drawdown_locked()
+            self._recommit()
 
     def _evaluate_daily_loss_locked(self) -> None:
         limit = self._risk_thresholds.max_daily_loss

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -94,6 +94,39 @@ class ModeController:
 
         return changed
 
+    def apply_health_and_risk(self, health_mode: OperationalMode, notify: bool = True) -> bool:
+        '''Set the health mode and evaluate the risk breakers in one commit.
+
+        The health tick uses this so the risk-breaker re-evaluation and the
+        health-mode write land under a single hold of the lock. Splitting
+        them into `evaluate_risk` then `apply_health_mode` releases the lock
+        between the two, leaving a window where a reader taking this lock
+        (but not the caller's) sees an intermediate mode the same tick then
+        overwrites.
+
+        Args:
+            health_mode: Mode the health evaluator derived this tick.
+            notify: Whether to fire a pending on-halt callback here. A caller
+                holding its own lock passes False and drains later via
+                `notify_pending_halt`.
+
+        Returns:
+            Whether the mode changed.
+        '''
+
+        with self._lock, self._state.risk.lock_cm():
+            previous = self._state.mode.mode
+            self._health_mode = health_mode
+            self._evaluate_daily_loss_locked()
+            self._evaluate_drawdown_locked()
+            self._recommit()
+            changed = self._state.mode.mode is not previous
+
+        if notify:
+            self.notify_pending_halt()
+
+        return changed
+
     def set_manual_halt(self, reason: str) -> bool:
         '''Place the manual hold and recommit the mode.'''
 

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -10,15 +10,48 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from decimal import Decimal
 
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.domain.operational_mode import ModeState
 
-__all__ = ['ModeController']
+__all__ = ['ModeController', 'RiskBreakerThresholds']
 
 _HALTED = OperationalMode.HALTED
+_ZERO = Decimal('0')
+
+
+@dataclass
+class RiskBreakerThresholds:
+    '''Configured limits that trip the risk breakers; `None` disables one.
+
+    Args:
+        max_daily_loss: Account 24h loss that trips the daily-loss breaker.
+        max_drawdown_pct: Peak total-drawdown fraction that trips the
+            drawdown breaker.
+        max_drawdown: Peak total-drawdown amount that trips the drawdown
+            breaker.
+    '''
+
+    max_daily_loss: Decimal | None = None
+    max_drawdown_pct: Decimal | None = None
+    max_drawdown: Decimal | None = None
+
+    def __post_init__(self) -> None:
+        '''Validate that configured thresholds are finite and non-negative.'''
+
+        for field_name in ('max_daily_loss', 'max_drawdown_pct', 'max_drawdown'):
+            value = getattr(self, field_name)
+
+            if value is None:
+                continue
+
+            if not isinstance(value, Decimal) or not value.is_finite() or value < _ZERO:
+                msg = f'RiskBreakerThresholds.{field_name} must be a finite non-negative Decimal or None'
+                raise ValueError(msg)
 
 
 def _utc_now() -> datetime:
@@ -34,6 +67,7 @@ class ModeController:
         state: Instance state whose mode and holds this controller owns.
         lock: Lock serialising mode and hold writes with state snapshots.
         clock: Source of UTC time for transition and hold timestamps.
+        risk_thresholds: Limits the risk breakers evaluate each tick.
     '''
 
     def __init__(
@@ -41,11 +75,13 @@ class ModeController:
         state: InstanceState,
         lock: threading.Lock,
         clock: Callable[[], datetime] = _utc_now,
+        risk_thresholds: RiskBreakerThresholds | None = None,
     ) -> None:
         self._state = state
         self._lock = lock
         self._clock = clock
         self._health_mode = OperationalMode.ACTIVE
+        self._risk_thresholds = risk_thresholds or RiskBreakerThresholds()
 
     def apply_health_mode(self, health_mode: OperationalMode) -> bool:
         '''Record the latest health-derived mode and recommit the mode.
@@ -92,31 +128,83 @@ class ModeController:
 
         return self._clear_hold('risk_drawdown')
 
+    def evaluate_risk(self) -> None:
+        '''Trip or lift the risk breakers from the current RiskState.
+
+        The daily-loss breaker sums the per-strategy 24h losses and
+        auto-lifts when they decay back under the limit. The drawdown
+        breaker trips on the lifetime-peak total drawdown and does not
+        auto-lift, so a recovered mark cannot silently resume trading.
+        '''
+
+        with self._lock:
+            self._evaluate_daily_loss_locked()
+            self._evaluate_drawdown_locked()
+
+    def _evaluate_daily_loss_locked(self) -> None:
+        limit = self._risk_thresholds.max_daily_loss
+
+        if limit is None:
+            return
+
+        daily_loss = sum(
+            (srs.rolling_loss_24h for srs in self._state.risk.per_strategy.values()),
+            _ZERO,
+        )
+
+        if daily_loss >= limit:
+            self._set_hold_locked('risk_daily_loss', f'24h loss {daily_loss} >= limit {limit}')
+
+        else:
+            self._clear_hold_locked('risk_daily_loss')
+
+    def _evaluate_drawdown_locked(self) -> None:
+        risk = self._state.risk
+        limit_pct = self._risk_thresholds.max_drawdown_pct
+
+        if limit_pct is not None and risk.max_total_drawdown_pct >= limit_pct:
+            self._set_hold_locked(
+                'risk_drawdown', f'drawdown {risk.max_total_drawdown_pct} >= limit {limit_pct}',
+            )
+
+        limit_abs = self._risk_thresholds.max_drawdown
+
+        if limit_abs is not None and risk.max_total_drawdown >= limit_abs:
+            self._set_hold_locked(
+                'risk_drawdown', f'drawdown {risk.max_total_drawdown} >= limit {limit_abs}',
+            )
+
     def _set_hold(self, name: str, reason: str) -> bool:
         with self._lock:
-            hold = getattr(self._state.mode_holds, name)
-
-            if hold.active:
-                return False
-
-            hold.active = True
-            hold.reason = reason
-            hold.since = self._clock()
-
-            return self._recommit()
+            return self._set_hold_locked(name, reason)
 
     def _clear_hold(self, name: str) -> bool:
         with self._lock:
-            hold = getattr(self._state.mode_holds, name)
+            return self._clear_hold_locked(name)
 
-            if not hold.active:
-                return False
+    def _set_hold_locked(self, name: str, reason: str) -> bool:
+        hold = getattr(self._state.mode_holds, name)
 
-            hold.active = False
-            hold.reason = ''
-            hold.since = None
+        if hold.active:
+            return False
 
-            return self._recommit()
+        hold.active = True
+        hold.reason = reason
+        hold.since = self._clock()
+
+        return self._recommit()
+
+    def _clear_hold_locked(self, name: str) -> bool:
+        hold = getattr(self._state.mode_holds, name)
+
+        if not hold.active:
+            return False
+
+        hold.active = False
+        hold.reason = ''
+        hold.since = None
+
+        return self._recommit()
 
     def _recommit(self) -> bool:
         holds = self._state.mode_holds

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -60,6 +60,7 @@ class ModeController:
         self._health_mode = OperationalMode.ACTIVE
         self._risk_thresholds = risk_thresholds or RiskBreakerThresholds()
         self._on_halt = on_halt
+        self._pending_halt: str | None = None
 
     def apply_health_mode(self, health_mode: OperationalMode) -> bool:
         '''Record the latest health-derived mode and recommit the mode.
@@ -73,8 +74,11 @@ class ModeController:
 
         with self._lock:
             self._health_mode = health_mode
+            changed = self._recommit()
 
-            return self._recommit()
+        self._notify_halt()
+
+        return changed
 
     def set_manual_halt(self, reason: str) -> bool:
         '''Place the manual hold and recommit the mode.'''
@@ -119,6 +123,8 @@ class ModeController:
             self._evaluate_daily_loss_locked()
             self._evaluate_drawdown_locked()
 
+        self._notify_halt()
+
     def reconcile(self) -> None:
         '''Re-derive the mode after a restart, before trading resumes.
 
@@ -136,6 +142,23 @@ class ModeController:
             self._evaluate_daily_loss_locked()
             self._evaluate_drawdown_locked()
             self._recommit()
+
+        self._notify_halt()
+
+    def _notify_halt(self) -> None:
+        '''Fire the on-halt callback outside the lock for a pending halt.'''
+
+        with self._lock:
+            source = self._pending_halt
+            self._pending_halt = None
+
+        if source is None or self._on_halt is None:
+            return
+
+        try:
+            self._on_halt(source)
+        except Exception:  # noqa: BLE001 - alerting must not break mode control
+            _log.exception('mode-halt alert callback failed')
 
     def _evaluate_daily_loss_locked(self) -> None:
         limit = self._risk_thresholds.max_daily_loss
@@ -172,11 +195,19 @@ class ModeController:
 
     def _set_hold(self, name: str, reason: str) -> bool:
         with self._lock:
-            return self._set_hold_locked(name, reason)
+            changed = self._set_hold_locked(name, reason)
+
+        self._notify_halt()
+
+        return changed
 
     def _clear_hold(self, name: str) -> bool:
         with self._lock:
-            return self._clear_hold_locked(name)
+            changed = self._clear_hold_locked(name)
+
+        self._notify_halt()
+
+        return changed
 
     def _set_hold_locked(self, name: str, reason: str) -> bool:
         hold = getattr(self._state.mode_holds, name)
@@ -222,12 +253,8 @@ class ModeController:
             transitioned_at=transitioned_at,
         )
 
-        if mode_changed and new_mode is _HALTED and self._on_halt is not None:
-
-            try:
-                self._on_halt(source)
-            except Exception:  # noqa: BLE001 - alerting must not break mode control
-                _log.exception('mode-halt alert callback failed')
+        if mode_changed and new_mode is _HALTED:
+            self._pending_halt = source
 
         return mode_changed
 

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -1,0 +1,156 @@
+'''Single writer of instance operational mode.
+
+Arbitrates the health-derived mode against the sticky manual and risk
+holds so a healthy tick can never lift a hold. The mode is
+HALTED whenever any hold is active or health itself is HALTED, and the
+health-derived mode otherwise.
+'''
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from datetime import datetime, timezone
+
+from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.operational_mode import ModeState
+
+__all__ = ['ModeController']
+
+_HALTED = OperationalMode.HALTED
+
+
+def _utc_now() -> datetime:
+    '''Return the current UTC time.'''
+
+    return datetime.now(tz=timezone.utc)
+
+
+class ModeController:
+    '''The only sanctioned writer of `state.mode` and `state.mode_holds`.
+
+    Args:
+        state: Instance state whose mode and holds this controller owns.
+        lock: Lock serialising mode and hold writes with state snapshots.
+        clock: Source of UTC time for transition and hold timestamps.
+    '''
+
+    def __init__(
+        self,
+        state: InstanceState,
+        lock: threading.Lock,
+        clock: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self._state = state
+        self._lock = lock
+        self._clock = clock
+        self._health_mode = OperationalMode.ACTIVE
+
+    def apply_health_mode(self, health_mode: OperationalMode) -> bool:
+        '''Record the latest health-derived mode and recommit the mode.
+
+        Args:
+            health_mode: Mode the health evaluator derived this tick.
+
+        Returns:
+            Whether the mode changed.
+        '''
+
+        with self._lock:
+            self._health_mode = health_mode
+
+            return self._recommit()
+
+    def set_manual_halt(self, reason: str) -> bool:
+        '''Place the manual hold and recommit the mode.'''
+
+        return self._set_hold('manual_hold', reason)
+
+    def clear_manual_halt(self) -> bool:
+        '''Lift the manual hold and recommit; never writes ACTIVE directly.'''
+
+        return self._clear_hold('manual_hold')
+
+    def set_daily_loss_halt(self, reason: str) -> bool:
+        '''Place the daily-loss hold and recommit the mode.'''
+
+        return self._set_hold('risk_daily_loss', reason)
+
+    def clear_daily_loss_halt(self) -> bool:
+        '''Lift the daily-loss hold and recommit the mode.'''
+
+        return self._clear_hold('risk_daily_loss')
+
+    def set_drawdown_halt(self, reason: str) -> bool:
+        '''Place the drawdown hold and recommit the mode.'''
+
+        return self._set_hold('risk_drawdown', reason)
+
+    def clear_drawdown_halt(self) -> bool:
+        '''Lift the drawdown hold and recommit the mode.'''
+
+        return self._clear_hold('risk_drawdown')
+
+    def _set_hold(self, name: str, reason: str) -> bool:
+        with self._lock:
+            hold = getattr(self._state.mode_holds, name)
+
+            if hold.active:
+                return False
+
+            hold.active = True
+            hold.reason = reason
+            hold.since = self._clock()
+
+            return self._recommit()
+
+    def _clear_hold(self, name: str) -> bool:
+        with self._lock:
+            hold = getattr(self._state.mode_holds, name)
+
+            if not hold.active:
+                return False
+
+            hold.active = False
+            hold.reason = ''
+            hold.since = None
+
+            return self._recommit()
+
+    def _recommit(self) -> bool:
+        holds = self._state.mode_holds
+        halted = holds.any_active() or self._health_mode is _HALTED
+        new_mode = _HALTED if halted else self._health_mode
+
+        source = self._mode_source(new_mode)
+        mode_changed = new_mode is not self._state.mode.mode
+
+        if not mode_changed and source == self._state.mode.trigger:
+            return False
+
+        transitioned_at = (
+            self._clock() if mode_changed else self._state.mode.transitioned_at
+        )
+        self._state.mode = ModeState(
+            mode=new_mode,
+            trigger=source,
+            transitioned_at=transitioned_at,
+        )
+
+        return mode_changed
+
+    def _mode_source(self, mode: OperationalMode) -> str:
+        '''Return which input drives the mode: manual, risk, or health.'''
+
+        holds = self._state.mode_holds
+
+        if mode is _HALTED:
+
+            if holds.manual_hold.active:
+                return 'manual'
+
+            if holds.risk_daily_loss.active or holds.risk_drawdown.active:
+                return 'risk'
+
+        return 'health'

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -62,11 +62,14 @@ class ModeController:
         self._on_halt = on_halt
         self._pending_halt: str | None = None
 
-    def apply_health_mode(self, health_mode: OperationalMode) -> bool:
+    def apply_health_mode(self, health_mode: OperationalMode, notify: bool = True) -> bool:
         '''Record the latest health-derived mode and recommit the mode.
 
         Args:
             health_mode: Mode the health evaluator derived this tick.
+            notify: Whether to fire a pending on-halt callback here. A caller
+                holding its own lock passes False and drains later via
+                `notify_pending_halt` once that lock is released.
 
         Returns:
             Whether the mode changed.
@@ -76,7 +79,8 @@ class ModeController:
             self._health_mode = health_mode
             changed = self._recommit()
 
-        self._notify_halt()
+        if notify:
+            self.notify_pending_halt()
 
         return changed
 
@@ -110,20 +114,26 @@ class ModeController:
 
         return self._clear_hold('risk_drawdown')
 
-    def evaluate_risk(self) -> None:
+    def evaluate_risk(self, notify: bool = True) -> None:
         '''Trip or lift the risk breakers from the current RiskState.
 
         The daily-loss breaker sums the per-strategy 24h losses and
         auto-lifts when they decay back under the limit. The drawdown
         breaker trips on the lifetime-peak total drawdown and does not
         auto-lift, so a recovered mark cannot silently resume trading.
+
+        Args:
+            notify: Whether to fire a pending on-halt callback here. A caller
+                holding its own lock passes False and drains later via
+                `notify_pending_halt`.
         '''
 
         with self._lock:
             self._evaluate_daily_loss_locked()
             self._evaluate_drawdown_locked()
 
-        self._notify_halt()
+        if notify:
+            self.notify_pending_halt()
 
     def reconcile(self) -> None:
         '''Re-derive the mode after a restart, before trading resumes.
@@ -143,16 +153,21 @@ class ModeController:
             self._evaluate_drawdown_locked()
             self._recommit()
 
-        self._notify_halt()
+        self.notify_pending_halt()
 
-    def _notify_halt(self) -> None:
-        '''Fire the on-halt callback outside the lock for a pending halt.'''
+    def notify_pending_halt(self) -> None:
+        '''Fire the on-halt callback outside the lock for a pending halt.
+
+        Skips when the mode is no longer HALTED by the time it drains, so a
+        halt lifted before the notifier ran does not raise a stale alert.
+        '''
 
         with self._lock:
             source = self._pending_halt
             self._pending_halt = None
+            still_halted = self._state.mode.mode is _HALTED
 
-        if source is None or self._on_halt is None:
+        if source is None or not still_halted or self._on_halt is None:
             return
 
         try:
@@ -197,7 +212,7 @@ class ModeController:
         with self._lock:
             changed = self._set_hold_locked(name, reason)
 
-        self._notify_halt()
+        self.notify_pending_halt()
 
         return changed
 
@@ -205,7 +220,7 @@ class ModeController:
         with self._lock:
             changed = self._clear_hold_locked(name)
 
-        self._notify_halt()
+        self.notify_pending_halt()
 
         return changed
 

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -275,7 +275,7 @@ class ModeController:
         hold = getattr(self._state.mode_holds, name)
 
         if hold.active:
-            return False
+            return self._recommit()
 
         hold.active = True
         hold.reason = reason
@@ -287,7 +287,7 @@ class ModeController:
         hold = getattr(self._state.mode_holds, name)
 
         if not hold.active:
-            return False
+            return self._recommit()
 
         hold.active = False
         hold.reason = ''

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -1,9 +1,13 @@
-'''Single writer of instance operational mode.
+'''Arbitrate the instance operational mode against halt holds.
 
-Arbitrates the health-derived mode against the sticky manual and risk
-holds so a healthy tick can never lift a hold. The mode is
-HALTED whenever any hold is active or health itself is HALTED, and the
-health-derived mode otherwise.
+Owns `state.mode_holds` and writes `state.mode` on the
+health-and-hold-arbitrated path: the mode is HALTED whenever any hold
+is active or health itself is HALTED, and the health-derived mode
+otherwise, so a healthy tick can never lift a hold.
+
+The startup and shutdown sequencers still write `state.mode` directly
+and are not yet routed through this controller; until they are, it is
+the sole writer only on the health/hold path, not process-wide.
 '''
 
 from __future__ import annotations
@@ -12,7 +16,6 @@ import logging
 import threading
 from collections.abc import Callable
 from datetime import datetime, timezone
-from decimal import Decimal
 
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
@@ -25,7 +28,6 @@ _log = logging.getLogger(__name__)
 
 _HALTED = OperationalMode.HALTED
 _HEALTH_TRIGGER = 'health'
-_ZERO = Decimal('0')
 
 
 def _utc_now() -> datetime:
@@ -35,11 +37,19 @@ def _utc_now() -> datetime:
 
 
 class ModeController:
-    '''The only sanctioned writer of `state.mode` and `state.mode_holds`.
+    '''Write `state.mode` and own `state.mode_holds` on the health/hold path.
+
+    Not yet the process-wide sole writer: `StartupSequencer` and
+    `ShutdownSequencer` still set `state.mode` directly. Routing those
+    through this controller is tracked as follow-on wiring.
 
     Args:
         state: Instance state whose mode and holds this controller owns.
         lock: Lock serialising mode and hold writes with state snapshots.
+            Must not be the HealthLoop's own lock: the loop calls this
+            controller while holding that lock and the controller
+            re-acquires this one, so sharing a non-reentrant lock
+            deadlocks.
         clock: Source of UTC time for transition and hold timestamps.
         risk_thresholds: Limits the risk breakers evaluate each tick.
         on_halt: Optional callback invoked with the halt source ('manual',
@@ -188,13 +198,10 @@ class ModeController:
         if limit is None:
             return
 
-        daily_loss = sum(
-            (srs.rolling_loss_24h for srs in self._state.risk.per_strategy.values()),
-            _ZERO,
-        )
+        daily_loss = self._state.risk.rolling_loss_24h
 
-        if daily_loss >= limit:
-            self._set_hold_locked('risk_daily_loss', f"24h loss {daily_loss} >= limit {limit}")
+        if daily_loss > limit:
+            self._set_hold_locked('risk_daily_loss', f"24h loss {daily_loss} > limit {limit}")
 
         else:
             self._clear_hold_locked('risk_daily_loss')
@@ -203,16 +210,16 @@ class ModeController:
         risk = self._state.risk
         limit_pct = self._risk_thresholds.max_drawdown_pct
 
-        if limit_pct is not None and risk.max_total_drawdown_pct >= limit_pct:
+        if limit_pct is not None and risk.max_total_drawdown_pct > limit_pct:
             self._set_hold_locked(
-                'risk_drawdown', f"drawdown {risk.max_total_drawdown_pct} >= limit {limit_pct}",
+                'risk_drawdown', f"drawdown {risk.max_total_drawdown_pct} > limit {limit_pct}",
             )
 
         limit_abs = self._risk_thresholds.max_drawdown
 
-        if limit_abs is not None and risk.max_total_drawdown >= limit_abs:
+        if limit_abs is not None and risk.max_total_drawdown > limit_abs:
             self._set_hold_locked(
-                'risk_drawdown', f"drawdown {risk.max_total_drawdown} >= limit {limit_abs}",
+                'risk_drawdown', f"drawdown {risk.max_total_drawdown} > limit {limit_abs}",
             )
 
     def _set_hold(self, name: str, reason: str) -> bool:

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -8,6 +8,7 @@ health-derived mode otherwise.
 
 from __future__ import annotations
 
+import logging
 import threading
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -19,6 +20,8 @@ from nexus.core.domain.operational_mode import ModeState
 from nexus.core.domain.risk_breaker_thresholds import RiskBreakerThresholds
 
 __all__ = ['ModeController']
+
+_log = logging.getLogger(__name__)
 
 _HALTED = OperationalMode.HALTED
 _HEALTH_TRIGGER = 'health'
@@ -39,6 +42,8 @@ class ModeController:
         lock: Lock serialising mode and hold writes with state snapshots.
         clock: Source of UTC time for transition and hold timestamps.
         risk_thresholds: Limits the risk breakers evaluate each tick.
+        on_halt: Optional callback invoked with the halt source ('manual',
+            'risk', or 'health') when the mode transitions to HALTED.
     '''
 
     def __init__(
@@ -47,12 +52,14 @@ class ModeController:
         lock: threading.Lock,
         clock: Callable[[], datetime] = _utc_now,
         risk_thresholds: RiskBreakerThresholds | None = None,
+        on_halt: Callable[[str], None] | None = None,
     ) -> None:
         self._state = state
         self._lock = lock
         self._clock = clock
         self._health_mode = OperationalMode.ACTIVE
         self._risk_thresholds = risk_thresholds or RiskBreakerThresholds()
+        self._on_halt = on_halt
 
     def apply_health_mode(self, health_mode: OperationalMode) -> bool:
         '''Record the latest health-derived mode and recommit the mode.
@@ -214,6 +221,13 @@ class ModeController:
             trigger=source,
             transitioned_at=transitioned_at,
         )
+
+        if mode_changed and new_mode is _HALTED and self._on_halt is not None:
+
+            try:
+                self._on_halt(source)
+            except Exception:  # noqa: BLE001 - alerting must not break mode control
+                _log.exception('mode-halt alert callback failed')
 
         return mode_changed
 

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -10,48 +10,18 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Callable
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.domain.operational_mode import ModeState
+from nexus.core.domain.risk_breaker_thresholds import RiskBreakerThresholds
 
-__all__ = ['ModeController', 'RiskBreakerThresholds']
+__all__ = ['ModeController']
 
 _HALTED = OperationalMode.HALTED
 _ZERO = Decimal('0')
-
-
-@dataclass
-class RiskBreakerThresholds:
-    '''Configured limits that trip the risk breakers; `None` disables one.
-
-    Args:
-        max_daily_loss: Account 24h loss that trips the daily-loss breaker.
-        max_drawdown_pct: Peak total-drawdown fraction that trips the
-            drawdown breaker.
-        max_drawdown: Peak total-drawdown amount that trips the drawdown
-            breaker.
-    '''
-
-    max_daily_loss: Decimal | None = None
-    max_drawdown_pct: Decimal | None = None
-    max_drawdown: Decimal | None = None
-
-    def __post_init__(self) -> None:
-        '''Validate that configured thresholds are finite and non-negative.'''
-
-        for field_name in ('max_daily_loss', 'max_drawdown_pct', 'max_drawdown'):
-            value = getattr(self, field_name)
-
-            if value is None:
-                continue
-
-            if not isinstance(value, Decimal) or not value.is_finite() or value < _ZERO:
-                msg = f'RiskBreakerThresholds.{field_name} must be a finite non-negative Decimal or None'
-                raise ValueError(msg)
 
 
 def _utc_now() -> datetime:

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -122,13 +122,18 @@ class ModeController:
         breaker trips on the lifetime-peak total drawdown and does not
         auto-lift, so a recovered mark cannot silently resume trading.
 
+        The RiskState reads run under `state.risk.lock_cm()` so the
+        per-strategy iteration and drawdown reads see a consistent
+        snapshot relative to concurrent OutcomeProcessor / MtmLoop
+        writers (FINAL-MAJOR-02).
+
         Args:
             notify: Whether to fire a pending on-halt callback here. A caller
                 holding its own lock passes False and drains later via
                 `notify_pending_halt`.
         '''
 
-        with self._lock:
+        with self._lock, self._state.risk.lock_cm():
             self._evaluate_daily_loss_locked()
             self._evaluate_drawdown_locked()
 
@@ -149,8 +154,10 @@ class ModeController:
             if self._state.mode.trigger == _HEALTH_TRIGGER:
                 self._health_mode = self._state.mode.mode
 
-            self._evaluate_daily_loss_locked()
-            self._evaluate_drawdown_locked()
+            with self._state.risk.lock_cm():
+                self._evaluate_daily_loss_locked()
+                self._evaluate_drawdown_locked()
+
             self._recommit()
 
         self.notify_pending_halt()

--- a/nexus/core/mode_controller.py
+++ b/nexus/core/mode_controller.py
@@ -187,7 +187,7 @@ class ModeController:
         )
 
         if daily_loss >= limit:
-            self._set_hold_locked('risk_daily_loss', f'24h loss {daily_loss} >= limit {limit}')
+            self._set_hold_locked('risk_daily_loss', f"24h loss {daily_loss} >= limit {limit}")
 
         else:
             self._clear_hold_locked('risk_daily_loss')
@@ -198,14 +198,14 @@ class ModeController:
 
         if limit_pct is not None and risk.max_total_drawdown_pct >= limit_pct:
             self._set_hold_locked(
-                'risk_drawdown', f'drawdown {risk.max_total_drawdown_pct} >= limit {limit_pct}',
+                'risk_drawdown', f"drawdown {risk.max_total_drawdown_pct} >= limit {limit_pct}",
             )
 
         limit_abs = self._risk_thresholds.max_drawdown
 
         if limit_abs is not None and risk.max_total_drawdown >= limit_abs:
             self._set_hold_locked(
-                'risk_drawdown', f'drawdown {risk.max_total_drawdown} >= limit {limit_abs}',
+                'risk_drawdown', f"drawdown {risk.max_total_drawdown} >= limit {limit_abs}",
             )
 
     def _set_hold(self, name: str, reason: str) -> bool:

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -8,12 +8,14 @@ existence and Python syntax.
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+from nexus.core.domain.risk_breaker_thresholds import RiskBreakerThresholds
 
 __all__ = ['Manifest', 'SignalSpec', 'StrategySpec', 'TimerSpec', 'load_manifest']
 
@@ -176,12 +178,14 @@ class Manifest:
             must not exceed this value.
         capital_pool: Operational allocation in quote asset for this instance.
         strategies: Strategy specifications for this instance.
+        risk_controls: Per-account risk-breaker limits; all-unset by default.
     '''
 
     account_id: str
     allocated_capital: Decimal
     capital_pool: Decimal
     strategies: tuple[StrategySpec, ...]
+    risk_controls: RiskBreakerThresholds = field(default_factory=RiskBreakerThresholds)
 
     def __post_init__(self) -> None:
         '''Validate manifest invariants.'''
@@ -243,6 +247,46 @@ class Manifest:
         if total_pct > _ONE_HUNDRED:
             msg = f'Manifest.strategies capital_pct sum {total_pct} exceeds 100'
             raise ValueError(msg)
+
+
+def _optional_manifest_decimal(raw: Any, field_name: str) -> Decimal | None:
+    '''Parse an optional decimal from a manifest field, or `None`.
+
+    Args:
+        raw: Raw YAML value, or `None` when the key is absent.
+        field_name: Field name for error messages.
+
+    Returns:
+        The parsed `Decimal`, or `None` when `raw` is `None`.
+
+    Raises:
+        ValueError: `raw` is present but not a valid decimal.
+    '''
+
+    if raw is None:
+        return None
+
+    try:
+        return Decimal(str(raw))
+    except InvalidOperation as exc:
+        msg = f'risk_controls.{field_name} must be a decimal, got {raw!r}'
+        raise ValueError(msg) from exc
+
+
+def _parse_risk_controls(data: dict[str, Any]) -> RiskBreakerThresholds:
+    '''Parse the optional `risk_controls` block into RiskBreakerThresholds.'''
+
+    raw = data.get('risk_controls') or {}
+
+    if not isinstance(raw, dict):
+        msg = 'risk_controls must be a mapping'
+        raise ValueError(msg)
+
+    return RiskBreakerThresholds(
+        max_daily_loss=_optional_manifest_decimal(raw.get('max_daily_loss'), 'max_daily_loss'),
+        max_drawdown_pct=_optional_manifest_decimal(raw.get('max_drawdown_pct'), 'max_drawdown_pct'),
+        max_drawdown=_optional_manifest_decimal(raw.get('max_drawdown'), 'max_drawdown'),
+    )
 
 
 def load_manifest(path: Path) -> Manifest:
@@ -437,6 +481,7 @@ def load_manifest(path: Path) -> Manifest:
         allocated_capital=allocated_capital,
         capital_pool=capital_pool,
         strategies=tuple(specs),
+        risk_controls=_parse_risk_controls(data),
     )
 
     _validate_strategy_files(manifest, path.parent)

--- a/nexus/infrastructure/manifest.py
+++ b/nexus/infrastructure/manifest.py
@@ -269,14 +269,17 @@ def _optional_manifest_decimal(raw: Any, field_name: str) -> Decimal | None:
     try:
         return Decimal(str(raw))
     except InvalidOperation as exc:
-        msg = f'risk_controls.{field_name} must be a decimal, got {raw!r}'
+        msg = f"risk_controls.{field_name} must be a decimal, got {raw!r}"
         raise ValueError(msg) from exc
 
 
 def _parse_risk_controls(data: dict[str, Any]) -> RiskBreakerThresholds:
     '''Parse the optional `risk_controls` block into RiskBreakerThresholds.'''
 
-    raw = data.get('risk_controls') or {}
+    raw = data.get('risk_controls')
+
+    if raw is None:
+        raw = {}
 
     if not isinstance(raw, dict):
         msg = 'risk_controls must be a mapping'

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -427,7 +427,7 @@ def _decode_operational_holds(d: dict[str, Any] | None) -> OperationalHolds:
         Reconstructed operational holds.
     '''
 
-    if not d:
+    if d is None:
         return OperationalHolds()
 
     return OperationalHolds(

--- a/nexus/infrastructure/wal_codec.py
+++ b/nexus/infrastructure/wal_codec.py
@@ -17,7 +17,12 @@ from nexus.core.domain.capital_state import SUB_ULP_TOLERANCE as _SUB_ULP_TOLERA
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode, OrderSide
 from nexus.core.domain.instance_state import InstanceState
-from nexus.core.domain.operational_mode import ModeState, StrategyModeState
+from nexus.core.domain.operational_mode import (
+    HaltHold,
+    ModeState,
+    OperationalHolds,
+    StrategyModeState,
+)
 from nexus.core.domain.position import Position
 from nexus.core.domain.risk_state import RiskState, StrategyRiskState
 from nexus.infrastructure.strategy_event import StrategyEvent
@@ -78,6 +83,7 @@ def serialize_state(state: InstanceState) -> bytes:
         'risk': _encode_risk_state(state.risk),
         'positions': {k: _encode_position(v) for k, v in positions_snapshot.items()},
         'mode': _encode_mode_state(state.mode),
+        'mode_holds': _encode_operational_holds(state.mode_holds),
         'strategy_modes': {
             k: _encode_strategy_mode_state(v) for k, v in strategy_modes_snapshot.items()
         },
@@ -130,6 +136,7 @@ def _decode_state_v1(d: dict[str, Any]) -> InstanceState:
             risk=_decode_risk_state(d['risk']),
             positions={k: _decode_position(v) for k, v in d['positions'].items()},
             mode=_decode_mode_state(d['mode']),
+            mode_holds=_decode_operational_holds(d.get('mode_holds')),
             strategy_modes={
                 k: _decode_strategy_mode_state(v)
                 for k, v in d['strategy_modes'].items()
@@ -390,6 +397,65 @@ def _decode_mode_state(d: dict[str, str]) -> ModeState:
         mode=OperationalMode(d['mode']),
         trigger=d['trigger'],
         transitioned_at=datetime.fromisoformat(d['transitioned_at']),
+    )
+
+
+def _encode_operational_holds(holds: OperationalHolds) -> dict[str, Any]:
+    '''Encode OperationalHolds to a nested dict for msgpack.
+
+    Args:
+        holds: Operational holds to encode.
+
+    Returns:
+        Dict of hold name to encoded HaltHold.
+    '''
+
+    return {
+        'manual_hold': _encode_halt_hold(holds.manual_hold),
+        'risk_daily_loss': _encode_halt_hold(holds.risk_daily_loss),
+        'risk_drawdown': _encode_halt_hold(holds.risk_drawdown),
+    }
+
+
+def _decode_operational_holds(d: dict[str, Any] | None) -> OperationalHolds:
+    '''Decode OperationalHolds, defaulting to empty for pre-field snapshots.
+
+    Args:
+        d: Encoded holds dict, or `None` when absent from an old snapshot.
+
+    Returns:
+        Reconstructed operational holds.
+    '''
+
+    if not d:
+        return OperationalHolds()
+
+    return OperationalHolds(
+        manual_hold=_decode_halt_hold(d['manual_hold']),
+        risk_daily_loss=_decode_halt_hold(d['risk_daily_loss']),
+        risk_drawdown=_decode_halt_hold(d['risk_drawdown']),
+    )
+
+
+def _encode_halt_hold(hold: HaltHold) -> dict[str, Any]:
+    '''Encode a single HaltHold, `since` as an ISO string or `None`.'''
+
+    return {
+        'active': hold.active,
+        'reason': hold.reason,
+        'since': hold.since.isoformat() if hold.since is not None else None,
+    }
+
+
+def _decode_halt_hold(d: dict[str, Any]) -> HaltHold:
+    '''Decode a single HaltHold from its encoded dict.'''
+
+    since = d['since']
+
+    return HaltHold(
+        active=d['active'],
+        reason=d['reason'],
+        since=datetime.fromisoformat(since) if since is not None else None,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum-nexus"
-version = "0.67.0"
+version = "0.68.0"
 description = "Layer for intelligence and decision-making between signal generation and trade execution."
 readme = "README.md"
 authors = [

--- a/tests/test_health_loop.py
+++ b/tests/test_health_loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 from datetime import datetime
 from decimal import Decimal
@@ -395,3 +396,31 @@ def test_health_path_fires_on_halt_outside_the_loop_lock() -> None:
 
     assert lock_free == [True]
     assert state.mode.mode is OperationalMode.HALTED
+
+
+def test_health_tick_logs_a_trigger_only_change(caplog: pytest.LogCaptureFixture) -> None:
+    state = _make_state()
+    controller = ModeController(
+        state, threading.Lock(),
+        risk_thresholds=RiskBreakerThresholds(max_daily_loss=Decimal('250')),
+    )
+    loop = HealthLoop(
+        snapshot_provider=lambda: HealthSnapshot(latency_p99_ms=5000.0),
+        evaluator=_make_evaluator(),
+        state=state,
+        mode_controller=controller,
+    )
+
+    loop.tick_once()
+
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'health'
+
+    state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('300'))
+
+    with caplog.at_level(logging.INFO, logger='nexus.core.health_loop'):
+        loop.tick_once()
+
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'risk'
+    assert any('operational mode transition' in r.message for r in caplog.records)

--- a/tests/test_health_loop.py
+++ b/tests/test_health_loop.py
@@ -369,3 +369,29 @@ def test_mode_controller_hook_evaluates_risk_breaker_on_tick() -> None:
 
     assert state.mode.mode is OperationalMode.HALTED
     assert state.mode.trigger == 'risk'
+
+
+def test_health_path_fires_on_halt_outside_the_loop_lock() -> None:
+    state = _make_state()
+    lock_free: list[bool] = []
+    holder: dict[str, HealthLoop] = {}
+
+    def on_halt(_source: str) -> None:
+        acquired = holder['loop']._lock.acquire(blocking=False)
+        lock_free.append(acquired)
+        if acquired:
+            holder['loop']._lock.release()
+
+    controller = ModeController(state, threading.Lock(), on_halt=on_halt)
+    loop = HealthLoop(
+        snapshot_provider=lambda: HealthSnapshot(latency_p99_ms=5000.0),
+        evaluator=_make_evaluator(),
+        state=state,
+        mode_controller=controller,
+    )
+    holder['loop'] = loop
+
+    loop.tick_once()
+
+    assert lock_free == [True]
+    assert state.mode.mode is OperationalMode.HALTED

--- a/tests/test_health_loop.py
+++ b/tests/test_health_loop.py
@@ -13,6 +13,7 @@ from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.health_evaluator import HealthEvaluator, HealthSnapshot, HealthThresholds
 from nexus.core.health_loop import HealthLoop
+from nexus.core.mode_controller import ModeController
 
 
 def _make_state() -> InstanceState:
@@ -310,3 +311,36 @@ def test_tick_swallows_rolling_loss_refresher_exception() -> None:
     loop.tick_once()
 
     assert state.mode.mode == OperationalMode.ACTIVE
+
+
+def test_mode_controller_hook_keeps_manual_halt_through_healthy_tick() -> None:
+    state = _make_state()
+    controller = ModeController(state, threading.Lock())
+    controller.set_manual_halt('manual stop')
+    loop = HealthLoop(
+        snapshot_provider=lambda: HealthSnapshot(),
+        evaluator=_make_evaluator(),
+        state=state,
+        mode_controller=controller,
+    )
+
+    loop.tick_once()
+
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'manual'
+
+
+def test_mode_controller_hook_applies_health_halt() -> None:
+    state = _make_state()
+    controller = ModeController(state, threading.Lock())
+    loop = HealthLoop(
+        snapshot_provider=lambda: HealthSnapshot(latency_p99_ms=5000.0),
+        evaluator=_make_evaluator(),
+        state=state,
+        mode_controller=controller,
+    )
+
+    loop.tick_once()
+
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'health'

--- a/tests/test_health_loop.py
+++ b/tests/test_health_loop.py
@@ -11,9 +11,10 @@ import pytest
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.risk_state import StrategyRiskState
 from nexus.core.health_evaluator import HealthEvaluator, HealthSnapshot, HealthThresholds
 from nexus.core.health_loop import HealthLoop
-from nexus.core.mode_controller import ModeController
+from nexus.core.mode_controller import ModeController, RiskBreakerThresholds
 
 
 def _make_state() -> InstanceState:
@@ -344,3 +345,26 @@ def test_mode_controller_hook_applies_health_halt() -> None:
 
     assert state.mode.mode is OperationalMode.HALTED
     assert state.mode.trigger == 'health'
+
+
+def test_mode_controller_hook_evaluates_risk_breaker_on_tick() -> None:
+    state = _make_state()
+    state.risk.per_strategy['s1'] = StrategyRiskState(
+        strategy_id='s1', rolling_loss_24h=Decimal('300'),
+    )
+    controller = ModeController(
+        state,
+        threading.Lock(),
+        risk_thresholds=RiskBreakerThresholds(max_daily_loss=Decimal('250')),
+    )
+    loop = HealthLoop(
+        snapshot_provider=lambda: HealthSnapshot(),
+        evaluator=_make_evaluator(),
+        state=state,
+        mode_controller=controller,
+    )
+
+    loop.tick_once()
+
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'risk'

--- a/tests/test_health_loop.py
+++ b/tests/test_health_loop.py
@@ -11,10 +11,11 @@ import pytest
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.risk_breaker_thresholds import RiskBreakerThresholds
 from nexus.core.domain.risk_state import StrategyRiskState
 from nexus.core.health_evaluator import HealthEvaluator, HealthSnapshot, HealthThresholds
 from nexus.core.health_loop import HealthLoop
-from nexus.core.mode_controller import ModeController, RiskBreakerThresholds
+from nexus.core.mode_controller import ModeController
 
 
 def _make_state() -> InstanceState:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -929,3 +929,58 @@ class TestLoadManifestTimers:
 
         with pytest.raises(ValueError, match='duplicate timer_id'):
             load_manifest(path)
+
+
+def _write_min_manifest(tmp_path: Path, risk_block: str = '') -> Path:
+    path = tmp_path / 'manifest.yaml'
+    _write_strategy_file(tmp_path, 'strategies/momentum.py')
+    _write_yaml(
+        path,
+        'account_id: test_acct\n'
+        'allocated_capital: 10000\n'
+        'capital_pool: 10000\n'
+        + risk_block +
+        'strategies:\n'
+        '  - id: momentum\n'
+        '    file: strategies/momentum.py\n'
+        '    signal:\n'
+        '      series: time_15m\n'
+        '      interval_seconds: 900\n'
+        '    capital_pct: 100\n',
+    )
+
+    return path
+
+
+def test_risk_controls_parsed(tmp_path: Path) -> None:
+    path = _write_min_manifest(
+        tmp_path,
+        'risk_controls:\n'
+        '  max_daily_loss: 250\n'
+        '  max_drawdown_pct: 0.05\n',
+    )
+
+    manifest = load_manifest(path)
+
+    assert manifest.risk_controls.max_daily_loss == Decimal('250')
+    assert manifest.risk_controls.max_drawdown_pct == Decimal('0.05')
+    assert manifest.risk_controls.max_drawdown is None
+
+
+def test_risk_controls_absent_defaults_to_empty(tmp_path: Path) -> None:
+    manifest = load_manifest(_write_min_manifest(tmp_path))
+
+    assert manifest.risk_controls.max_daily_loss is None
+    assert manifest.risk_controls.max_drawdown_pct is None
+    assert manifest.risk_controls.max_drawdown is None
+
+
+def test_negative_risk_control_rejected(tmp_path: Path) -> None:
+    path = _write_min_manifest(
+        tmp_path,
+        'risk_controls:\n'
+        '  max_daily_loss: -1\n',
+    )
+
+    with pytest.raises(ValueError, match='non-negative'):
+        load_manifest(path)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -982,7 +982,7 @@ def test_negative_risk_control_rejected(tmp_path: Path) -> None:
         '  max_daily_loss: -1\n',
     )
 
-    with pytest.raises(ValueError, match='non-negative'):
+    with pytest.raises(ValueError, match='positive'):
         load_manifest(path)
 
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -984,3 +984,13 @@ def test_negative_risk_control_rejected(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match='non-negative'):
         load_manifest(path)
+
+
+def test_risk_controls_non_mapping_rejected(tmp_path: Path) -> None:
+    path = _write_min_manifest(
+        tmp_path,
+        'risk_controls: []\n',
+    )
+
+    with pytest.raises(ValueError, match='must be a mapping'):
+        load_manifest(path)

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -300,3 +300,23 @@ def test_on_halt_runs_outside_the_lock():
 
     assert done.wait(timeout=2.0), 'on_halt ran under the lock and deadlocked'
     assert state.mode.mode is OperationalMode.HALTED
+
+
+def test_notify_pending_halt_skips_when_no_longer_halted():
+    state = _state()
+    state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('300'))
+    sources: list[str] = []
+    controller = ModeController(
+        state, threading.Lock(), clock=lambda: _TS,
+        risk_thresholds=RiskBreakerThresholds(max_daily_loss=Decimal('250')),
+        on_halt=sources.append,
+    )
+
+    controller.evaluate_risk(notify=False)
+    assert state.mode.mode is OperationalMode.HALTED
+
+    state.risk.per_strategy['s1'].rolling_loss_24h = Decimal('100')
+    controller.evaluate_risk(notify=False)
+    controller.notify_pending_halt()
+
+    assert sources == []

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -7,6 +7,7 @@ import pytest
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.operational_mode import HaltHold, ModeState
 from nexus.core.domain.risk_breaker_thresholds import RiskBreakerThresholds
 from nexus.core.domain.risk_state import StrategyRiskState
 from nexus.core.mode_controller import ModeController
@@ -190,3 +191,45 @@ def test_evaluate_risk_without_thresholds_is_a_noop():
 def test_risk_breaker_thresholds_reject_negative():
     with pytest.raises(ValueError, match='non-negative'):
         RiskBreakerThresholds(max_daily_loss=Decimal('-1'))
+
+
+def test_reconcile_preserves_a_recovered_health_halt():
+    state = _state()
+    state.mode = ModeState(mode=OperationalMode.HALTED, trigger='health', transitioned_at=_TS)
+    controller = _controller(state)
+
+    controller.reconcile()
+
+    assert state.mode.mode is OperationalMode.HALTED
+
+
+def test_reconcile_keeps_a_recovered_manual_hold():
+    state = _state()
+    state.mode_holds.manual_hold = HaltHold(active=True, reason='manual stop', since=_TS)
+    state.mode = ModeState(mode=OperationalMode.HALTED, trigger='manual', transitioned_at=_TS)
+    controller = _controller(state)
+
+    controller.reconcile()
+
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'manual'
+
+
+def test_reconcile_retrips_risk_from_recovered_state():
+    state = _state()
+    state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('300'))
+    controller = _breaker(state, RiskBreakerThresholds(max_daily_loss=Decimal('250')))
+
+    controller.reconcile()
+
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode_holds.risk_daily_loss.active
+
+
+def test_reconcile_leaves_a_clean_state_active():
+    state = _state()
+    controller = _controller(state)
+
+    controller.reconcile()
+
+    assert state.mode.mode is OperationalMode.ACTIVE

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -277,3 +277,26 @@ def test_on_halt_failure_does_not_break_controller():
     controller.set_manual_halt('manual stop')
 
     assert state.mode.mode is OperationalMode.HALTED
+
+
+def test_on_halt_runs_outside_the_lock():
+    state = _state()
+    holder: dict[str, ModeController] = {}
+
+    def on_halt(_source: str) -> None:
+        holder['controller'].clear_daily_loss_halt()
+
+    controller = ModeController(state, threading.Lock(), clock=lambda: _TS, on_halt=on_halt)
+    holder['controller'] = controller
+
+    done = threading.Event()
+
+    def run() -> None:
+        controller.set_manual_halt('manual stop')
+        done.set()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+
+    assert done.wait(timeout=2.0), 'on_halt ran under the lock and deadlocked'
+    assert state.mode.mode is OperationalMode.HALTED

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -189,8 +189,24 @@ def test_evaluate_risk_without_thresholds_is_a_noop() -> None:
 
 
 def test_risk_breaker_thresholds_reject_negative() -> None:
-    with pytest.raises(ValueError, match='non-negative'):
+    with pytest.raises(ValueError, match='positive'):
         RiskBreakerThresholds(max_daily_loss=Decimal('-1'))
+
+
+def test_risk_breaker_thresholds_reject_zero() -> None:
+    with pytest.raises(ValueError, match='positive'):
+        RiskBreakerThresholds(max_drawdown_pct=Decimal('0'))
+
+
+def test_drawdown_breaker_trips_on_absolute_limit() -> None:
+    state = _state()
+    state.risk.max_total_drawdown = Decimal('1500')
+    controller = _breaker(state, RiskBreakerThresholds(max_drawdown=Decimal('1000')))
+
+    controller.evaluate_risk()
+
+    assert state.mode_holds.risk_drawdown.active
+    assert state.mode.mode is OperationalMode.HALTED
 
 
 def test_reconcile_preserves_a_recovered_health_halt() -> None:

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -7,8 +7,9 @@ import pytest
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.risk_breaker_thresholds import RiskBreakerThresholds
 from nexus.core.domain.risk_state import StrategyRiskState
-from nexus.core.mode_controller import ModeController, RiskBreakerThresholds
+from nexus.core.mode_controller import ModeController
 
 _TS = datetime(2026, 1, 1, tzinfo=timezone.utc)
 

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -1,4 +1,5 @@
 import threading
+from dataclasses import FrozenInstanceError
 from datetime import datetime, timezone
 from decimal import Decimal
 
@@ -380,3 +381,51 @@ def test_reconcile_acquires_the_risk_lock() -> None:
 
     assert blocked
     assert state.mode.mode is OperationalMode.HALTED
+
+
+class _CountingLock:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.entries = 0
+
+    def __enter__(self) -> '_CountingLock':
+        self.entries += 1
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self._lock.release()
+
+
+def test_apply_health_and_risk_commits_under_a_single_lock_acquisition() -> None:
+    state = _state()
+    state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('300'))
+    lock = _CountingLock()
+    controller = ModeController(
+        state, lock, clock=lambda: _TS,  # type: ignore[arg-type]
+        risk_thresholds=RiskBreakerThresholds(max_daily_loss=Decimal('250')),
+    )
+
+    controller.apply_health_and_risk(OperationalMode.ACTIVE, notify=False)
+
+    assert lock.entries == 1
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'risk'
+
+
+def test_apply_health_and_risk_honours_health_halt() -> None:
+    state = _state()
+    controller = _controller(state)
+
+    changed = controller.apply_health_and_risk(OperationalMode.HALTED)
+
+    assert changed
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'health'
+
+
+def test_risk_breaker_thresholds_are_frozen() -> None:
+    thresholds = RiskBreakerThresholds(max_daily_loss=Decimal('250'))
+
+    with pytest.raises(FrozenInstanceError):
+        thresholds.max_daily_loss = Decimal('1')  # type: ignore[misc]

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -429,3 +429,27 @@ def test_risk_breaker_thresholds_are_frozen() -> None:
 
     with pytest.raises(FrozenInstanceError):
         thresholds.max_daily_loss = Decimal('1')  # type: ignore[misc]
+
+
+def test_set_hold_reasserts_halt_after_external_mode_drift() -> None:
+    state = _state()
+    controller = _controller(state)
+    controller.set_manual_halt('manual stop')
+    state.mode = ModeState(mode=OperationalMode.ACTIVE, trigger='health', transitioned_at=_TS)
+
+    changed = controller.set_manual_halt('manual stop')
+
+    assert changed
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'manual'
+
+
+def test_clear_hold_reconciles_mode_after_external_drift() -> None:
+    state = _state()
+    controller = _controller(state)
+    state.mode = ModeState(mode=OperationalMode.HALTED, trigger='manual', transitioned_at=_TS)
+
+    changed = controller.clear_manual_halt()
+
+    assert changed
+    assert state.mode.mode is OperationalMode.ACTIVE

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -320,3 +320,47 @@ def test_notify_pending_halt_skips_when_no_longer_halted() -> None:
     controller.notify_pending_halt()
 
     assert sources == []
+
+
+def test_evaluate_risk_acquires_the_risk_lock() -> None:
+    state = _state()
+    state.risk.lock = threading.Lock()
+    state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('300'))
+    controller = _breaker(state, RiskBreakerThresholds(max_daily_loss=Decimal('250')))
+    done = threading.Event()
+
+    def run() -> None:
+        controller.evaluate_risk()
+        done.set()
+
+    with state.risk.lock:
+        worker = threading.Thread(target=run)
+        worker.start()
+        blocked = not done.wait(timeout=0.2)
+
+    worker.join(timeout=2.0)
+
+    assert blocked
+    assert state.mode.mode is OperationalMode.HALTED
+
+
+def test_reconcile_acquires_the_risk_lock() -> None:
+    state = _state()
+    state.risk.lock = threading.Lock()
+    state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('300'))
+    controller = _breaker(state, RiskBreakerThresholds(max_daily_loss=Decimal('250')))
+    done = threading.Event()
+
+    def run() -> None:
+        controller.reconcile()
+        done.set()
+
+    with state.risk.lock:
+        worker = threading.Thread(target=run)
+        worker.start()
+        blocked = not done.wait(timeout=0.2)
+
+    worker.join(timeout=2.0)
+
+    assert blocked
+    assert state.mode.mode is OperationalMode.HALTED

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -1,0 +1,125 @@
+import threading
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OperationalMode
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.mode_controller import ModeController
+
+_TS = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _state() -> InstanceState:
+    return InstanceState(capital=CapitalState(capital_pool=Decimal('10000')))
+
+
+def _controller(state: InstanceState) -> ModeController:
+    return ModeController(state, threading.Lock(), clock=lambda: _TS)
+
+
+def test_manual_halt_sets_halted():
+    state = _state()
+    controller = _controller(state)
+
+    assert controller.set_manual_halt('manual stop')
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'manual'
+    assert state.mode_holds.manual_hold.active
+    assert state.mode_holds.manual_hold.since == _TS
+
+
+def test_healthy_tick_cannot_lift_manual_halt():
+    state = _state()
+    controller = _controller(state)
+    controller.set_manual_halt('manual stop')
+
+    changed = controller.apply_health_mode(OperationalMode.ACTIVE)
+
+    assert not changed
+    assert state.mode.mode is OperationalMode.HALTED
+
+
+def test_resume_holds_halted_while_risk_hold_active():
+    state = _state()
+    controller = _controller(state)
+    controller.set_manual_halt('manual stop')
+    controller.set_daily_loss_halt('daily loss breached')
+
+    changed = controller.clear_manual_halt()
+
+    assert not changed
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'risk'
+
+
+def test_resume_returns_to_health_mode_when_no_other_hold():
+    state = _state()
+    controller = _controller(state)
+    controller.apply_health_mode(OperationalMode.REDUCE_ONLY)
+    controller.set_manual_halt('manual stop')
+
+    controller.clear_manual_halt()
+
+    assert state.mode.mode is OperationalMode.REDUCE_ONLY
+    assert state.mode.trigger == 'health'
+
+
+def test_resume_stays_halted_when_health_is_halted():
+    state = _state()
+    controller = _controller(state)
+    controller.set_manual_halt('manual stop')
+    controller.apply_health_mode(OperationalMode.HALTED)
+
+    controller.clear_manual_halt()
+
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'health'
+
+
+def test_health_drives_mode_without_holds():
+    state = _state()
+    controller = _controller(state)
+
+    assert controller.apply_health_mode(OperationalMode.REDUCE_ONLY)
+    assert state.mode.mode is OperationalMode.REDUCE_ONLY
+    assert state.mode.trigger == 'health'
+
+
+def test_all_holds_cleared_and_healthy_returns_active():
+    state = _state()
+    controller = _controller(state)
+    controller.set_daily_loss_halt('daily loss breached')
+    controller.apply_health_mode(OperationalMode.ACTIVE)
+
+    controller.clear_daily_loss_halt()
+
+    assert state.mode.mode is OperationalMode.ACTIVE
+
+
+def test_drawdown_hold_is_independent_of_daily_loss():
+    state = _state()
+    controller = _controller(state)
+    controller.set_daily_loss_halt('daily loss breached')
+    controller.set_drawdown_halt('drawdown breached')
+
+    controller.clear_daily_loss_halt()
+
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode_holds.risk_drawdown.active
+
+
+def test_repeated_halt_is_idempotent():
+    state = _state()
+    controller = _controller(state)
+    controller.set_manual_halt('manual stop')
+
+    assert not controller.set_manual_halt('manual stop again')
+
+
+def test_clearing_inactive_hold_is_a_noop():
+    state = _state()
+    controller = _controller(state)
+
+    assert not controller.clear_manual_halt()
+    assert state.mode.mode is OperationalMode.ACTIVE

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -2,10 +2,13 @@ import threading
 from datetime import datetime, timezone
 from decimal import Decimal
 
+import pytest
+
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode
 from nexus.core.domain.instance_state import InstanceState
-from nexus.core.mode_controller import ModeController
+from nexus.core.domain.risk_state import StrategyRiskState
+from nexus.core.mode_controller import ModeController, RiskBreakerThresholds
 
 _TS = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
@@ -123,3 +126,66 @@ def test_clearing_inactive_hold_is_a_noop():
 
     assert not controller.clear_manual_halt()
     assert state.mode.mode is OperationalMode.ACTIVE
+
+
+def _breaker(state: InstanceState, thresholds: RiskBreakerThresholds) -> ModeController:
+    return ModeController(state, threading.Lock(), clock=lambda: _TS, risk_thresholds=thresholds)
+
+
+def test_daily_loss_breaker_trips_and_auto_clears():
+    state = _state()
+    state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('300'))
+    controller = _breaker(state, RiskBreakerThresholds(max_daily_loss=Decimal('250')))
+
+    controller.evaluate_risk()
+
+    assert state.mode.mode is OperationalMode.HALTED
+    assert state.mode.trigger == 'risk'
+    assert state.mode_holds.risk_daily_loss.active
+
+    state.risk.per_strategy['s1'].rolling_loss_24h = Decimal('100')
+    controller.evaluate_risk()
+
+    assert not state.mode_holds.risk_daily_loss.active
+    assert state.mode.mode is OperationalMode.ACTIVE
+
+
+def test_daily_loss_sums_across_strategies():
+    state = _state()
+    state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('150'))
+    state.risk.per_strategy['s2'] = StrategyRiskState(strategy_id='s2', rolling_loss_24h=Decimal('150'))
+    controller = _breaker(state, RiskBreakerThresholds(max_daily_loss=Decimal('250')))
+
+    controller.evaluate_risk()
+
+    assert state.mode_holds.risk_daily_loss.active
+
+
+def test_drawdown_breaker_trips_and_does_not_auto_clear():
+    state = _state()
+    state.risk.max_total_drawdown_pct = Decimal('0.08')
+    controller = _breaker(state, RiskBreakerThresholds(max_drawdown_pct=Decimal('0.05')))
+
+    controller.evaluate_risk()
+
+    assert state.mode_holds.risk_drawdown.active
+
+    state.risk.max_total_drawdown_pct = Decimal('0.01')
+    controller.evaluate_risk()
+
+    assert state.mode_holds.risk_drawdown.active
+
+
+def test_evaluate_risk_without_thresholds_is_a_noop():
+    state = _state()
+    state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('9999'))
+    controller = ModeController(state, threading.Lock(), clock=lambda: _TS)
+
+    controller.evaluate_risk()
+
+    assert state.mode.mode is OperationalMode.ACTIVE
+
+
+def test_risk_breaker_thresholds_reject_negative():
+    with pytest.raises(ValueError, match='non-negative'):
+        RiskBreakerThresholds(max_daily_loss=Decimal('-1'))

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -23,7 +23,7 @@ def _controller(state: InstanceState) -> ModeController:
     return ModeController(state, threading.Lock(), clock=lambda: _TS)
 
 
-def test_manual_halt_sets_halted():
+def test_manual_halt_sets_halted() -> None:
     state = _state()
     controller = _controller(state)
 
@@ -34,7 +34,7 @@ def test_manual_halt_sets_halted():
     assert state.mode_holds.manual_hold.since == _TS
 
 
-def test_healthy_tick_cannot_lift_manual_halt():
+def test_healthy_tick_cannot_lift_manual_halt() -> None:
     state = _state()
     controller = _controller(state)
     controller.set_manual_halt('manual stop')
@@ -45,7 +45,7 @@ def test_healthy_tick_cannot_lift_manual_halt():
     assert state.mode.mode is OperationalMode.HALTED
 
 
-def test_resume_holds_halted_while_risk_hold_active():
+def test_resume_holds_halted_while_risk_hold_active() -> None:
     state = _state()
     controller = _controller(state)
     controller.set_manual_halt('manual stop')
@@ -58,7 +58,7 @@ def test_resume_holds_halted_while_risk_hold_active():
     assert state.mode.trigger == 'risk'
 
 
-def test_resume_returns_to_health_mode_when_no_other_hold():
+def test_resume_returns_to_health_mode_when_no_other_hold() -> None:
     state = _state()
     controller = _controller(state)
     controller.apply_health_mode(OperationalMode.REDUCE_ONLY)
@@ -70,7 +70,7 @@ def test_resume_returns_to_health_mode_when_no_other_hold():
     assert state.mode.trigger == 'health'
 
 
-def test_resume_stays_halted_when_health_is_halted():
+def test_resume_stays_halted_when_health_is_halted() -> None:
     state = _state()
     controller = _controller(state)
     controller.set_manual_halt('manual stop')
@@ -82,7 +82,7 @@ def test_resume_stays_halted_when_health_is_halted():
     assert state.mode.trigger == 'health'
 
 
-def test_health_drives_mode_without_holds():
+def test_health_drives_mode_without_holds() -> None:
     state = _state()
     controller = _controller(state)
 
@@ -91,7 +91,7 @@ def test_health_drives_mode_without_holds():
     assert state.mode.trigger == 'health'
 
 
-def test_all_holds_cleared_and_healthy_returns_active():
+def test_all_holds_cleared_and_healthy_returns_active() -> None:
     state = _state()
     controller = _controller(state)
     controller.set_daily_loss_halt('daily loss breached')
@@ -102,7 +102,7 @@ def test_all_holds_cleared_and_healthy_returns_active():
     assert state.mode.mode is OperationalMode.ACTIVE
 
 
-def test_drawdown_hold_is_independent_of_daily_loss():
+def test_drawdown_hold_is_independent_of_daily_loss() -> None:
     state = _state()
     controller = _controller(state)
     controller.set_daily_loss_halt('daily loss breached')
@@ -114,7 +114,7 @@ def test_drawdown_hold_is_independent_of_daily_loss():
     assert state.mode_holds.risk_drawdown.active
 
 
-def test_repeated_halt_is_idempotent():
+def test_repeated_halt_is_idempotent() -> None:
     state = _state()
     controller = _controller(state)
     controller.set_manual_halt('manual stop')
@@ -122,7 +122,7 @@ def test_repeated_halt_is_idempotent():
     assert not controller.set_manual_halt('manual stop again')
 
 
-def test_clearing_inactive_hold_is_a_noop():
+def test_clearing_inactive_hold_is_a_noop() -> None:
     state = _state()
     controller = _controller(state)
 
@@ -134,7 +134,7 @@ def _breaker(state: InstanceState, thresholds: RiskBreakerThresholds) -> ModeCon
     return ModeController(state, threading.Lock(), clock=lambda: _TS, risk_thresholds=thresholds)
 
 
-def test_daily_loss_breaker_trips_and_auto_clears():
+def test_daily_loss_breaker_trips_and_auto_clears() -> None:
     state = _state()
     state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('300'))
     controller = _breaker(state, RiskBreakerThresholds(max_daily_loss=Decimal('250')))
@@ -152,7 +152,7 @@ def test_daily_loss_breaker_trips_and_auto_clears():
     assert state.mode.mode is OperationalMode.ACTIVE
 
 
-def test_daily_loss_sums_across_strategies():
+def test_daily_loss_sums_across_strategies() -> None:
     state = _state()
     state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('150'))
     state.risk.per_strategy['s2'] = StrategyRiskState(strategy_id='s2', rolling_loss_24h=Decimal('150'))
@@ -163,7 +163,7 @@ def test_daily_loss_sums_across_strategies():
     assert state.mode_holds.risk_daily_loss.active
 
 
-def test_drawdown_breaker_trips_and_does_not_auto_clear():
+def test_drawdown_breaker_trips_and_does_not_auto_clear() -> None:
     state = _state()
     state.risk.max_total_drawdown_pct = Decimal('0.08')
     controller = _breaker(state, RiskBreakerThresholds(max_drawdown_pct=Decimal('0.05')))
@@ -178,7 +178,7 @@ def test_drawdown_breaker_trips_and_does_not_auto_clear():
     assert state.mode_holds.risk_drawdown.active
 
 
-def test_evaluate_risk_without_thresholds_is_a_noop():
+def test_evaluate_risk_without_thresholds_is_a_noop() -> None:
     state = _state()
     state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('9999'))
     controller = ModeController(state, threading.Lock(), clock=lambda: _TS)
@@ -188,12 +188,12 @@ def test_evaluate_risk_without_thresholds_is_a_noop():
     assert state.mode.mode is OperationalMode.ACTIVE
 
 
-def test_risk_breaker_thresholds_reject_negative():
+def test_risk_breaker_thresholds_reject_negative() -> None:
     with pytest.raises(ValueError, match='non-negative'):
         RiskBreakerThresholds(max_daily_loss=Decimal('-1'))
 
 
-def test_reconcile_preserves_a_recovered_health_halt():
+def test_reconcile_preserves_a_recovered_health_halt() -> None:
     state = _state()
     state.mode = ModeState(mode=OperationalMode.HALTED, trigger='health', transitioned_at=_TS)
     controller = _controller(state)
@@ -203,7 +203,7 @@ def test_reconcile_preserves_a_recovered_health_halt():
     assert state.mode.mode is OperationalMode.HALTED
 
 
-def test_reconcile_keeps_a_recovered_manual_hold():
+def test_reconcile_keeps_a_recovered_manual_hold() -> None:
     state = _state()
     state.mode_holds.manual_hold = HaltHold(active=True, reason='manual stop', since=_TS)
     state.mode = ModeState(mode=OperationalMode.HALTED, trigger='manual', transitioned_at=_TS)
@@ -215,7 +215,7 @@ def test_reconcile_keeps_a_recovered_manual_hold():
     assert state.mode.trigger == 'manual'
 
 
-def test_reconcile_retrips_risk_from_recovered_state():
+def test_reconcile_retrips_risk_from_recovered_state() -> None:
     state = _state()
     state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('300'))
     controller = _breaker(state, RiskBreakerThresholds(max_daily_loss=Decimal('250')))
@@ -226,7 +226,7 @@ def test_reconcile_retrips_risk_from_recovered_state():
     assert state.mode_holds.risk_daily_loss.active
 
 
-def test_reconcile_leaves_a_clean_state_active():
+def test_reconcile_leaves_a_clean_state_active() -> None:
     state = _state()
     controller = _controller(state)
 
@@ -235,7 +235,7 @@ def test_reconcile_leaves_a_clean_state_active():
     assert state.mode.mode is OperationalMode.ACTIVE
 
 
-def test_on_halt_fires_with_source_on_halt_transition():
+def test_on_halt_fires_with_source_on_halt_transition() -> None:
     state = _state()
     sources: list[str] = []
     controller = ModeController(state, threading.Lock(), clock=lambda: _TS, on_halt=sources.append)
@@ -245,7 +245,7 @@ def test_on_halt_fires_with_source_on_halt_transition():
     assert sources == ['manual']
 
 
-def test_on_halt_does_not_fire_without_a_halt_transition():
+def test_on_halt_does_not_fire_without_a_halt_transition() -> None:
     state = _state()
     sources: list[str] = []
     controller = ModeController(state, threading.Lock(), clock=lambda: _TS, on_halt=sources.append)
@@ -255,7 +255,7 @@ def test_on_halt_does_not_fire_without_a_halt_transition():
     assert sources == []
 
 
-def test_on_halt_not_refired_when_already_halted():
+def test_on_halt_not_refired_when_already_halted() -> None:
     state = _state()
     sources: list[str] = []
     controller = ModeController(state, threading.Lock(), clock=lambda: _TS, on_halt=sources.append)
@@ -266,7 +266,7 @@ def test_on_halt_not_refired_when_already_halted():
     assert sources == ['manual']
 
 
-def test_on_halt_failure_does_not_break_controller():
+def test_on_halt_failure_does_not_break_controller() -> None:
     state = _state()
 
     def boom(_source: str) -> None:
@@ -279,7 +279,7 @@ def test_on_halt_failure_does_not_break_controller():
     assert state.mode.mode is OperationalMode.HALTED
 
 
-def test_on_halt_runs_outside_the_lock():
+def test_on_halt_runs_outside_the_lock() -> None:
     state = _state()
     holder: dict[str, ModeController] = {}
 
@@ -302,7 +302,7 @@ def test_on_halt_runs_outside_the_lock():
     assert state.mode.mode is OperationalMode.HALTED
 
 
-def test_notify_pending_halt_skips_when_no_longer_halted():
+def test_notify_pending_halt_skips_when_no_longer_halted() -> None:
     state = _state()
     state.risk.per_strategy['s1'] = StrategyRiskState(strategy_id='s1', rolling_loss_24h=Decimal('300'))
     sources: list[str] = []

--- a/tests/test_mode_controller.py
+++ b/tests/test_mode_controller.py
@@ -233,3 +233,47 @@ def test_reconcile_leaves_a_clean_state_active():
     controller.reconcile()
 
     assert state.mode.mode is OperationalMode.ACTIVE
+
+
+def test_on_halt_fires_with_source_on_halt_transition():
+    state = _state()
+    sources: list[str] = []
+    controller = ModeController(state, threading.Lock(), clock=lambda: _TS, on_halt=sources.append)
+
+    controller.set_manual_halt('manual stop')
+
+    assert sources == ['manual']
+
+
+def test_on_halt_does_not_fire_without_a_halt_transition():
+    state = _state()
+    sources: list[str] = []
+    controller = ModeController(state, threading.Lock(), clock=lambda: _TS, on_halt=sources.append)
+
+    controller.apply_health_mode(OperationalMode.REDUCE_ONLY)
+
+    assert sources == []
+
+
+def test_on_halt_not_refired_when_already_halted():
+    state = _state()
+    sources: list[str] = []
+    controller = ModeController(state, threading.Lock(), clock=lambda: _TS, on_halt=sources.append)
+    controller.set_manual_halt('manual stop')
+
+    controller.set_daily_loss_halt('daily loss')
+
+    assert sources == ['manual']
+
+
+def test_on_halt_failure_does_not_break_controller():
+    state = _state()
+
+    def boom(_source: str) -> None:
+        raise RuntimeError('alert down')
+
+    controller = ModeController(state, threading.Lock(), clock=lambda: _TS, on_halt=boom)
+
+    controller.set_manual_halt('manual stop')
+
+    assert state.mode.mode is OperationalMode.HALTED

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -1057,3 +1057,11 @@ class TestModeHoldsRoundTrip:
         restored = deserialize_state(msgpack.packb(encoded))
 
         assert not restored.mode_holds.any_active()
+
+    def test_present_but_malformed_holds_fails_decode(self) -> None:
+        original = _make_minimal_state()
+        encoded = msgpack.unpackb(serialize_state(original), raw=False)
+        encoded['mode_holds'] = []
+
+        with pytest.raises(ValueError, match='Malformed WAL codec payload'):
+            deserialize_state(msgpack.packb(encoded))

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -1051,7 +1051,7 @@ class TestModeHoldsRoundTrip:
 
     def test_pre_field_snapshot_defaults_to_empty_holds(self) -> None:
         original = _make_minimal_state()
-        encoded = msgpack.unpackb(serialize_state(original))
+        encoded = msgpack.unpackb(serialize_state(original), raw=False)
         del encoded['mode_holds']
 
         restored = deserialize_state(msgpack.packb(encoded))

--- a/tests/test_wal_codec.py
+++ b/tests/test_wal_codec.py
@@ -13,7 +13,7 @@ import pytest
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OperationalMode, OrderSide
 from nexus.core.domain.instance_state import InstanceState
-from nexus.core.domain.operational_mode import ModeState, StrategyModeState
+from nexus.core.domain.operational_mode import HaltHold, ModeState, StrategyModeState
 from nexus.core.domain.position import Position
 from nexus.core.domain.risk_state import RiskState, StrategyRiskState
 from nexus.infrastructure import wal_codec
@@ -1026,3 +1026,34 @@ class TestProcessedDedupIds:
 
         assert restored.processed_outcome_ids == set()
         assert restored.processed_dust_close_ids == set()
+
+
+class TestModeHoldsRoundTrip:
+    '''Verify mode_holds survive serialize → deserialize.'''
+
+    def test_active_holds_survive_round_trip(self) -> None:
+        original = _make_minimal_state()
+        original.mode_holds.manual_hold = HaltHold(
+            active=True,
+            reason='operator stop',
+            since=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        original.mode_holds.risk_drawdown = HaltHold(active=True, reason='drawdown breach')
+
+        restored = deserialize_state(serialize_state(original))
+
+        assert restored.mode_holds.manual_hold.active
+        assert restored.mode_holds.manual_hold.reason == 'operator stop'
+        assert restored.mode_holds.manual_hold.since == datetime(2026, 1, 1, tzinfo=timezone.utc)
+        assert restored.mode_holds.risk_drawdown.active
+        assert restored.mode_holds.risk_drawdown.since is None
+        assert not restored.mode_holds.risk_daily_loss.active
+
+    def test_pre_field_snapshot_defaults_to_empty_holds(self) -> None:
+        original = _make_minimal_state()
+        encoded = msgpack.unpackb(serialize_state(original))
+        del encoded['mode_holds']
+
+        restored = deserialize_state(msgpack.packb(encoded))
+
+        assert not restored.mode_holds.any_active()


### PR DESCRIPTION
## What does this PR change?

### Change

Adds the operational-mode subsystem that backs Praxis WP-0008 (live operability & safety):

- `ModeController` arbitrates operational mode against sticky manual and risk halt holds, as the sole writer of `state.mode` — a healthy tick can no longer lift a non-health halt
- `HaltHold` / `OperationalHolds` on `InstanceState.mode_holds`, persisted through the WAL codec with backward-compatible decode
- `RiskBreakerThresholds` + `ModeController.evaluate_risk`: daily-loss (sum of per-strategy 24h losses, auto-lifting) and drawdown (lifetime-peak, latching) circuit-breakers, evaluated on the health tick
- `ModeController.reconcile` re-derives the mode on restart before startup actions drain
- Optional `on_halt` callback, fired outside the lock, on any HALT transition
- `HealthLoop` routes its mode writes through an optional `ModeController`
- Per-account `risk_controls` parsed from the manifest into `RiskBreakerThresholds`

## Tests

Full suite: 1490 passed. New coverage for the arbitration rules, the daily-loss/drawdown breakers, `reconcile`, the WAL `mode_holds` round-trip (incl. pre-field snapshots), manifest `risk_controls` parsing, and the outside-the-lock callback.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable