### PR TITLE
Remove zero-bang from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @zero-bang


### PR DESCRIPTION
Removes `@zero-bang` from CODEOWNERS.

For Praxis, Nexus, and Agent0, this removes the only ownership rule.