### PR TITLE
chore: configure CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mikkokotila @pdey @bit-mis @zero-bang


### PR DESCRIPTION
Adds `@mikkokotila`, `@pdey`, `@bit-mis`, and `@zero-bang` as global code owners.